### PR TITLE
ci: fix promote workflow to skip when token missing

### DIFF
--- a/.github/workflows/promote-develop.yml
+++ b/.github/workflows/promote-develop.yml
@@ -9,9 +9,11 @@ jobs:
   create_pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Create or update PR to main
+      - name: Create or update PR to main (using PAT)
+        if: ${{ secrets.PR_CREATION_TOKEN != '' }}
         uses: actions/github-script@v6
         with:
+          github-token: ${{ secrets.PR_CREATION_TOKEN }}
           script: |
             const prTitle = 'Promote develop to main';
             const prBody = 'Automated PR to propose changes from develop to main. Review and merge according to repo policy.';
@@ -41,3 +43,12 @@ jobs:
                 body: prBody,
               });
             }
+
+      - name: Skip automatic promotion (no token)
+        if: ${{ secrets.PR_CREATION_TOKEN == '' }}
+        run: |
+          echo "Automatic promotion to main skipped: PR_CREATION_TOKEN secret not set."
+          echo "To enable automatic promotion, either:"
+          echo "  1) Enable 'Allow GitHub Actions to create and approve pull requests' in the repository Settings → Actions → General (recommended), or"
+          echo "  2) Create a Personal Access Token (PAT) with 'repo' scope and add it as a repository secret named 'PR_CREATION_TOKEN'."
+          echo "Create secret via GH CLI: gh secret set PR_CREATION_TOKEN --body '<your-token>'"

--- a/README.md
+++ b/README.md
@@ -179,6 +179,19 @@ Promotion to main
 - On push to `develop`, a workflow will create or update a PR from `develop` → `main` for final review and merge.
 - Maintainers should review the `develop`→`main` PR, ensure CI/status checks pass, then merge to `main`.
 
+Note about permissions
+
+If the promotion workflow fails with an error like "GitHub Actions is not permitted to create or approve pull requests", you can resolve it by doing one of the following:
+
+- Enable the repository setting: Settings → Actions → General → enable "Allow GitHub Actions to create and approve pull requests" (recommended).
+- Or create a Personal Access Token (PAT) with `repo` scope and add it as a repository secret named `PR_CREATION_TOKEN`. The promotion workflow will use that secret to create/update the PR when present.
+
+Create the secret via the GH CLI:
+
+```bash
+gh secret set PR_CREATION_TOKEN --body '<your-personal-access-token>'
+```
+
 Branch protection & admin notes
 
 - Protect `main` with branch protection rules: require PR reviews (1+), require passing status checks, disallow force pushes, and enable required linear history if desired.


### PR DESCRIPTION
Make promotion conditional on PR_CREATION_TOKEN secret and provide guidance for enabling auto-promotion.