### PR TITLE
feat: add universal installer support for macOS and Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,8 @@ on:
   push:
     tags: ['v*']
 jobs:
-  build:
+  build-macos:
     runs-on: macos-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -22,7 +20,66 @@ jobs:
             target/aarch64-apple-darwin/release/squeez \
             target/x86_64-apple-darwin/release/squeez \
             -output squeez-macos-universal
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: squeez-macos-universal
+          path: squeez-macos-universal
+
+  build-linux-x86_64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Add target
+        run: rustup target add x86_64-unknown-linux-musl
+      - name: Install musl-tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build
+        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Rename binary
+        run: mv target/x86_64-unknown-linux-musl/release/squeez squeez-linux-x86_64
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: squeez-linux-x86_64
+          path: squeez-linux-x86_64
+
+  build-linux-aarch64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cross
+        run: cargo install cross
+      - name: Build
+        run: cross build --release --target aarch64-unknown-linux-musl
+      - name: Rename binary
+        run: mv target/aarch64-unknown-linux-musl/release/squeez squeez-linux-aarch64
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: squeez-linux-aarch64
+          path: squeez-linux-aarch64
+
+  release:
+    needs: [build-macos, build-linux-x86_64, build-linux-aarch64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+      - name: Generate checksums
+        run: |
+          cd squeez-macos-universal && sha256sum squeez-macos-universal > ../checksums.sha256 && cd ..
+          cd squeez-linux-x86_64 && sha256sum squeez-linux-x86_64 >> ../checksums.sha256 && cd ..
+          cd squeez-linux-aarch64 && sha256sum squeez-linux-aarch64 >> ../checksums.sha256 && cd ..
       - name: Upload to release
         uses: softprops/action-gh-release@v1
         with:
-          files: squeez-macos-universal
+          files: |
+            squeez-macos-universal/squeez-macos-universal
+            squeez-linux-x86_64/squeez-linux-x86_64
+            squeez-linux-aarch64/squeez-linux-aarch64
+            checksums.sha256

--- a/install.sh
+++ b/install.sh
@@ -4,22 +4,49 @@ REPO_RAW="https://raw.githubusercontent.com/claudioemmanuel/squeez/main"
 RELEASES="https://github.com/claudioemmanuel/squeez/releases/latest/download"
 INSTALL_DIR="$HOME/.claude/squeez"
 
+# Detect OS and architecture
+OS=$(uname -s)
+ARCH=$(uname -m)
+
+case "$OS" in
+  Darwin)  BINARY="squeez-macos-universal" ;;
+  Linux)
+    case "$ARCH" in
+      x86_64)          BINARY="squeez-linux-x86_64" ;;
+      aarch64|arm64)   BINARY="squeez-linux-aarch64" ;;
+      *) echo "ERROR: unsupported arch $ARCH" >&2; exit 1 ;;
+    esac
+    ;;
+  Windows*|MINGW*|CYGWIN*)
+    echo "ERROR: Windows não é suportado. Use macOS ou Linux." >&2
+    exit 1
+    ;;
+  *) echo "ERROR: unsupported OS $OS" >&2; exit 1 ;;
+esac
+
 mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/hooks" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
 chmod 700 "$INSTALL_DIR" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
 
-echo "Downloading squeez binary..."
-curl -fsSL "$RELEASES/squeez-macos-universal" -o "$INSTALL_DIR/bin/squeez"
+echo "Downloading squeez binary for $OS/$ARCH..."
+curl -fsSL "$RELEASES/$BINARY" -o "$INSTALL_DIR/bin/squeez"
 
 echo "Verifying checksum..."
 curl -fsSL "$RELEASES/checksums.sha256" -o /tmp/squeez-checksums.sha256
-expected=$(grep "squeez-macos-universal" /tmp/squeez-checksums.sha256 2>/dev/null | awk '{print $1}')
+expected=$(grep "$BINARY" /tmp/squeez-checksums.sha256 2>/dev/null | awk '{print $1}')
 rm -f /tmp/squeez-checksums.sha256
 if [ -z "$expected" ]; then
-    echo "ERROR: could not find checksum for squeez-macos-universal in release" >&2
+    echo "ERROR: could not find checksum for $BINARY in release" >&2
     rm -f "$INSTALL_DIR/bin/squeez"
     exit 1
 fi
-actual=$(shasum -a 256 "$INSTALL_DIR/bin/squeez" | awk '{print $1}')
+
+# Use sha256sum if available (Linux), otherwise fall back to shasum (macOS)
+if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$INSTALL_DIR/bin/squeez" | awk '{print $1}')
+else
+    actual=$(shasum -a 256 "$INSTALL_DIR/bin/squeez" | awk '{print $1}')
+fi
+
 if [ "$expected" != "$actual" ]; then
     echo "ERROR: checksum mismatch — binary may be corrupted or tampered" >&2
     rm -f "$INSTALL_DIR/bin/squeez"


### PR DESCRIPTION
## Summary
- Add cross-platform build matrix to release workflow (macOS, Linux x86_64, Linux aarch64)
- Use musl for Linux static builds and `cross` for aarch64 compilation
- Generate `checksums.sha256` covering all platform binaries
- Update `install.sh` to auto-detect OS/arch and download correct binary
- Use portable `sha256sum`/`shasum` detection for checksum verification
- Reject Windows with clear error message (POSIX signal APIs in wrap.rs)

## Test Plan
- ✅ Tested `squeez-linux-x86_64` in Docker - works perfectly
- ✅ Release workflow builds all 3 binaries + checksums
- ✅ Installer detects macOS → downloads `squeez-macos-universal`
- ✅ Installer detects Linux x86_64 → downloads `squeez-linux-x86_64`
- ✅ Installer detects Linux aarch64 → downloads `squeez-linux-aarch64`
- ✅ Installer rejects Windows with clear error message

## Release Artifacts
https://github.com/levyvix/squeez/releases/tag/v0.2.0

All binaries verified and working in isolated environment.