### PR TITLE
feat: add Windows support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,23 @@ jobs:
           name: squeez-linux-aarch64
           path: squeez-linux-aarch64
 
+  build-windows-x86_64:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --release --target x86_64-pc-windows-msvc
+      - name: Rename binary
+        run: mv target/x86_64-pc-windows-msvc/release/squeez.exe squeez-windows-x86_64.exe
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: squeez-windows-x86_64
+          path: squeez-windows-x86_64.exe
+
   release:
-    needs: [build-macos, build-linux-x86_64, build-linux-aarch64]
+    needs: [build-macos, build-linux-x86_64, build-linux-aarch64, build-windows-x86_64]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -75,6 +90,7 @@ jobs:
           cd squeez-macos-universal && sha256sum squeez-macos-universal > ../checksums.sha256 && cd ..
           cd squeez-linux-x86_64 && sha256sum squeez-linux-x86_64 >> ../checksums.sha256 && cd ..
           cd squeez-linux-aarch64 && sha256sum squeez-linux-aarch64 >> ../checksums.sha256 && cd ..
+          cd squeez-windows-x86_64 && sha256sum squeez-windows-x86_64.exe >> ../checksums.sha256 && cd ..
       - name: Upload to release
         uses: softprops/action-gh-release@v1
         with:
@@ -82,4 +98,5 @@ jobs:
             squeez-macos-universal/squeez-macos-universal
             squeez-linux-x86_64/squeez-linux-x86_64
             squeez-linux-aarch64/squeez-linux-aarch64
+            squeez-windows-x86_64/squeez-windows-x86_64.exe
             checksums.sha256

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin/
 *.DS_Store
 .omc/
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.DS_Store
 .omc/
 docs/
+.worktrees/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ name = "squeez"
 path = "src/lib.rs"
 
 [dependencies]
+
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org)
 
-Token compression + context optimization for Claude Code. Runs automatically. No configuration required.
+Token compression + context optimization for Claude Code and OpenCode. Runs automatically in Claude Code. Manual usage in OpenCode.
 
 ## What it does
 
@@ -19,7 +19,8 @@ Token compression + context optimization for Claude Code. Runs automatically. No
 curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh
 ```
 
-Restart Claude Code. Done.
+- **Claude Code:** Restart Claude Code to activate
+- **OpenCode:** Restart OpenCode to activate the plugin
 
 ## Benchmarks
 
@@ -70,6 +71,32 @@ Three Claude Code hooks work together:
 **Session memory** (`SessionStart`): On each new session, `squeez init` finalizes the previous session into a summary (files touched, errors resolved, test results, git events) and prints a memory banner so Claude has prior-session context from the start.
 
 **Token tracking** (`PostToolUse`): Every tool call's output size is tracked. When cumulative session tokens cross 80% of the context budget, a compact warning is emitted in the next bash output header.
+
+## OpenCode
+
+OpenCode is supported via an auto-loading plugin that intercepts all Bash commands.
+
+**Install:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh
+```
+
+**What happens:**
+- Plugin is installed to `~/.config/opencode/plugins/squeez.js`
+- OpenCode auto-loads plugins on startup
+- All Bash commands are automatically compressed via `squeez wrap`
+
+**Escape hatch:**
+```bash
+--no-squeez git log --all --graph
+```
+
+**Manual usage:**
+```bash
+squeez wrap git status
+squeez wrap docker logs mycontainer
+squeez wrap npm install
+```
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg)](https://www.rust-lang.org)
 
-Token compression + context optimization for Claude Code and OpenCode. Runs automatically in Claude Code. Manual usage in OpenCode.
+Token compression + context optimization for Claude Code, OpenCode, and GitHub Copilot CLI. Runs automatically in Claude Code and Copilot CLI. Manual usage in OpenCode.
 
 ## What it does
 
@@ -21,6 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install
 
 - **Claude Code:** Restart Claude Code to activate
 - **OpenCode:** Restart OpenCode to activate the plugin
+- **Copilot CLI:** Memory injected into `~/.copilot/copilot-instructions.md`; restart Copilot CLI to activate hook-based bash compression
 
 ## Benchmarks
 
@@ -30,15 +31,16 @@ Measured on macOS (Apple Silicon), token estimate = chars/4. Run with `bash benc
 |---------|--------|-------|-----------|---------|
 | `ps aux` | 40,373 tk | 2,352 tk | **-95%** | 6ms |
 | `git log` (200 commits) | 2,667 tk | 819 tk | **-70%** | 4ms |
+| `docker logs` | 665 tk | 186 tk | **-73%** | 5ms |
 | `find` (deep tree) | 424 tk | 134 tk | **-69%** | 3ms |
 | `git status` | 50 tk | 16 tk | **-68%** | 3ms |
-| `docker logs` | 665 tk | 186 tk | **-73%** | 5ms |
-| `npm install` | 524 tk | 231 tk | **-56%** | 3ms |
 | `ls -la` | 1,782 tk | 886 tk | **-51%** | 4ms |
+| `npm install` | 524 tk | 231 tk | **-56%** | 3ms |
 | `git diff` | 502 tk | 317 tk | **-37%** | 4ms |
 | `env` dump | 441 tk | 287 tk | **-35%** | 3ms |
+| Copilot CLI session | 639 tk | 421 tk | **-35%** | 3ms |
 
-9/9 fixtures pass. Latency under 10ms on every fixture.
+10/10 fixtures pass. Latency under 10ms on every fixture.
 
 ## Escape hatch
 
@@ -48,7 +50,9 @@ Measured on macOS (Apple Silicon), token estimate = chars/4. Run with `bash benc
 
 ## Configuration
 
-Optional `~/.claude/squeez/config.ini` (all fields optional):
+Optional config file (all fields optional):
+- Claude Code / default: `~/.claude/squeez/config.ini`
+- Copilot CLI: `~/.copilot/squeez/config.ini`
 ```ini
 # Compression
 max_lines = 200
@@ -64,11 +68,13 @@ memory_retention_days = 30          # how long to keep session summaries
 
 ## How it works
 
-Three Claude Code hooks work together:
+### Claude Code & Copilot CLI
+
+Three hooks work together:
 
 **Compression** (`PreToolUse`): Every Bash call is rewritten — `git status` → `squeez wrap git status`. The wrap command runs via `sh -c`, captures stdout+stderr, applies 4 strategies (smart_filter → dedup → grouping → truncation), and prints a compressed result with a savings header.
 
-**Session memory** (`SessionStart`): On each new session, `squeez init` finalizes the previous session into a summary (files touched, errors resolved, test results, git events) and prints a memory banner so Claude has prior-session context from the start.
+**Session memory** (`SessionStart`): On each new session, `squeez init` finalizes the previous session into a summary (files touched, errors resolved, test results, git events) and prints a memory banner so the agent has prior-session context from the start. For Copilot CLI, this banner is also written to `~/.copilot/copilot-instructions.md` which is loaded automatically at every session.
 
 **Token tracking** (`PostToolUse`): Every tool call's output size is tracked. When cumulative session tokens cross 80% of the context budget, a compact warning is emitted in the next bash output header.
 
@@ -98,6 +104,30 @@ squeez wrap docker logs mycontainer
 squeez wrap npm install
 ```
 
+## GitHub Copilot CLI
+
+Copilot CLI is supported via hooks registered in `~/.copilot/settings.json` and session memory injected into `~/.copilot/copilot-instructions.md`.
+
+**Install:**
+```bash
+curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh
+```
+
+**What happens:**
+- Session memory is written to `~/.copilot/copilot-instructions.md` — Copilot CLI reads this automatically at every session start, giving the agent prior-session context without re-discovery tokens
+- Hooks are registered in `~/.copilot/settings.json` for PreToolUse (bash compression), SessionStart (memory refresh), and PostToolUse (token tracking)
+- Session state is stored separately in `~/.copilot/squeez/` (independent from Claude Code state)
+
+**Refresh memory manually:**
+```bash
+SQUEEZ_DIR=~/.copilot/squeez ~/.claude/squeez/bin/squeez init --copilot
+```
+
+**Escape hatch:**
+```bash
+--no-squeez git log --all --graph
+```
+
 ## Local development
 
 **Prerequisites:** Rust stable (`rustup update stable`), `bash`, macOS or Linux.
@@ -110,16 +140,14 @@ cd squeez
 # 2. Build & test
 cargo test
 
-# 3. Run benchmarks (requires release binary)
+# 3. Run benchmarks (uses local release binary automatically)
 cargo build --release
-mkdir -p "$HOME/.claude/squeez/bin"
-cp target/release/squeez "$HOME/.claude/squeez/bin/squeez"
 bash bench/run.sh
 
-# 4. Install hooks into your Claude Code config
+# 4. Install hooks into Claude Code and Copilot CLI config
 bash install.sh
 
-# 5. Restart Claude Code — squeez is active
+# 5. Restart Claude Code / Copilot CLI — squeez is active
 ```
 
 To uninstall: `bash uninstall.sh`

--- a/README.md
+++ b/README.md
@@ -130,7 +130,18 @@ SQUEEZ_DIR=~/.copilot/squeez ~/.claude/squeez/bin/squeez init --copilot
 
 ## Local development
 
-**Prerequisites:** Rust stable (`rustup update stable`), `bash`, macOS or Linux.
+**Prerequisites:** Rust stable, `bash` (Git Bash on Windows). Works on Windows, macOS, and Linux.
+
+Install Rust via [rustup](https://rust-lang.org/tools/install/):
+```bash
+# macOS / Linux
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Windows: download and run rustup-init.exe from https://rust-lang.org/tools/install/
+# Then restart your terminal so cargo is in PATH.
+# Windows users also need MSVC C++ Build Tools:
+# https://visualstudio.microsoft.com/visual-cpp-build-tools/
+```
 
 ```bash
 # 1. Clone

--- a/bench/fixtures/git_copilot_session.txt
+++ b/bench/fixtures/git_copilot_session.txt
@@ -1,0 +1,45 @@
+Cloning into 'openwatch'...
+remote: Enumerating objects: 2745, done.
+remote: Counting objects:   0% (1/150)
+remote: Counting objects:  50% (75/150)
+remote: Counting objects: 100% (150/150), done.
+remote: Compressing objects:  50% (39/78)
+remote: Compressing objects: 100% (78/78), done.
+Receiving objects:  10% (275/2745)
+Receiving objects:  50% (1373/2745)
+Receiving objects: 100% (2745/2745), 1.82 MiB | 8.36 MiB/s, done.
+Resolving deltas:  50% (849/1696)
+Resolving deltas: 100% (1696/1696), done.
+# squeez [git] 950→42 tokens (-95%) 12ms
+1dc6071 Fix systemic limitations and improve data reliability
+6d7c12b chore: track copilot-instructions.md and fix inconsistencies
+68dd123 chore: ignore _worktrees directory
+602e402 feat: expand data coverage via MCP Brasil
+c2d6044 fix(worker): structured logging and resilient startup observability
+branch 'main' set up to track 'origin/main'.
+Already up to date.
+Updating fc86688..1dc6071
+Fast-forward
+ .claude/settings.json                                           |   10 +-
+ .gitattributes                                                  |    7 +
+ shared/connectors/__init__.py                                   |   12 +-
+ shared/connectors/datajud.py                                    |  312 ++++
+ shared/connectors/ibge.py                                       |  287 ++++
+ shared/connectors/tcu.py                                        |  198 +++
+ shared/typologies/base.py                                       |   34 +-
+ shared/typologies/registry.py                                   |   21 +-
+ shared/typologies/t01_concentration.py                          |    8 +-
+ shared/typologies/t02_low_competition.py                        |   15 +-
+ shared/typologies/t03_splitting.py                              |    8 +-
+ tests/conftest.py                                               |   45 +-
+ tests/connectors/test_connectors.py                             |   87 +-
+ tests/worker/test_signal_tasks.py                               |   34 +-
+ web/src/app/globals.css                                         |  112 +-
+ web/src/app/page.tsx                                            |   89 +-
+ web/src/components/Badge.tsx                                    |   45 +-
+ web/src/lib/design-tokens.ts                                    |   78 +-
+ worker/tasks/signal_tasks.py                                    |   56 +-
+ 37 files changed, 1847 insertions(+), 423 deletions(-)
+CONFLICT (content): Merge conflict in shared/connectors/__init__.py
+CONFLICT (content): Merge conflict in tests/conftest.py
+Done

--- a/bench/report.md
+++ b/bench/report.md
@@ -1,13 +1,14 @@
 FIXTURE                               BEFORE    AFTER  REDUCTION  LATENCY STATUS
 ──────────────────────────────────────────────────────────────────────────────
-docker_logs.txt                         665tk     186tk        73%       5ms  ✅
+docker_logs.txt                         665tk     186tk        73%       4ms  ✅
 env_dump.txt                            441tk     287tk        35%       3ms  ✅
 find_deep.txt                           424tk     134tk        69%       3ms  ✅
-git_diff.txt                            502tk     317tk        37%       4ms  ✅
-git_log_200.txt                        2667tk     819tk        70%       4ms  ✅
+git_copilot_session.txt                 639tk     421tk        35%       3ms  ✅
+git_diff.txt                            502tk     317tk        37%       3ms  ✅
+git_log_200.txt                        2667tk     819tk        70%       3ms  ✅
 git_status.txt                           50tk      16tk        68%       3ms  ✅
 ls_la.txt                              1782tk     886tk        51%       4ms  ✅
 npm_install.txt                         524tk     231tk        56%       3ms  ✅
 ps_aux.txt                            40373tk    2352tk        95%       6ms  ✅
 
-PASS: 9/9  FAIL: 0/9
+PASS: 10/10  FAIL: 0/10

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
-SQUEEZ="$HOME/.claude/squeez/bin/squeez"
-if [ ! -x "$SQUEEZ" ]; then
-    echo "ERROR: squeez binary not found at $SQUEEZ" >&2
+# Use local dev build if available, otherwise fall back to installed binary
+if [ -x "$(dirname "$0")/../target/release/squeez" ]; then
+    SQUEEZ="$(cd "$(dirname "$0")/.." && pwd)/target/release/squeez"
+elif [ -x "$HOME/.claude/squeez/bin/squeez" ]; then
+    SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+else
+    echo "ERROR: squeez binary not found. Run 'cargo build --release' first." >&2
     exit 1
 fi
 FIXTURES="$(dirname "$0")/fixtures"

--- a/hooks/copilot-posttooluse.sh
+++ b/hooks/copilot-posttooluse.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# squeez Copilot CLI PostToolUse hook — tracks token usage per tool call
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.copilot/squeez"
+
+input=$(cat)
+
+tool=$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('tool_name', 'unknown'))
+except Exception:
+    print('unknown')
+" 2>/dev/null || echo "unknown")
+
+size=$(printf '%s' "$input" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    content = d.get('tool_result', {})
+    if isinstance(content, dict):
+        content = str(content.get('content', ''))
+    elif content is None:
+        content = ''
+    else:
+        content = str(content)
+    print(len(content))
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0)
+
+"$SQUEEZ" track "$tool" "$size" 2>/dev/null || true

--- a/hooks/copilot-pretooluse.sh
+++ b/hooks/copilot-pretooluse.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# squeez Copilot CLI PreToolUse hook — compresses Bash tool output
+# Registered in ~/.copilot/settings.json (same format as Claude Code)
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.copilot/squeez"
+
+SQUEEZ_BIN="$SQUEEZ" python3 -c "
+import sys, json, os, shlex
+
+data = sys.stdin.read()
+if not data.strip():
+    sys.exit(0)
+
+try:
+    d = json.loads(data)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+if d.get('tool_name') != 'Bash':
+    sys.exit(0)
+
+cmd = d.get('tool_input', {}).get('command')
+if cmd is None:
+    sys.exit(0)
+
+squeez = os.environ['SQUEEZ_BIN']
+
+if cmd.startswith(squeez):
+    sys.exit(0)
+
+if cmd.startswith('--no-squeez '):
+    d['tool_input']['command'] = cmd[len('--no-squeez '):]
+    print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+    sys.exit(0)
+
+d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
+print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+"

--- a/hooks/copilot-session-start.sh
+++ b/hooks/copilot-session-start.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# squeez Copilot CLI session-start integration
+# Initialises the session and injects memory into ~/.copilot/copilot-instructions.md
+# Run this once per session: add to shell RC or invoke manually.
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.copilot/squeez"
+mkdir -p "$SQUEEZ_DIR/sessions" "$SQUEEZ_DIR/memory"
+chmod 700 "$SQUEEZ_DIR" "$SQUEEZ_DIR/sessions" "$SQUEEZ_DIR/memory" 2>/dev/null || true
+
+"$SQUEEZ" init --copilot

--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,30 @@ curl -fsSL "$REPO_RAW/hooks/session-start.sh"  -o "$INSTALL_DIR/hooks/session-st
 curl -fsSL "$REPO_RAW/hooks/posttooluse.sh"    -o "$INSTALL_DIR/hooks/posttooluse.sh"
 chmod +x "$INSTALL_DIR/hooks/pretooluse.sh" "$INSTALL_DIR/hooks/session-start.sh" "$INSTALL_DIR/hooks/posttooluse.sh"
 
+echo "Installing OpenCode plugin..."
+OPENCODE_PLUGIN_DIR="$HOME/.config/opencode/plugins"
+mkdir -p "$OPENCODE_PLUGIN_DIR"
+curl -fsSL "$REPO_RAW/opencode-plugin/squeez.js" -o "$OPENCODE_PLUGIN_DIR/squeez.js" 2>/dev/null || {
+    cat > "$OPENCODE_PLUGIN_DIR/squeez.js" <<'PLUGIN_EOF'
+const SQUEEZ_BIN = `${process.env.HOME}/.claude/squeez/bin/squeez`;
+
+export const SqueezPlugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "bash") {
+        const command = output.args?.command;
+        if (!command || typeof command !== "string") return;
+        if (command.startsWith(SQUEEZ_BIN)) return;
+        if (command.includes("squeez wrap")) return;
+        if (command.startsWith("--no-squeez")) return;
+        output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+      }
+    },
+  };
+};
+PLUGIN_EOF
+}
+
 echo "Registering hooks in ~/.claude/settings.json..."
 python3 - <<'EOF'
 import json, os, sys
@@ -102,4 +126,7 @@ os.replace(tmp, path)
 EOF
 
 version=$("$INSTALL_DIR/bin/squeez" --version 2>/dev/null || echo "squeez")
-echo "✅ $version installed. Restart Claude Code to activate."
+echo "✅ $version installed."
+echo ""
+echo "Claude Code: Restart Claude Code to activate."
+echo "OpenCode: Restart OpenCode to activate the plugin (automatic Bash compression)."

--- a/install.sh
+++ b/install.sh
@@ -17,18 +17,23 @@ case "$OS" in
       *) echo "ERROR: unsupported arch $ARCH" >&2; exit 1 ;;
     esac
     ;;
-  Windows*|MINGW*|CYGWIN*)
-    echo "ERROR: Windows não é suportado. Use macOS ou Linux." >&2
-    exit 1
+  Windows*|MINGW*|MSYS*|CYGWIN*)
+    BINARY="squeez-windows-x86_64.exe"
     ;;
   *) echo "ERROR: unsupported OS $OS" >&2; exit 1 ;;
 esac
 
+# Local binary name: squeez.exe on Windows, squeez elsewhere
+case "$OS" in
+  Windows*|MINGW*|MSYS*|CYGWIN*) BIN_NAME="squeez.exe" ;;
+  *) BIN_NAME="squeez" ;;
+esac
+
 mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/hooks" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
-chmod 700 "$INSTALL_DIR" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
+chmod 700 "$INSTALL_DIR" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory" 2>/dev/null || true
 
 echo "Downloading squeez binary for $OS/$ARCH..."
-curl -fsSL "$RELEASES/$BINARY" -o "$INSTALL_DIR/bin/squeez"
+curl -fsSL "$RELEASES/$BINARY" -o "$INSTALL_DIR/bin/$BIN_NAME"
 
 echo "Verifying checksum..."
 curl -fsSL "$RELEASES/checksums.sha256" -o /tmp/squeez-checksums.sha256
@@ -36,25 +41,25 @@ expected=$(grep "$BINARY" /tmp/squeez-checksums.sha256 2>/dev/null | awk '{print
 rm -f /tmp/squeez-checksums.sha256
 if [ -z "$expected" ]; then
     echo "ERROR: could not find checksum for $BINARY in release" >&2
-    rm -f "$INSTALL_DIR/bin/squeez"
+    rm -f "$INSTALL_DIR/bin/$BIN_NAME"
     exit 1
 fi
 
-# Use sha256sum if available (Linux), otherwise fall back to shasum (macOS)
+# Use sha256sum if available (Linux/Windows Git Bash), otherwise fall back to shasum (macOS)
 if command -v sha256sum >/dev/null 2>&1; then
-    actual=$(sha256sum "$INSTALL_DIR/bin/squeez" | awk '{print $1}')
+    actual=$(sha256sum "$INSTALL_DIR/bin/$BIN_NAME" | awk '{print $1}')
 else
-    actual=$(shasum -a 256 "$INSTALL_DIR/bin/squeez" | awk '{print $1}')
+    actual=$(shasum -a 256 "$INSTALL_DIR/bin/$BIN_NAME" | awk '{print $1}')
 fi
 
 if [ "$expected" != "$actual" ]; then
     echo "ERROR: checksum mismatch — binary may be corrupted or tampered" >&2
-    rm -f "$INSTALL_DIR/bin/squeez"
+    rm -f "$INSTALL_DIR/bin/$BIN_NAME"
     exit 1
 fi
 echo "Checksum verified."
 
-chmod +x "$INSTALL_DIR/bin/squeez"
+chmod +x "$INSTALL_DIR/bin/$BIN_NAME" 2>/dev/null || true
 
 echo "Installing hooks..."
 curl -fsSL "$REPO_RAW/hooks/pretooluse.sh"     -o "$INSTALL_DIR/hooks/pretooluse.sh"
@@ -132,8 +137,8 @@ mkdir -p "$COPILOT_SQUEEZ_DIR/bin" "$COPILOT_SQUEEZ_DIR/hooks" \
 chmod 700 "$COPILOT_SQUEEZ_DIR" "$COPILOT_SQUEEZ_DIR/sessions" "$COPILOT_SQUEEZ_DIR/memory" 2>/dev/null || true
 
 # Symlink the same binary so SQUEEZ_DIR-aware calls work
-ln -sf "$INSTALL_DIR/bin/squeez" "$COPILOT_SQUEEZ_DIR/bin/squeez" 2>/dev/null || \
-    cp "$INSTALL_DIR/bin/squeez" "$COPILOT_SQUEEZ_DIR/bin/squeez"
+ln -sf "$INSTALL_DIR/bin/$BIN_NAME" "$COPILOT_SQUEEZ_DIR/bin/$BIN_NAME" 2>/dev/null || \
+    cp "$INSTALL_DIR/bin/$BIN_NAME" "$COPILOT_SQUEEZ_DIR/bin/$BIN_NAME"
 
 curl -fsSL "$REPO_RAW/hooks/copilot-pretooluse.sh"     -o "$INSTALL_DIR/hooks/copilot-pretooluse.sh"
 curl -fsSL "$REPO_RAW/hooks/copilot-session-start.sh"  -o "$INSTALL_DIR/hooks/copilot-session-start.sh"
@@ -143,7 +148,7 @@ chmod +x "$INSTALL_DIR/hooks/copilot-pretooluse.sh" \
          "$INSTALL_DIR/hooks/copilot-posttooluse.sh"
 
 # Seed Copilot instructions (writes ~/.copilot/copilot-instructions.md)
-"$INSTALL_DIR/bin/squeez" init --copilot 2>/dev/null || true
+"$INSTALL_DIR/bin/$BIN_NAME" init --copilot 2>/dev/null || true
 
 # Register hooks in ~/.copilot/settings.json (Copilot CLI hook format mirrors Claude Code)
 if [ -d "$HOME/.copilot" ]; then
@@ -183,7 +188,7 @@ os.replace(tmp, path)
 COPILOT_EOF
 fi
 
-version=$("$INSTALL_DIR/bin/squeez" --version 2>/dev/null || echo "squeez")
+version=$("$INSTALL_DIR/bin/$BIN_NAME" --version 2>/dev/null || echo "squeez")
 echo "✅ $version installed."
 echo ""
 echo "Claude Code:  Restart Claude Code to activate."

--- a/install.sh
+++ b/install.sh
@@ -125,8 +125,68 @@ with open(tmp, "w") as f:
 os.replace(tmp, path)
 EOF
 
+echo "Installing Copilot CLI hooks..."
+COPILOT_SQUEEZ_DIR="$HOME/.copilot/squeez"
+mkdir -p "$COPILOT_SQUEEZ_DIR/bin" "$COPILOT_SQUEEZ_DIR/hooks" \
+         "$COPILOT_SQUEEZ_DIR/sessions" "$COPILOT_SQUEEZ_DIR/memory"
+chmod 700 "$COPILOT_SQUEEZ_DIR" "$COPILOT_SQUEEZ_DIR/sessions" "$COPILOT_SQUEEZ_DIR/memory" 2>/dev/null || true
+
+# Symlink the same binary so SQUEEZ_DIR-aware calls work
+ln -sf "$INSTALL_DIR/bin/squeez" "$COPILOT_SQUEEZ_DIR/bin/squeez" 2>/dev/null || \
+    cp "$INSTALL_DIR/bin/squeez" "$COPILOT_SQUEEZ_DIR/bin/squeez"
+
+curl -fsSL "$REPO_RAW/hooks/copilot-pretooluse.sh"     -o "$INSTALL_DIR/hooks/copilot-pretooluse.sh"
+curl -fsSL "$REPO_RAW/hooks/copilot-session-start.sh"  -o "$INSTALL_DIR/hooks/copilot-session-start.sh"
+curl -fsSL "$REPO_RAW/hooks/copilot-posttooluse.sh"    -o "$INSTALL_DIR/hooks/copilot-posttooluse.sh"
+chmod +x "$INSTALL_DIR/hooks/copilot-pretooluse.sh" \
+         "$INSTALL_DIR/hooks/copilot-session-start.sh" \
+         "$INSTALL_DIR/hooks/copilot-posttooluse.sh"
+
+# Seed Copilot instructions (writes ~/.copilot/copilot-instructions.md)
+"$INSTALL_DIR/bin/squeez" init --copilot 2>/dev/null || true
+
+# Register hooks in ~/.copilot/settings.json (Copilot CLI hook format mirrors Claude Code)
+if [ -d "$HOME/.copilot" ]; then
+python3 - <<'COPILOT_EOF'
+import json, os, sys
+path = os.path.expanduser("~/.copilot/settings.json")
+settings = {}
+try:
+    if os.path.exists(path):
+        with open(path) as f:
+            settings = json.load(f)
+except (json.JSONDecodeError, IOError) as e:
+    print(f"Warning: could not read ~/.copilot/settings.json: {e}", file=sys.stderr)
+
+if not isinstance(settings.get("PreToolUse"), list):
+    settings["PreToolUse"] = []
+pre = {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-pretooluse.sh"}]}
+if not any("squeez" in str(h) for h in settings["PreToolUse"]):
+    settings["PreToolUse"].append(pre)
+
+if not isinstance(settings.get("SessionStart"), list):
+    settings["SessionStart"] = []
+start = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-session-start.sh"}]}
+if not any("squeez" in str(h) for h in settings["SessionStart"]):
+    settings["SessionStart"].append(start)
+
+if not isinstance(settings.get("PostToolUse"), list):
+    settings["PostToolUse"] = []
+post = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-posttooluse.sh"}]}
+if not any("squeez" in str(h) for h in settings["PostToolUse"]):
+    settings["PostToolUse"].append(post)
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+COPILOT_EOF
+fi
+
 version=$("$INSTALL_DIR/bin/squeez" --version 2>/dev/null || echo "squeez")
 echo "✅ $version installed."
 echo ""
-echo "Claude Code: Restart Claude Code to activate."
-echo "OpenCode: Restart OpenCode to activate the plugin (automatic Bash compression)."
+echo "Claude Code:  Restart Claude Code to activate."
+echo "OpenCode:     Restart OpenCode to activate the plugin (automatic Bash compression)."
+echo "Copilot CLI:  Memory injected into ~/.copilot/copilot-instructions.md."
+echo "              Restart Copilot CLI to activate hook-based bash compression."

--- a/opencode-plugin/squeez.js
+++ b/opencode-plugin/squeez.js
@@ -1,0 +1,16 @@
+const SQUEEZ_BIN = `${process.env.HOME}/.claude/squeez/bin/squeez`;
+
+export const SqueezPlugin = async () => {
+  return {
+    "tool.execute.before": async (input, output) => {
+      if (input.tool === "bash") {
+        const command = output.args?.command;
+        if (!command || typeof command !== "string") return;
+        if (command.startsWith(SQUEEZ_BIN)) return;
+        if (command.includes("squeez wrap")) return;
+        if (command.startsWith("--no-squeez")) return;
+        output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+      }
+    },
+  };
+};

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -21,7 +21,7 @@ pub fn run() -> i32 {
 /// ~/.copilot/copilot-instructions.md so Copilot CLI picks it up
 /// at every session start (no hook system required).
 pub fn run_copilot() -> i32 {
-    let home = std::env::var("HOME").unwrap_or_default();
+    let home = crate::session::home_dir();
     // Honour SQUEEZ_DIR override, default to ~/.copilot/squeez
     let base = std::env::var("SQUEEZ_DIR")
         .unwrap_or_else(|_| format!("{}/.copilot/squeez", home));

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -16,6 +16,77 @@ pub fn run() -> i32 {
     run_with_dirs(&sessions, &mem, &cfg)
 }
 
+/// Entry point called from main.rs: `squeez init --copilot`
+/// Same as run() but also injects the memory banner into
+/// ~/.copilot/copilot-instructions.md so Copilot CLI picks it up
+/// at every session start (no hook system required).
+pub fn run_copilot() -> i32 {
+    let home = std::env::var("HOME").unwrap_or_default();
+    // Honour SQUEEZ_DIR override, default to ~/.copilot/squeez
+    let base = std::env::var("SQUEEZ_DIR")
+        .unwrap_or_else(|_| format!("{}/.copilot/squeez", home));
+    let sessions = std::path::PathBuf::from(&base).join("sessions");
+    let mem = std::path::PathBuf::from(&base).join("memory");
+    let _ = std::fs::create_dir_all(&sessions);
+    let _ = std::fs::create_dir_all(&mem);
+
+    // Load config from the copilot squeez dir
+    let cfg = load_config_from(&base);
+
+    let code = run_with_dirs(&sessions, &mem, &cfg);
+
+    // Inject memory banner into Copilot CLI instructions file
+    let summaries = memory::read_last_n(&mem, 3);
+    inject_copilot_instructions(&home, &cfg, &summaries);
+
+    code
+}
+
+fn load_config_from(base: &str) -> Config {
+    let path = format!("{}/config.ini", base);
+    std::fs::read_to_string(&path)
+        .map(|s| Config::from_str(&s))
+        .unwrap_or_default()
+}
+
+/// Replaces the squeez block (<!-- squeez:start --> … <!-- squeez:end -->)
+/// in ~/.copilot/copilot-instructions.md, creating the file if absent.
+fn inject_copilot_instructions(home: &str, cfg: &Config, summaries: &[memory::Summary]) {
+    let path = format!("{}/.copilot/copilot-instructions.md", home);
+    let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+    let mut block = String::from("<!-- squeez:start -->\n");
+    block.push_str("## squeez — session context\n");
+    let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
+    block.push_str(&format!(
+        "Context budget: ~{}K tokens | Compression: ON | Memory: ON\n",
+        budget_k
+    ));
+    for s in summaries {
+        block.push_str(&format!("- {}\n", s.display_line()));
+    }
+    if summaries.is_empty() {
+        block.push_str("- No prior sessions recorded yet.\n");
+    }
+    block.push_str("<!-- squeez:end -->\n");
+
+    // Strip previous squeez block if present
+    let cleaned = if existing.contains("<!-- squeez:start -->") {
+        let start = existing.find("<!-- squeez:start -->").unwrap_or(0);
+        let end = existing
+            .find("<!-- squeez:end -->")
+            .map(|i| i + "<!-- squeez:end -->".len() + 1) // include newline
+            .unwrap_or(start);
+        format!("{}{}", &existing[..start], &existing[end.min(existing.len())..])
+    } else {
+        existing
+    };
+
+    // Prepend the fresh block
+    let contents = format!("{}\n{}", block, cleaned.trim_start());
+    let _ = std::fs::write(&path, contents);
+}
+
 /// Testable version with explicit directories.
 pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) -> i32 {
     // 1. Finalise previous session → memory (best-effort)

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -2,15 +2,35 @@ use crate::config::Config;
 use crate::filter;
 use crate::{json_util, session};
 use std::io::Read;
-use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
+#[cfg(unix)]
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
+#[cfg(unix)]
 static CHILD_PID: AtomicI32 = AtomicI32::new(-1);
 
+/// Returns a `Command` pre-configured to run `cmd` through the platform shell.
+/// Unix/Git Bash: `sh -c <cmd>`
+/// Windows native: `cmd /C <cmd>`
+fn shell_command(cmd: &str) -> Command {
+    #[cfg(windows)]
+    {
+        let mut c = Command::new("cmd");
+        c.args(["/C", cmd]);
+        c
+    }
+    #[cfg(not(windows))]
+    {
+        let mut c = Command::new("sh");
+        c.args(["-c", cmd]);
+        c
+    }
+}
+
 pub fn run(cmd_str: &str) -> i32 {
+    #[cfg(unix)]
     setup_signals();
     let config = Config::load();
 
@@ -20,15 +40,15 @@ pub fn run(cmd_str: &str) -> i32 {
 
     let start = Instant::now();
 
-    // Spawn via sh -c to handle pipes, &&, redirections, builtins
-    let mut child = match Command::new("sh")
-        .arg("-c")
-        .arg(cmd_str)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .process_group(0)
-        .spawn()
+    // Spawn via platform shell to handle pipes, &&, redirections, builtins
+    let mut cmd = shell_command(cmd_str);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    #[cfg(unix)]
     {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let mut child = match cmd.spawn() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("squeez: {}", e);
@@ -36,7 +56,8 @@ pub fn run(cmd_str: &str) -> i32 {
         }
     };
 
-    // Store PID for signal forwarding
+    // Store PID for signal forwarding (Unix only)
+    #[cfg(unix)]
     CHILD_PID.store(child.id() as i32, Ordering::SeqCst);
 
     // Drain stdout/stderr on background threads to prevent pipe-buffer deadlock.
@@ -76,10 +97,11 @@ pub fn run(cmd_str: &str) -> i32 {
             Ok(Some(s)) => break s.code().unwrap_or(1),
             Ok(None) => {
                 if start.elapsed() >= timeout {
+                    #[cfg(unix)]
                     unsafe {
                         libc::kill(-(child.id() as i32), libc::SIGTERM);
+                        std::thread::sleep(Duration::from_millis(200));
                     }
-                    std::thread::sleep(Duration::from_millis(200));
                     let _ = child.kill();
                     eprintln!("squeez: command timed out after 120s");
                     let _ = stdout_thread.join();
@@ -148,9 +170,7 @@ pub fn run(cmd_str: &str) -> i32 {
 }
 
 fn passthrough(cmd: &str) -> i32 {
-    let status = Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
+    let status = shell_command(cmd)
         .status()
         .unwrap_or_else(|e| {
             eprintln!("squeez: {}", e);
@@ -166,6 +186,7 @@ fn is_streaming(cmd: &str) -> bool {
         && cmd.split_whitespace().any(|a| a == "-f" || a == "--follow")
 }
 
+#[cfg(unix)]
 fn setup_signals() {
     unsafe {
         libc::signal(libc::SIGTERM, forward_signal as *const () as libc::sighandler_t);
@@ -173,6 +194,7 @@ fn setup_signals() {
     }
 }
 
+#[cfg(unix)]
 extern "C" fn forward_signal(sig: libc::c_int) {
     let pid = CHILD_PID.load(Ordering::SeqCst);
     if pid > 0 {

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,10 +79,7 @@ impl Config {
 
     pub fn load() -> Self {
         let base = std::env::var("SQUEEZ_DIR").unwrap_or_else(|_| {
-            format!(
-                "{}/.claude/squeez",
-                std::env::var("HOME").unwrap_or_default()
-            )
+            format!("{}/.claude/squeez", crate::session::home_dir())
         });
         let path = format!("{}/config.ini", base);
         std::fs::read_to_string(&path)

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,10 +78,13 @@ impl Config {
     }
 
     pub fn load() -> Self {
-        let path = format!(
-            "{}/.claude/squeez/config.ini",
-            std::env::var("HOME").unwrap_or_default()
-        );
+        let base = std::env::var("SQUEEZ_DIR").unwrap_or_else(|_| {
+            format!(
+                "{}/.claude/squeez",
+                std::env::var("HOME").unwrap_or_default()
+            )
+        });
+        let path = format!("{}/config.ini", base);
         std::fs::read_to_string(&path)
             .map(|s| Self::from_str(&s))
             .unwrap_or_default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,12 @@ fn main() {
             std::process::exit(exit_code);
         }
         Some("init") => {
-            let exit_code = squeez::commands::init::run();
+            let copilot = args.get(2).map(String::as_str) == Some("--copilot");
+            let exit_code = if copilot {
+                squeez::commands::init::run_copilot()
+            } else {
+                squeez::commands::init::run()
+            };
             std::process::exit(exit_code);
         }
         Some("compact") => {

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,15 +3,20 @@ use std::path::{Path, PathBuf};
 
 // ── Directory helpers ──────────────────────────────────────────────────────
 
+/// Returns the user's home directory.
+/// Tries `HOME` first (Unix/Git Bash), then `USERPROFILE` (Windows native).
+pub fn home_dir() -> String {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .unwrap_or_default()
+}
+
 /// Returns the squeez state directory. Overridable via SQUEEZ_DIR env var (for tests).
 pub fn squeez_dir() -> PathBuf {
     if let Ok(d) = std::env::var("SQUEEZ_DIR") {
         return PathBuf::from(d);
     }
-    PathBuf::from(format!(
-        "{}/.claude/squeez",
-        std::env::var("HOME").unwrap_or_default()
-    ))
+    PathBuf::from(format!("{}/.claude/squeez", home_dir()))
 }
 
 pub fn sessions_dir() -> PathBuf {

--- a/tests/test_session.rs
+++ b/tests/test_session.rs
@@ -99,3 +99,10 @@ fn test_unix_to_date_epoch_zero() {
     let date = squeez::session::unix_to_date(0);
     assert_eq!(date, "1970-01-01", "got: {}", date);
 }
+
+#[test]
+fn test_home_dir_returns_nonempty() {
+    // HOME (Unix) or USERPROFILE (Windows) must be set in any real environment.
+    let home = squeez::session::home_dir();
+    assert!(!home.is_empty(), "home_dir() returned empty string");
+}

--- a/tests/test_wrap_integration.rs
+++ b/tests/test_wrap_integration.rs
@@ -37,6 +37,7 @@ fn no_squeez_bypasses_compression() {
     assert_ne!(out.status.code(), None);
 }
 
+#[cfg(not(windows))]
 #[test]
 fn wrap_handles_pipes_via_sh() {
     let out = Command::new(bin())
@@ -45,6 +46,17 @@ fn wrap_handles_pipes_via_sh() {
         .unwrap();
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("HELLO"));
+}
+
+#[cfg(windows)]
+#[test]
+fn wrap_handles_pipes_via_cmd() {
+    let out = Command::new(bin())
+        .args(["wrap", "echo hello | findstr hello"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.to_lowercase().contains("hello"));
 }
 
 #[test]


### PR DESCRIPTION
Adds full Windows support:

  - `home_dir()` helper: tries HOME, falls back to USERPROFILE (Windows)
  - `wrap.rs`: cross-platform shell execution (cmd /C on Windows, sh -c on Unix)
  - `libc` crate moved to `[target.'cfg(unix)'.dependencies]`
  - `install.sh`: detects Windows/MINGW/MSYS/CYGWIN, downloads .exe, uses BIN_NAME variable throughout
  - `release.yml`: new `build-windows-x86_64` job (windows-latest, msvc target), .exe included in release assets and checksums
  - README: Windows prerequisites and Rust install instructions