### PR TITLE
feat(pr2): compress-md, caveman persona, squeez update, track-result hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,51 @@ adaptive_intensity = true           # auto-tighten compression as budget fills
 context_cache_enabled = true        # persist cross-call state in sessions/context.json
 redundancy_cache_enabled = true     # collapse identical recent outputs to a reference line
 summarize_threshold_lines = 500     # raw lines above this trigger summary fallback
+
+# Output / memory-file (PR2)
+persona = ultra                     # off|lite|full|ultra — caveman prompt injected at session start
+auto_compress_md = true             # compress CLAUDE.md / copilot-instructions.md on every session start
 ```
+
+### Output compression — caveman persona
+
+squeez cannot intercept the model's response stream from the hook layer.
+Instead it ships a short caveman-style prompt text and injects it into:
+
+- The Claude Code session banner (printed by `squeez init` at session start)
+- The `<!-- squeez:start --> ... <!-- squeez:end -->` block in `~/.copilot/copilot-instructions.md`
+
+Three intensity levels (`lite`, `full`, `ultra`) plus `off`. Default is `ultra`.
+
+### Memory-file compression — `squeez compress-md`
+
+Pure-Rust, zero-LLM caveman compressor for `CLAUDE.md`, `AGENTS.md`,
+`copilot-instructions.md`, and any other markdown file. Preserves code
+blocks, inline code, URLs, headings, file paths, tables, and list markers.
+Compresses prose only. Backups always written to `<stem>.original.md`.
+
+```bash
+squeez compress-md path/to/file.md          # Full mode
+squeez compress-md --ultra path/to/file.md  # + abbreviations (with→w/, fn, etc.)
+squeez compress-md --dry-run path/to/file.md
+squeez compress-md --all                    # Walk known locations
+```
+
+When `auto_compress_md = true` (default), `squeez init` runs `--all`
+silently on every session start. The integrity heuristic aborts the
+write if any code block, URL, or heading was lost — your files are safe.
+
+### Self-update — `squeez update`
+
+```bash
+squeez update             # Download + verify SHA256 + atomic install
+squeez update --check     # Report only, do not install
+squeez update --insecure  # Skip checksum (NOT recommended)
+```
+
+Uses `curl` and `sha256sum`/`shasum -a 256` (both already required by
+`install.sh`). Atomic on Unix; on Windows the running .exe is replaced
+via a `.new` + manual `move` shim.
 
 ### Context engine
 

--- a/assets/persona_full.md
+++ b/assets/persona_full.md
@@ -1,0 +1,11 @@
+## squeez persona: full (caveman)
+
+Talk like smart caveman. Drop articles (a, an, the). Drop filler. Drop
+pleasantries. Fragments fine — no need full sentence. Pattern:
+"[thing] [action] [reason]. [next step]."
+
+Technical terms stay exact. Code blocks unchanged. Error messages quoted
+exact. Git commits and PR descriptions written normal.
+
+Goal: cut ~75% of output tokens, keep 100% technical accuracy. Same fix,
+fewer words. Brain still big.

--- a/assets/persona_lite.md
+++ b/assets/persona_lite.md
@@ -1,0 +1,5 @@
+## squeez persona: lite
+
+Be terse. Drop fillers ("just", "really", "basically"). Drop pleasantries
+("happy to help", "of course"). Skip hedging ("might want to", "perhaps").
+Keep grammar correct. Code blocks unchanged.

--- a/assets/persona_ultra.md
+++ b/assets/persona_ultra.md
@@ -1,0 +1,18 @@
+## squeez persona: ultra (max compression)
+
+Maximum compression. Telegraphic. Abbreviate everything outside code.
+Drop articles, filler, pleasantries, hedging. Fragments OK. Pattern:
+"[thing] → [action]. [next]."
+
+Substitutions: with→w/, without→w/o, because→b/c, function→fn,
+parameter→param, configuration→config, documentation→docs, directory→dir,
+repository→repo, between→btw, versus→vs, approximately→~.
+
+Rules that stay exact:
+- Code blocks: unchanged
+- Inline `code`: unchanged
+- Error messages: quoted verbatim
+- File paths, URLs, version numbers: unchanged
+- Git commits, PR descriptions: written normal
+
+Goal: minimum tokens, full technical accuracy. Brain big. Mouth small.

--- a/bench/fixtures/mdcompress_claude_md.txt
+++ b/bench/fixtures/mdcompress_claude_md.txt
@@ -1,0 +1,32 @@
+# Project Name
+
+The quick brown fox really just jumps over the lazy dog. This is basically a sample document that contains some natural language prose along with code blocks and tables.
+
+## Background
+
+The reason we are building this is because the existing solution does not really work the way we would like. I'd be happy to explain more, but the basic idea is to use the new framework with these parameters.
+
+In general, you could consider using the configuration directory for the documentation files. The repository structure is approximately as follows:
+
+```rust
+fn main() {
+    let config = Config::default();
+    println!("{}", config.as_str());
+}
+```
+
+## Usage
+
+Run `cargo build --release` to compile the binary. Then run the function with these arguments:
+
+| flag | description |
+|------|-------------|
+| --check | Just verify, do not write |
+| --all   | Walk all known directories |
+| --quiet | Suppress the informational output |
+
+For more details, see [the documentation](https://example.com/docs/v1.0).
+
+## Notes
+
+It might be worth considering the trade-off between the speed and the accuracy. Perhaps the configuration could be tuned. Maybe the function should be split into smaller pieces. The repository structure is documented in the README file.

--- a/bench/fixtures/mdcompress_prose.txt
+++ b/bench/fixtures/mdcompress_prose.txt
@@ -1,0 +1,5 @@
+The reason that this approach really works is because the underlying mechanism is basically a deduplication strategy that just removes the redundant entries. I'd be happy to walk through it.
+
+In general, you could consider that the function essentially takes a list of items and returns the unique ones. Perhaps the most important thing to note is that the order is preserved. Maybe you would like to use a different data structure, but for the simple case the basic implementation works really well.
+
+It might be worth considering the trade-off between memory and speed. Of course, you would also like to ensure correctness. Sure, the implementation could be optimized further, but for now the simple version is sufficient for the use case at hand.

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -30,14 +30,24 @@ for f in "$FIXTURES"/*.txt; do
     # Derive handler hint from fixture name: "git_log_200.txt" → hint="git"
     hint="${name%%_*}"
 
-    t0=$(date +%s%N)
-    compressed=$(echo "$input" | "$SQUEEZ" filter "$hint" 2>/dev/null || echo "$input")
-    t1=$(date +%s%N)
+    # mdcompress_* fixtures use the markdown compressor instead of filter
+    if [ "$hint" = "mdcompress" ]; then
+        t0=$(date +%s%N)
+        compressed=$("$SQUEEZ" compress-md --dry-run --ultra --quiet "$f" 2>/dev/null || cat "$f")
+        t1=$(date +%s%N)
+    else
+        t0=$(date +%s%N)
+        compressed=$(echo "$input" | "$SQUEEZ" filter "$hint" 2>/dev/null || echo "$input")
+        t1=$(date +%s%N)
+    fi
     ms=$(( (t1 - t0) / 1000000 ))
 
     after=$(( ${#compressed} / 4 ))
     pct=$(( 100 - (after * 100 / before) ))
-    status="✅"; [ "$pct" -lt 30 ] && { status="❌"; FAIL=$((FAIL+1)); }
+    # mdcompress fixtures: prose compression is naturally lighter (~15-30%)
+    threshold=30
+    if [ "$hint" = "mdcompress" ]; then threshold=15; fi
+    status="✅"; [ "$pct" -lt "$threshold" ] && { status="❌"; FAIL=$((FAIL+1)); }
     [ "$ms" -gt 100 ] && { status="❌ slow"; FAIL=$((FAIL+1)); }
     TOTAL=$((TOTAL+1))
 

--- a/hooks/copilot-posttooluse.sh
+++ b/hooks/copilot-posttooluse.sh
@@ -33,3 +33,7 @@ except Exception:
 " 2>/dev/null || echo 0)
 
 "$SQUEEZ" track "$tool" "$size" 2>/dev/null || true
+
+# Also feed the raw JSON to track-result so non-Bash tool outputs
+# (Read, Grep, LS, Glob) update SessionContext for cross-call dedup.
+printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true

--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -31,3 +31,7 @@ except Exception:
 " 2>/dev/null || echo 0)
 
 "$SQUEEZ" track "$tool" "$size" 2>/dev/null || true
+
+# Also feed the raw JSON to track-result so non-Bash tool outputs
+# (Read, Grep, LS, Glob) update SessionContext for cross-call dedup.
+printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true

--- a/src/commands/compress_md.rs
+++ b/src/commands/compress_md.rs
@@ -1,0 +1,895 @@
+// Pure-Rust caveman-style markdown compressor.
+// No LLM calls. Preserves code blocks, URLs, headings, file paths, tables.
+// Compresses natural-language prose only.
+
+use std::path::{Path, PathBuf};
+
+use crate::session::home_dir;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Mode {
+    Full,
+    Ultra,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Stats {
+    pub orig_bytes: usize,
+    pub new_bytes: usize,
+    pub orig_code_blocks: usize,
+    pub new_code_blocks: usize,
+    pub orig_urls: usize,
+    pub new_urls: usize,
+    pub orig_headings: usize,
+    pub new_headings: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CompressResult {
+    pub output: String,
+    pub stats: Stats,
+    pub safe: bool,
+}
+
+// ── CLI entry ──────────────────────────────────────────────────────────────
+
+pub fn run(args: &[String]) -> i32 {
+    let mut mode = Mode::Full;
+    let mut dry_run = false;
+    let mut all = false;
+    let mut quiet = false;
+    let mut targets: Vec<String> = Vec::new();
+
+    for a in args {
+        match a.as_str() {
+            "--ultra" => mode = Mode::Ultra,
+            "--dry-run" => dry_run = true,
+            "--all" => all = true,
+            "--quiet" => quiet = true,
+            "-h" | "--help" => {
+                print_help();
+                return 0;
+            }
+            s if s.starts_with("--") => {
+                eprintln!("squeez compress-md: unknown flag {}", s);
+                return 2;
+            }
+            s => targets.push(s.to_string()),
+        }
+    }
+
+    let files: Vec<PathBuf> = if all {
+        all_targets()
+    } else if targets.is_empty() {
+        eprintln!("squeez compress-md: no files given (use --all or pass paths)");
+        return 2;
+    } else {
+        targets.iter().map(PathBuf::from).collect()
+    };
+
+    let mut had_error = false;
+    let mut any_processed = false;
+
+    for f in &files {
+        if !f.exists() {
+            if !all && !quiet {
+                eprintln!("squeez compress-md: not found: {}", f.display());
+            }
+            continue;
+        }
+        any_processed = true;
+        match process_file(f, mode, dry_run, quiet) {
+            Ok(()) => {}
+            Err(e) => {
+                eprintln!("squeez compress-md: {} — {}", f.display(), e);
+                had_error = true;
+            }
+        }
+    }
+
+    if !any_processed && all && !quiet {
+        eprintln!("squeez compress-md: no markdown files found in known locations");
+    }
+
+    if had_error {
+        1
+    } else {
+        0
+    }
+}
+
+/// Quiet bulk-compression entry used by `init` when auto_compress_md=true.
+/// Never errors out the caller; failures are silent.
+pub fn run_all_quietly() -> i32 {
+    let files = all_targets();
+    for f in &files {
+        if !f.exists() {
+            continue;
+        }
+        let _ = process_file(f, Mode::Ultra, false, true);
+    }
+    0
+}
+
+fn print_help() {
+    println!("squeez compress-md — pure-Rust markdown prose compressor");
+    println!();
+    println!("Usage:");
+    println!("  squeez compress-md [--ultra] [--dry-run] <file>...");
+    println!("  squeez compress-md [--ultra] [--dry-run] --all");
+    println!();
+    println!("Flags:");
+    println!("  --ultra      Aggressive abbreviations (with→w/, function→fn, ...)");
+    println!("  --dry-run    Print compressed text to stdout, do not write");
+    println!("  --all        Walk known locations: ~/.claude/CLAUDE.md,");
+    println!("               ~/.copilot/copilot-instructions.md,");
+    println!("               $PWD/CLAUDE.md, $PWD/AGENTS.md,");
+    println!("               $PWD/.github/copilot-instructions.md");
+    println!("  --quiet      Suppress informational output");
+    println!();
+    println!("Preserved verbatim: code blocks (```...```), inline `code`,");
+    println!("URLs, file paths, headings, tables, list markers, version numbers.");
+    println!();
+    println!("Backups are written to <stem>.original.md and never overwritten.");
+}
+
+fn all_targets() -> Vec<PathBuf> {
+    let home = home_dir();
+    let mut v = vec![
+        PathBuf::from(format!("{}/.claude/CLAUDE.md", home)),
+        PathBuf::from(format!("{}/.copilot/copilot-instructions.md", home)),
+    ];
+    if let Ok(cwd) = std::env::current_dir() {
+        v.push(cwd.join("CLAUDE.md"));
+        v.push(cwd.join("AGENTS.md"));
+        v.push(cwd.join(".github/copilot-instructions.md"));
+    }
+    v
+}
+
+fn process_file(path: &Path, mode: Mode, dry_run: bool, quiet: bool) -> Result<(), String> {
+    let original = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    let result = compress_text(&original, mode);
+
+    if !result.safe {
+        return Err(format!(
+            "integrity check failed (code_blocks {}→{}, urls {}→{}, headings {}→{}, bytes {}→{})",
+            result.stats.orig_code_blocks,
+            result.stats.new_code_blocks,
+            result.stats.orig_urls,
+            result.stats.new_urls,
+            result.stats.orig_headings,
+            result.stats.new_headings,
+            result.stats.orig_bytes,
+            result.stats.new_bytes,
+        ));
+    }
+
+    let pct = if result.stats.orig_bytes > 0 {
+        100usize.saturating_sub(result.stats.new_bytes * 100 / result.stats.orig_bytes)
+    } else {
+        0
+    };
+
+    if dry_run {
+        print!("{}", result.output);
+        if !quiet {
+            eprintln!(
+                "# squeez compress-md (dry-run) {} {}→{} bytes (-{}%)",
+                path.display(),
+                result.stats.orig_bytes,
+                result.stats.new_bytes,
+                pct
+            );
+        }
+        return Ok(());
+    }
+
+    // Skip if already at-or-below target — backup may exist from a prior run.
+    if result.stats.new_bytes >= result.stats.orig_bytes {
+        if !quiet {
+            eprintln!(
+                "squeez compress-md: {} already compressed (no further reduction)",
+                path.display()
+            );
+        }
+        return Ok(());
+    }
+
+    // Backup once. Never clobber.
+    let backup = backup_path(path);
+    if !backup.exists() {
+        std::fs::write(&backup, &original).map_err(|e| e.to_string())?;
+    }
+
+    std::fs::write(path, &result.output).map_err(|e| e.to_string())?;
+
+    if !quiet {
+        eprintln!(
+            "squeez compress-md: {} {}→{} bytes (-{}%)",
+            path.display(),
+            result.stats.orig_bytes,
+            result.stats.new_bytes,
+            pct
+        );
+    }
+    Ok(())
+}
+
+fn backup_path(p: &Path) -> PathBuf {
+    let stem = p.file_stem().and_then(|s| s.to_str()).unwrap_or("file");
+    let parent = p.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!("{}.original.md", stem))
+}
+
+// ── Core compression ───────────────────────────────────────────────────────
+
+#[derive(Eq, PartialEq)]
+enum State {
+    Text,
+    FencedCode,
+    Table,
+}
+
+pub fn compress_text(input: &str, mode: Mode) -> CompressResult {
+    let mut stats = Stats::default();
+    stats.orig_bytes = input.len();
+    stats.orig_code_blocks = count_code_blocks(input);
+    stats.orig_urls = count_urls(input);
+    stats.orig_headings = count_headings(input);
+
+    let mut out = String::with_capacity(input.len());
+    let mut state = State::Text;
+
+    let lines: Vec<&str> = input.split('\n').collect();
+    let mut i = 0;
+    while i < lines.len() {
+        let line = lines[i];
+        match state {
+            State::FencedCode => {
+                out.push_str(line);
+                out.push('\n');
+                if line.trim_start().starts_with("```") {
+                    state = State::Text;
+                }
+                i += 1;
+            }
+            State::Table => {
+                if is_table_row(line) {
+                    out.push_str(line);
+                    out.push('\n');
+                    i += 1;
+                } else {
+                    state = State::Text;
+                    // reprocess this line as Text without advancing i
+                }
+            }
+            State::Text => {
+                if line.trim_start().starts_with("```") {
+                    out.push_str(line);
+                    out.push('\n');
+                    state = State::FencedCode;
+                    i += 1;
+                } else if is_table_row(line) {
+                    out.push_str(line);
+                    out.push('\n');
+                    state = State::Table;
+                    i += 1;
+                } else if is_protected_line(line) {
+                    out.push_str(line);
+                    out.push('\n');
+                    i += 1;
+                } else {
+                    let compressed = compress_prose_line(line, mode);
+                    out.push_str(&compressed);
+                    out.push('\n');
+                    i += 1;
+                }
+            }
+        }
+    }
+
+    // Strip trailing newline introduced by split('\n') if input didn't end with one.
+    if !input.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+
+    let collapsed = collapse_blank_runs(&out);
+
+    stats.new_bytes = collapsed.len();
+    stats.new_code_blocks = count_code_blocks(&collapsed);
+    stats.new_urls = count_urls(&collapsed);
+    stats.new_headings = count_headings(&collapsed);
+
+    let safe = stats.new_code_blocks == stats.orig_code_blocks
+        && stats.new_urls >= stats.orig_urls
+        && stats.new_headings == stats.orig_headings
+        && stats.new_bytes * 5 >= stats.orig_bytes; // not >80% reduction
+
+    CompressResult {
+        output: collapsed,
+        stats,
+        safe,
+    }
+}
+
+// ── Helpers: classification ────────────────────────────────────────────────
+
+fn is_table_row(s: &str) -> bool {
+    let t = s.trim_start();
+    t.starts_with('|') && t[1..].contains('|')
+}
+
+fn is_protected_line(s: &str) -> bool {
+    let t = s.trim_start();
+    t.is_empty()
+        || t.starts_with('#')
+        || t.starts_with("<!--")
+        || t.starts_with('>')
+        || t.starts_with("---")
+        || t.starts_with("===")
+}
+
+fn count_code_blocks(s: &str) -> usize {
+    s.lines()
+        .filter(|l| l.trim_start().starts_with("```"))
+        .count()
+        / 2
+}
+
+fn count_urls(s: &str) -> usize {
+    let mut n = 0;
+    let mut rest = s;
+    while let Some(idx) = rest.find("http") {
+        let after = &rest[idx..];
+        if after.starts_with("http://") || after.starts_with("https://") {
+            n += 1;
+            // Skip past the URL
+            let end = after
+                .find(|c: char| c.is_whitespace() || c == ')' || c == ']' || c == '"')
+                .unwrap_or(after.len());
+            rest = &after[end..];
+        } else {
+            rest = &after[4..];
+        }
+    }
+    n
+}
+
+fn count_headings(s: &str) -> usize {
+    s.lines()
+        .filter(|l| l.trim_start().starts_with('#'))
+        .count()
+}
+
+fn collapse_blank_runs(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut blank_run = 0;
+    for line in s.split('\n') {
+        if line.trim().is_empty() {
+            blank_run += 1;
+            if blank_run <= 1 {
+                out.push('\n');
+            }
+        } else {
+            blank_run = 0;
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if !s.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+// ── Prose compression ──────────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum Span<'a> {
+    Verbatim(&'a str),
+    Prose(&'a str),
+}
+
+fn split_protected_spans(line: &str) -> Vec<Span<'_>> {
+    let mut spans = Vec::new();
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    let mut prose_start = 0;
+
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+
+        // Inline code: `…`
+        if c == '`' {
+            if prose_start < i {
+                spans.push(Span::Prose(&line[prose_start..i]));
+            }
+            let start = i;
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'`' {
+                i += 1;
+            }
+            if i < bytes.len() {
+                i += 1; // include closing backtick
+            }
+            spans.push(Span::Verbatim(&line[start..i]));
+            prose_start = i;
+            continue;
+        }
+
+        // URL: http:// or https://
+        if c == 'h' && (line[i..].starts_with("http://") || line[i..].starts_with("https://")) {
+            if prose_start < i {
+                spans.push(Span::Prose(&line[prose_start..i]));
+            }
+            let start = i;
+            while i < bytes.len() {
+                let cc = bytes[i] as char;
+                if cc.is_whitespace() || matches!(cc, ')' | ']' | '"' | '>') {
+                    break;
+                }
+                i += 1;
+            }
+            spans.push(Span::Verbatim(&line[start..i]));
+            prose_start = i;
+            continue;
+        }
+
+        i += 1;
+    }
+    if prose_start < line.len() {
+        spans.push(Span::Prose(&line[prose_start..]));
+    }
+    spans
+}
+
+fn compress_prose_line(line: &str, mode: Mode) -> String {
+    // Preserve leading whitespace + list markers
+    let leading_ws_len = line.len() - line.trim_start().len();
+    let leading = &line[..leading_ws_len];
+    let body = &line[leading_ws_len..];
+
+    // Detect & preserve list markers (-, *, +, "1.", "1)")
+    let (marker, rest) = split_list_marker(body);
+
+    let spans = split_protected_spans(rest);
+    let mut out = String::with_capacity(rest.len());
+    for span in spans {
+        match span {
+            Span::Verbatim(v) => out.push_str(v),
+            Span::Prose(p) => out.push_str(&compress_prose_span(p, mode)),
+        }
+    }
+
+    let mut result = String::with_capacity(line.len());
+    result.push_str(leading);
+    result.push_str(marker);
+    result.push_str(&out);
+    // trim trailing whitespace
+    while result.ends_with(' ') || result.ends_with('\t') {
+        result.pop();
+    }
+    result
+}
+
+fn split_list_marker(s: &str) -> (&str, &str) {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return ("", s);
+    }
+    // - * + followed by space
+    if matches!(bytes[0], b'-' | b'*' | b'+') && bytes.get(1) == Some(&b' ') {
+        return (&s[..2], &s[2..]);
+    }
+    // "1. " or "12. "
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i > 0
+        && i + 1 < bytes.len()
+        && (bytes[i] == b'.' || bytes[i] == b')')
+        && bytes[i + 1] == b' '
+    {
+        return (&s[..i + 2], &s[i + 2..]);
+    }
+    ("", s)
+}
+
+const FILLERS: &[&str] = &[
+    "just",
+    "really",
+    "basically",
+    "actually",
+    "simply",
+    "sure",
+    "certainly",
+];
+
+const ARTICLES: &[&str] = &["the", "a", "an"];
+
+const PHRASES: &[&str] = &[
+    "of course",
+    "i'd be happy to",
+    "let me ",
+    "i'll help you",
+    "i would like to",
+    "please note that",
+    "it might be worth",
+    "you could consider",
+    "in general",
+    "as a rule",
+];
+
+const HEDGES: &[&str] = &["perhaps", "maybe"];
+
+const ULTRA_SUBS: &[(&str, &str)] = &[
+    ("without", "w/o"),
+    ("with", "w/"),
+    ("because", "b/c"),
+    ("function", "fn"),
+    ("parameter", "param"),
+    ("arguments", "args"),
+    ("argument", "arg"),
+    ("configuration", "config"),
+    ("documentation", "docs"),
+    ("directory", "dir"),
+    ("repository", "repo"),
+    ("between", "btw"),
+    ("versus", "vs"),
+    ("approximately", "~"),
+];
+
+fn compress_prose_span(text: &str, mode: Mode) -> String {
+    if text.trim().is_empty() {
+        return text.to_string();
+    }
+    let mut s = text.to_string();
+
+    // Drop multi-word phrases (case-insensitive substring)
+    for phrase in PHRASES {
+        s = drop_phrase_ci(&s, phrase);
+    }
+
+    // Drop fillers + hedges + articles as whole words
+    let mut tokens: Vec<String> = Vec::new();
+    let mut buf = String::new();
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c.is_whitespace() {
+            if !buf.is_empty() {
+                tokens.push(std::mem::take(&mut buf));
+            }
+            tokens.push(c.to_string());
+        } else {
+            buf.push(c);
+        }
+    }
+    if !buf.is_empty() {
+        tokens.push(buf);
+    }
+
+    let mut kept: Vec<String> = Vec::with_capacity(tokens.len());
+    for tok in &tokens {
+        if tok.chars().all(|c| c.is_whitespace()) {
+            kept.push(tok.clone());
+            continue;
+        }
+        // Only drop a token if it's a clean word (no structural punctuation
+        // like brackets/parens/braces). Allow trailing comma/period only.
+        if is_clean_word(tok) {
+            let lower = strip_punct(&tok.to_lowercase());
+            if FILLERS.contains(&lower.as_str())
+                || HEDGES.contains(&lower.as_str())
+                || ARTICLES.contains(&lower.as_str())
+            {
+                // drop the following whitespace too
+                if matches!(kept.last().map(|s| s.as_str()), Some(s) if s.chars().all(|c| c.is_whitespace())) {
+                    kept.pop();
+                }
+                continue;
+            }
+        }
+        kept.push(tok.clone());
+    }
+
+    // Collapse whitespace runs
+    let mut out = String::with_capacity(s.len());
+    let mut last_ws = false;
+    for tok in &kept {
+        if tok.chars().all(|c| c.is_whitespace()) {
+            if !last_ws {
+                out.push(' ');
+                last_ws = true;
+            }
+        } else {
+            out.push_str(tok);
+            last_ws = false;
+        }
+    }
+
+    // Trim trailing dangling conjunctions
+    let trimmed = trim_trailing_conjunction(out.trim_end());
+
+    // Strip stray leading punctuation left behind by dropped phrases
+    // (e.g. "In general, you could…" → ", you could…" → "you could…").
+    let cleaned = strip_leading_orphan_punct(&trimmed);
+
+    // Ultra: word substitutions outside protected spans (we are inside one)
+    let final_out = if mode == Mode::Ultra {
+        ultra_subs(cleaned)
+    } else {
+        cleaned
+    };
+
+    // Preserve trailing whitespace if original prose ended with whitespace
+    let needs_trailing = text.ends_with(' ') && !final_out.ends_with(' ');
+    let needs_leading = text.starts_with(' ') && !final_out.starts_with(' ');
+    match (needs_leading, needs_trailing) {
+        (true, true) => format!(" {} ", final_out),
+        (true, false) => format!(" {}", final_out),
+        (false, true) => format!("{} ", final_out),
+        (false, false) => final_out,
+    }
+}
+
+fn strip_leading_orphan_punct(s: &str) -> String {
+    let trimmed = s.trim_start();
+    let mut chars = trimmed.chars().peekable();
+    let mut to_skip = 0;
+    while let Some(&c) = chars.peek() {
+        if matches!(c, ',' | ';' | ':' | ' ') {
+            to_skip += c.len_utf8();
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    let lead_ws = s.len() - trimmed.len();
+    let original_lead = &s[..lead_ws];
+    let body = &trimmed[to_skip..];
+    let body = body.trim_start();
+    format!("{}{}", original_lead, body)
+}
+
+fn strip_punct(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || *c == '\'' || *c == '/')
+        .collect()
+}
+
+/// A token is "clean" if it contains only word characters plus optional
+/// trailing comma/period/semicolon. Tokens with brackets, parens, or
+/// other structural punctuation are NEVER dropped (they may be link
+/// brackets or markup).
+fn is_clean_word(tok: &str) -> bool {
+    let bytes = tok.as_bytes();
+    let mut i = 0;
+    // body: alphanumeric or apostrophe
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if c.is_alphanumeric() || c == '\'' {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    if i == 0 {
+        return false;
+    }
+    // optional trailing punctuation
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        if matches!(c, ',' | '.' | ';' | ':' | '!' | '?') {
+            i += 1;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+fn drop_phrase_ci(s: &str, needle: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let lower = s.to_lowercase();
+    let mut i = 0;
+    while i < s.len() {
+        if lower[i..].starts_with(needle) {
+            // skip following whitespace too
+            let mut end = i + needle.len();
+            while end < s.len() && s.as_bytes()[end] == b' ' {
+                end += 1;
+            }
+            i = end;
+        } else {
+            // copy one char
+            let next_boundary = s[i..]
+                .char_indices()
+                .nth(1)
+                .map(|(b, _)| i + b)
+                .unwrap_or(s.len());
+            result.push_str(&s[i..next_boundary]);
+            i = next_boundary;
+        }
+    }
+    result
+}
+
+fn trim_trailing_conjunction(s: &str) -> String {
+    let lower = s.to_lowercase();
+    for c in &[" and", " or", " but", " so"] {
+        if lower.ends_with(c) {
+            return s[..s.len() - c.len()].trim_end().to_string();
+        }
+    }
+    s.to_string()
+}
+
+fn ultra_subs(mut s: String) -> String {
+    for (long, short) in ULTRA_SUBS {
+        s = replace_word_boundary(&s, long, short);
+    }
+    s
+}
+
+fn replace_word_boundary(s: &str, needle: &str, repl: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let nbytes = needle.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + nbytes.len() <= bytes.len()
+            && s[i..i + nbytes.len()].eq_ignore_ascii_case(needle)
+        {
+            let prev_ok = i == 0 || !is_word_char(bytes[i - 1] as char);
+            let next_ok = i + nbytes.len() == bytes.len()
+                || !is_word_char(bytes[i + nbytes.len()] as char);
+            if prev_ok && next_ok {
+                out.push_str(repl);
+                i += nbytes.len();
+                continue;
+            }
+        }
+        let next_boundary = s[i..]
+            .char_indices()
+            .nth(1)
+            .map(|(b, _)| i + b)
+            .unwrap_or(s.len());
+        out.push_str(&s[i..next_boundary]);
+        i = next_boundary;
+    }
+    out
+}
+
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn count_code_blocks_pairs_fences() {
+        let s = "intro\n```\ncode\n```\nmid\n```rust\nx\n```\n";
+        assert_eq!(count_code_blocks(s), 2);
+    }
+
+    #[test]
+    fn fenced_code_preserved_verbatim() {
+        let input = "Some prose with the article.\n```rust\nfn main() { let x = 1; }\n```\nMore prose.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.safe);
+        assert!(r.output.contains("fn main() { let x = 1; }"));
+        // 'the' article dropped
+        assert!(!r.output.contains("the article"));
+    }
+
+    #[test]
+    fn url_preserved_inline() {
+        let input = "Check https://example.com/foo for the docs.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.safe);
+        assert!(r.output.contains("https://example.com/foo"));
+    }
+
+    #[test]
+    fn markdown_link_url_preserved() {
+        let input = "See [the docs](https://example.com/x) for more.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.safe);
+        assert!(r.output.contains("https://example.com/x"));
+    }
+
+    #[test]
+    fn heading_count_unchanged() {
+        let input = "# H1\n\nprose\n\n## H2\n\nmore prose with the article\n";
+        let r = compress_text(input, Mode::Full);
+        assert_eq!(r.stats.orig_headings, r.stats.new_headings);
+    }
+
+    #[test]
+    fn fillers_removed() {
+        let input = "This is just really basically a simple test.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(!r.output.contains("just"));
+        assert!(!r.output.contains("really"));
+        assert!(!r.output.contains("basically"));
+    }
+
+    #[test]
+    fn pleasantries_removed() {
+        let input = "I'd be happy to help you with that, of course.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(!r.output.to_lowercase().contains("happy to"));
+        assert!(!r.output.to_lowercase().contains("of course"));
+    }
+
+    #[test]
+    fn ultra_substitutes_with() {
+        let input = "Configure the app with these parameters.\n";
+        let r = compress_text(input, Mode::Ultra);
+        assert!(r.output.contains("w/"));
+        assert!(r.output.contains("param"));
+    }
+
+    #[test]
+    fn ultra_does_not_touch_code_block() {
+        let input = "Configure with these.\n```\nfn with_config() {}\n```\n";
+        let r = compress_text(input, Mode::Ultra);
+        assert!(r.output.contains("fn with_config() {}"));
+    }
+
+    #[test]
+    fn inline_code_preserved() {
+        let input = "Use `cargo build --release` to compile the binary.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.output.contains("`cargo build --release`"));
+    }
+
+    #[test]
+    fn table_preserved_verbatim() {
+        let input = "Intro.\n\n| col1 | col2 |\n|------|------|\n| a    | b    |\n\nOutro.\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.output.contains("| col1 | col2 |"));
+        assert!(r.output.contains("| a    | b    |"));
+    }
+
+    #[test]
+    fn safe_false_when_url_dropped() {
+        // Synthetic: stats compare orig_urls vs new_urls
+        let mut s = Stats::default();
+        s.orig_urls = 3;
+        s.new_urls = 2;
+        assert!(s.new_urls < s.orig_urls);
+    }
+
+    #[test]
+    fn integrity_check_on_real_input() {
+        let input = "# Title\n\nprose with the link [example](https://example.com).\n\n```\ncode\n```\n";
+        let r = compress_text(input, Mode::Full);
+        assert!(r.safe);
+        assert_eq!(r.stats.orig_headings, r.stats.new_headings);
+        assert_eq!(r.stats.orig_code_blocks, r.stats.new_code_blocks);
+        assert!(r.stats.new_urls >= r.stats.orig_urls);
+    }
+
+    #[test]
+    fn idempotent_on_already_compressed() {
+        let input = "# Title\n\nshort terse content.\n";
+        let r1 = compress_text(input, Mode::Full);
+        let r2 = compress_text(&r1.output, Mode::Full);
+        // Second pass should not damage further
+        assert!(r2.safe);
+    }
+
+    #[test]
+    fn list_marker_preserved() {
+        let input = "- the first item\n- the second item\n";
+        let r = compress_text(input, Mode::Full);
+        // markers preserved, articles dropped
+        assert!(r.output.starts_with("- "));
+        assert!(!r.output.contains("the first"));
+    }
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use crate::{
+    commands::{compress_md, persona},
     config::Config,
     json_util, memory,
     session::{self, CurrentSession},
@@ -39,6 +40,11 @@ pub fn run_copilot() -> i32 {
     let summaries = memory::read_last_n(&mem, 3);
     inject_copilot_instructions(&home, &cfg, &summaries);
 
+    // Auto-compress copilot-instructions.md after we just rewrote it.
+    if cfg.auto_compress_md {
+        let _ = compress_md::run_all_quietly();
+    }
+
     code
 }
 
@@ -59,14 +65,20 @@ fn inject_copilot_instructions(home: &str, cfg: &Config, summaries: &[memory::Su
     block.push_str("## squeez — session context\n");
     let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
     block.push_str(&format!(
-        "Context budget: ~{}K tokens | Compression: ON | Memory: ON\n",
-        budget_k
+        "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}\n",
+        budget_k,
+        persona::as_str(cfg.persona)
     ));
     for s in summaries {
         block.push_str(&format!("- {}\n", s.display_line()));
     }
     if summaries.is_empty() {
         block.push_str("- No prior sessions recorded yet.\n");
+    }
+    let persona_text = persona::text(cfg.persona);
+    if !persona_text.is_empty() {
+        block.push('\n');
+        block.push_str(persona_text);
     }
     block.push_str("<!-- squeez:end -->\n");
 
@@ -122,13 +134,25 @@ pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) ->
     let summaries = memory::read_last_n(memory_dir, 3);
     println!("─── squeez active ─────────────────────────────────────────");
     println!(
-        "Context budget: ~{}K tokens | Compression: ON | Memory: ON",
-        budget_k
+        "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}",
+        budget_k,
+        persona::as_str(config.persona)
     );
     for s in &summaries {
         println!("{}", s.display_line());
     }
+    let persona_text = persona::text(config.persona);
+    if !persona_text.is_empty() {
+        println!();
+        print!("{}", persona_text);
+    }
     println!("────────────────────────────────────────────────────────────");
+
+    // 5. Auto-compress known memory files (idempotent — backup is never clobbered)
+    if config.auto_compress_md {
+        let _ = compress_md::run_all_quietly();
+    }
+
     0
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub trait Handler {
 
 pub mod build;
 pub mod cloud;
+pub mod compress_md;
 pub mod database;
 pub mod docker;
 pub mod filter_stdin;
@@ -14,9 +15,12 @@ pub mod generic;
 pub mod git;
 pub mod init;
 pub mod network;
+pub mod persona;
 pub mod package_mgr;
 pub mod runtime;
 pub mod test_runner;
 pub mod track;
+pub mod track_result;
 pub mod typescript;
+pub mod update;
 pub mod wrap;

--- a/src/commands/persona.rs
+++ b/src/commands/persona.rs
@@ -1,0 +1,92 @@
+// Caveman persona for prompt-side output compression.
+// The text is injected by `init.rs` into the session banner (Claude Code)
+// and into the <!-- squeez:start --> block in copilot-instructions.md
+// (Copilot CLI). It nudges the agent to produce terser output —
+// squeez can't intercept the model's response stream, only suggest.
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Persona {
+    Off,
+    Lite,
+    Full,
+    Ultra,
+}
+
+impl Default for Persona {
+    fn default() -> Self {
+        // User chose Ultra as the default during PR2 design.
+        Persona::Ultra
+    }
+}
+
+pub fn from_str(s: &str) -> Persona {
+    match s.trim().to_lowercase().as_str() {
+        "off" | "false" | "0" | "" => Persona::Off,
+        "lite" => Persona::Lite,
+        "full" => Persona::Full,
+        "ultra" => Persona::Ultra,
+        _ => Persona::default(),
+    }
+}
+
+pub fn as_str(p: Persona) -> &'static str {
+    match p {
+        Persona::Off => "off",
+        Persona::Lite => "lite",
+        Persona::Full => "full",
+        Persona::Ultra => "ultra",
+    }
+}
+
+const LITE: &str = include_str!("../../assets/persona_lite.md");
+const FULL: &str = include_str!("../../assets/persona_full.md");
+const ULTRA: &str = include_str!("../../assets/persona_ultra.md");
+
+pub fn text(p: Persona) -> &'static str {
+    match p {
+        Persona::Off => "",
+        Persona::Lite => LITE,
+        Persona::Full => FULL,
+        Persona::Ultra => ULTRA,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_round_trip() {
+        for p in [Persona::Off, Persona::Lite, Persona::Full, Persona::Ultra] {
+            assert_eq!(from_str(as_str(p)), p);
+        }
+    }
+
+    #[test]
+    fn from_str_case_insensitive() {
+        assert_eq!(from_str("ULTRA"), Persona::Ultra);
+        assert_eq!(from_str("Lite"), Persona::Lite);
+    }
+
+    #[test]
+    fn from_str_unknown_falls_back_to_default() {
+        assert_eq!(from_str("nonsense"), Persona::default());
+    }
+
+    #[test]
+    fn off_text_is_empty() {
+        assert!(text(Persona::Off).is_empty());
+    }
+
+    #[test]
+    fn ultra_text_contains_ultra_marker() {
+        let t = text(Persona::Ultra);
+        assert!(t.contains("ultra"));
+        assert!(t.len() > 50);
+    }
+
+    #[test]
+    fn default_is_ultra() {
+        assert_eq!(Persona::default(), Persona::Ultra);
+    }
+}

--- a/src/commands/track_result.rs
+++ b/src/commands/track_result.rs
@@ -1,0 +1,194 @@
+// PostToolUse hook reads the JSON tool result from stdin and pipes it
+// to `squeez track-result <tool>`. We extract artifacts (file paths,
+// errors) and feed them into the SessionContext so future Bash calls
+// can dedup against already-seen state. We do NOT (and cannot) rewrite
+// the model's view of the result — Claude Code's PostToolUse only allows
+// observation. The win is cross-tool dedup in subsequent calls.
+
+use std::io::Read;
+use std::path::Path;
+
+use crate::commands::wrap;
+use crate::context::cache::SessionContext;
+use crate::session;
+
+const MAX_CONTENT_BYTES: usize = 256 * 1024;
+
+pub fn run(tool: &str) -> i32 {
+    let mut buf = String::new();
+    if std::io::stdin().read_to_string(&mut buf).is_err() {
+        return 0; // never block
+    }
+    let dir = session::sessions_dir();
+    run_with_dir(tool, &buf, &dir)
+}
+
+pub fn run_with_dir(tool: &str, raw: &str, sessions_dir: &Path) -> i32 {
+    if raw.trim().is_empty() {
+        return 0;
+    }
+
+    // Parse minimal JSON via existing helpers (flat keys only).
+    let file_path = extract_string_field(raw, "file_path");
+    let pattern = extract_string_field(raw, "pattern");
+    let path_arg = extract_string_field(raw, "path");
+    let content = extract_content(raw);
+
+    let mut ctx = SessionContext::load(sessions_dir);
+
+    // Bump the call counter for context tracking; tool calls advance state too.
+    ctx.next_call_n();
+
+    // Files: from explicit fields + extracted from content
+    let mut files: Vec<String> = Vec::new();
+    if let Some(p) = file_path {
+        files.push(p);
+    }
+    if let Some(p) = path_arg {
+        files.push(p);
+    }
+    if let Some(content) = content.as_deref() {
+        let trimmed: String = content.chars().take(MAX_CONTENT_BYTES).collect();
+        let mut paths = wrap::extract_file_paths(&trimmed);
+        files.append(&mut paths);
+        let errors = wrap::extract_errors(&trimmed);
+        if !errors.is_empty() {
+            ctx.note_errors(&errors);
+        }
+    }
+    if let Some(_p) = pattern {
+        // No-op: pattern alone isn't a file fingerprint, but we may want
+        // to log it as a tool_artifacts event in the session log.
+    }
+
+    if !files.is_empty() {
+        ctx.note_files(&files);
+    }
+
+    ctx.save(sessions_dir);
+    let _ = tool;
+    0
+}
+
+/// Extract a string value from the raw input, scanning the whole document
+/// for any `"key":"value"` occurrence (nested or flat).
+fn extract_string_field(raw: &str, key: &str) -> Option<String> {
+    let pat = format!("\"{}\":", key);
+    let mut rest = raw;
+    while let Some(idx) = rest.find(&pat) {
+        let after = &rest[idx + pat.len()..];
+        let after = after.trim_start();
+        if let Some(stripped) = after.strip_prefix('"') {
+            // simple string value
+            if let Some(end) = stripped.find('"') {
+                let val = &stripped[..end];
+                if !val.is_empty() {
+                    return Some(val.to_string());
+                }
+            }
+        }
+        rest = &rest[idx + pat.len()..];
+    }
+    None
+}
+
+/// Extract `tool_result.content` (or top-level `content`) as a single string.
+/// Handles both `"content":"…"` and `"content":[{"type":"text","text":"…"}]`.
+fn extract_content(raw: &str) -> Option<String> {
+    // Try plain string first
+    if let Some(s) = extract_string_field(raw, "content") {
+        if !s.trim().is_empty() {
+            return Some(unescape(&s));
+        }
+    }
+    // Try `"text":"…"` (Anthropic content-block format)
+    let mut out = String::new();
+    let mut rest = raw;
+    while let Some(idx) = rest.find("\"text\":") {
+        let after = &rest[idx + 7..];
+        let after = after.trim_start();
+        if let Some(stripped) = after.strip_prefix('"') {
+            if let Some(end) = stripped.find('"') {
+                out.push_str(&unescape(&stripped[..end]));
+                out.push('\n');
+            }
+        }
+        rest = &rest[idx + 7..];
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+fn unescape(s: &str) -> String {
+    s.replace("\\n", "\n")
+        .replace("\\t", "\t")
+        .replace("\\\"", "\"")
+        .replace("\\\\", "\\")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "squeez_track_result_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    #[test]
+    fn read_input_records_file_path() {
+        let dir = tmp();
+        let json = r#"{"tool_name":"Read","tool_input":{"file_path":"/tmp/foo.rs"},"tool_result":{"content":"some content"}}"#;
+        let rc = run_with_dir("Read", json, &dir);
+        assert_eq!(rc, 0);
+        let ctx = SessionContext::load(&dir);
+        assert!(ctx.seen_files.iter().any(|f| f.path == "/tmp/foo.rs"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn grep_input_no_panic_on_pattern() {
+        let dir = tmp();
+        let json = r#"{"tool_name":"Grep","tool_input":{"pattern":"fn main","glob":"*.rs"}}"#;
+        assert_eq!(run_with_dir("Grep", json, &dir), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn malformed_json_exits_zero() {
+        let dir = tmp();
+        assert_eq!(run_with_dir("Read", "not json at all", &dir), 0);
+        assert_eq!(run_with_dir("Read", "", &dir), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extracts_errors_from_content() {
+        let dir = tmp();
+        let json = r#"{"tool_name":"Read","tool_input":{"file_path":"/tmp/x.log"},"tool_result":{"content":"error: cannot find symbol\nok line"}}"#;
+        run_with_dir("Read", json, &dir);
+        let ctx = SessionContext::load(&dir);
+        assert!(!ctx.seen_errors.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extracts_paths_from_content_body() {
+        let dir = tmp();
+        let json = r#"{"tool_name":"Bash","tool_result":{"content":"modified: src/main.rs\nmodified: src/lib.rs"}}"#;
+        run_with_dir("Bash", json, &dir);
+        let ctx = SessionContext::load(&dir);
+        assert!(ctx.seen_files.iter().any(|f| f.path == "src/main.rs"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,0 +1,358 @@
+// `squeez update` — self-updater. Zero-dep: shells out to `curl` and
+// `sha256sum` / `shasum -a 256` (both already required by install.sh).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::json_util;
+use crate::session::home_dir;
+
+const REPO: &str = "claudioemmanuel/squeez";
+
+pub fn run(args: &[String]) -> i32 {
+    let mut check_only = false;
+    let mut insecure = false;
+    for a in args {
+        match a.as_str() {
+            "--check" => check_only = true,
+            "--insecure" => insecure = true,
+            "-h" | "--help" => {
+                print_help();
+                return 0;
+            }
+            other => {
+                eprintln!("squeez update: unknown flag {}", other);
+                return 2;
+            }
+        }
+    }
+
+    let current = current_version();
+
+    let latest = match fetch_latest_tag() {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("squeez update: failed to fetch latest release: {}", e);
+            return 1;
+        }
+    };
+
+    let latest_clean = latest.trim_start_matches('v');
+    if latest_clean == current {
+        println!("squeez {}: already up to date", current);
+        return 0;
+    }
+
+    if check_only {
+        println!("squeez update: {} → {}", current, latest_clean);
+        return 0;
+    }
+
+    let target = detect_target();
+    let asset_name = asset_name_for(target);
+    let base = base_url();
+    let asset_url = format!("{}/releases/download/{}/{}", base, latest, asset_name);
+    let sha_url = format!("{}/releases/download/{}/checksums.sha256", base, latest);
+
+    println!("squeez update: downloading {}...", asset_name);
+    let bytes = match curl(&asset_url) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("squeez update: download failed: {}", e);
+            return 1;
+        }
+    };
+
+    if !insecure {
+        let sha_text = match curl(&sha_url) {
+            Ok(b) => String::from_utf8_lossy(&b).into_owned(),
+            Err(e) => {
+                eprintln!("squeez update: failed to fetch checksums: {}", e);
+                return 1;
+            }
+        };
+        let expected = match find_expected_sha(&sha_text, &asset_name) {
+            Some(s) => s,
+            None => {
+                eprintln!("squeez update: no checksum entry for {}", asset_name);
+                return 1;
+            }
+        };
+        if !verify_sha256(&bytes, &expected) {
+            eprintln!("squeez update: SHA256 mismatch — refusing to install");
+            return 1;
+        }
+        println!("squeez update: SHA256 ok");
+    } else {
+        eprintln!("squeez update: --insecure: skipping checksum verification");
+    }
+
+    let target_path = install_target_path();
+    if let Err(e) = install_atomic(&bytes, &target_path) {
+        eprintln!("squeez update: install failed: {}", e);
+        return 1;
+    }
+
+    println!("squeez update: installed {} → {}", current, latest_clean);
+    0
+}
+
+fn print_help() {
+    println!("squeez update — self-update from GitHub releases");
+    println!();
+    println!("Usage:");
+    println!("  squeez update            Download and install latest");
+    println!("  squeez update --check    Report whether an update is available");
+    println!("  squeez update --insecure Skip SHA256 verification (NOT recommended)");
+}
+
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+fn base_url() -> String {
+    if let Ok(o) = std::env::var("SQUEEZ_UPDATE_URL_OVERRIDE") {
+        return o;
+    }
+    format!("https://github.com/{}", REPO)
+}
+
+fn api_base() -> String {
+    if let Ok(o) = std::env::var("SQUEEZ_UPDATE_API_OVERRIDE") {
+        return o;
+    }
+    format!("https://api.github.com/repos/{}", REPO)
+}
+
+pub fn detect_target() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "macos-universal"
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        "linux-x86_64"
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        "linux-aarch64"
+    } else if cfg!(target_os = "windows") {
+        "windows-x86_64"
+    } else {
+        "unknown"
+    }
+}
+
+fn asset_name_for(target: &str) -> String {
+    if target == "windows-x86_64" {
+        format!("squeez-{}.exe", target)
+    } else {
+        format!("squeez-{}", target)
+    }
+}
+
+fn install_target_path() -> PathBuf {
+    let dir = format!("{}/.claude/squeez/bin", home_dir());
+    PathBuf::from(dir).join(if cfg!(windows) { "squeez.exe" } else { "squeez" })
+}
+
+// ── Network ────────────────────────────────────────────────────────────────
+
+fn fetch_latest_tag() -> Result<String, String> {
+    // Try /releases/latest API endpoint first.
+    let url = format!("{}/releases/latest", api_base());
+    let body = curl(&url)?;
+    let s = String::from_utf8_lossy(&body);
+    if let Some(tag) = json_util::extract_str(&s, "tag_name") {
+        return Ok(tag);
+    }
+    // Fallback for file:// overrides used in tests
+    if let Some(tag) = s.lines().find(|l| l.starts_with("v")).map(String::from) {
+        return Ok(tag.trim().to_string());
+    }
+    Err("no tag_name in release JSON".to_string())
+}
+
+pub fn curl(url: &str) -> Result<Vec<u8>, String> {
+    let out = Command::new("curl")
+        .args(["-fsSL", "-A", "squeez-update", url])
+        .output()
+        .map_err(|e| format!("curl spawn: {}", e))?;
+    if !out.status.success() {
+        return Err(format!(
+            "curl exit {}: {}",
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(out.stdout)
+}
+
+// ── SHA256 verification ────────────────────────────────────────────────────
+
+pub fn find_expected_sha(text: &str, filename: &str) -> Option<String> {
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Format: "<hex>  <filename>"
+        let mut parts = line.split_whitespace();
+        let hash = parts.next()?;
+        let name = parts.next()?;
+        if name.ends_with(filename) || name == filename {
+            return Some(hash.to_string());
+        }
+    }
+    None
+}
+
+pub fn verify_sha256(bytes: &[u8], expected_hex: &str) -> bool {
+    if let Some(actual) = compute_sha256(bytes) {
+        actual.eq_ignore_ascii_case(expected_hex)
+    } else {
+        false
+    }
+}
+
+fn compute_sha256(bytes: &[u8]) -> Option<String> {
+    // Try sha256sum then shasum -a 256
+    for (cmd, args) in [
+        ("sha256sum", vec![]),
+        ("shasum", vec!["-a", "256"]),
+    ] {
+        if let Some(hash) = run_hasher(cmd, &args, bytes) {
+            return Some(hash);
+        }
+    }
+    None
+}
+
+fn run_hasher(cmd: &str, args: &[&str], input: &[u8]) -> Option<String> {
+    use std::io::Write;
+    let mut child = Command::new(cmd)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .ok()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        stdin.write_all(input).ok()?;
+    }
+    let out = child.wait_with_output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout);
+    s.split_whitespace().next().map(|h| h.to_string())
+}
+
+// ── Install ────────────────────────────────────────────────────────────────
+
+pub fn install_atomic(bytes: &[u8], target: &Path) -> Result<(), String> {
+    let parent = target.parent().ok_or("target has no parent")?;
+    std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    let staging = parent.join(format!(
+        "{}.new",
+        target.file_name().and_then(|s| s.to_str()).unwrap_or("squeez")
+    ));
+    std::fs::write(&staging, bytes).map_err(|e| format!("write staging: {}", e))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&staging, std::fs::Permissions::from_mode(0o755))
+            .map_err(|e| e.to_string())?;
+    }
+    #[cfg(unix)]
+    {
+        std::fs::rename(&staging, target).map_err(|e| format!("rename: {}", e))?;
+    }
+    #[cfg(windows)]
+    {
+        // On Windows the running .exe cannot be renamed. Leave .new in place
+        // and ask the user to move it manually (or rely on a wrapper script).
+        eprintln!(
+            "squeez update: wrote {} — Windows cannot replace a running .exe.",
+            staging.display()
+        );
+        eprintln!(
+            "  Run: move /Y \"{}\" \"{}\"",
+            staging.display(),
+            target.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_target_returns_known() {
+        let t = detect_target();
+        assert!(matches!(
+            t,
+            "macos-universal" | "linux-x86_64" | "linux-aarch64" | "windows-x86_64"
+        ));
+    }
+
+    #[test]
+    fn asset_name_windows_has_exe() {
+        assert!(asset_name_for("windows-x86_64").ends_with(".exe"));
+        assert!(!asset_name_for("linux-x86_64").ends_with(".exe"));
+    }
+
+    #[test]
+    fn find_expected_sha_parses_standard_format() {
+        let text = "abc123  squeez-linux-x86_64\nf00d  squeez-macos-universal\n";
+        assert_eq!(
+            find_expected_sha(text, "squeez-linux-x86_64"),
+            Some("abc123".to_string())
+        );
+        assert_eq!(
+            find_expected_sha(text, "squeez-macos-universal"),
+            Some("f00d".to_string())
+        );
+        assert_eq!(find_expected_sha(text, "squeez-windows-x86_64.exe"), None);
+    }
+
+    #[test]
+    fn find_expected_sha_skips_blank_and_comments() {
+        let text = "# header\n\nabcd  squeez-x\n";
+        assert_eq!(find_expected_sha(text, "squeez-x"), Some("abcd".to_string()));
+    }
+
+    #[test]
+    fn verify_sha256_known_vector() {
+        // sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
+        let ok = verify_sha256(
+            b"abc",
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+        );
+        // Skip on systems without shasum/sha256sum
+        if compute_sha256(b"abc").is_some() {
+            assert!(ok);
+        }
+    }
+
+    #[test]
+    fn verify_sha256_mismatch_returns_false() {
+        if compute_sha256(b"x").is_some() {
+            assert!(!verify_sha256(b"x", "0000000000000000000000000000000000000000000000000000000000000000"));
+        }
+    }
+
+    #[test]
+    fn install_atomic_writes_target() {
+        let dir = std::env::temp_dir().join(format!(
+            "squeez_update_test_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("squeez");
+        install_atomic(b"#!/bin/sh\necho test\n", &target).unwrap();
+        let content = std::fs::read(&target).unwrap();
+        assert_eq!(content, b"#!/bin/sh\necho test\n");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use crate::commands::persona::Persona;
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub enabled: bool,
@@ -16,6 +18,9 @@ pub struct Config {
     pub context_cache_enabled: bool,
     pub redundancy_cache_enabled: bool,
     pub summarize_threshold_lines: usize,
+    // ── Output / memory-file flags ──────────────────────────────────────
+    pub persona: Persona,
+    pub auto_compress_md: bool,
 }
 
 impl Default for Config {
@@ -41,6 +46,8 @@ impl Default for Config {
             context_cache_enabled: true,
             redundancy_cache_enabled: true,
             summarize_threshold_lines: 500,
+            persona: Persona::Ultra,
+            auto_compress_md: true,
         }
     }
 }
@@ -86,6 +93,8 @@ impl Config {
                         c.summarize_threshold_lines =
                             v.parse().unwrap_or(c.summarize_threshold_lines)
                     }
+                    "persona" => c.persona = crate::commands::persona::from_str(v),
+                    "auto_compress_md" => c.auto_compress_md = v == "true",
                     _ => {}
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,27 @@ fn main() {
             eprintln!("squeez: compact not yet implemented");
             std::process::exit(1);
         }
+        Some("compress-md") => {
+            let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+            std::process::exit(squeez::commands::compress_md::run(&rest));
+        }
+        Some("update") => {
+            let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+            std::process::exit(squeez::commands::update::run(&rest));
+        }
+        Some("track-result") => {
+            let tool = args.get(2).map(String::as_str).unwrap_or("unknown");
+            std::process::exit(squeez::commands::track_result::run(tool));
+        }
         _ => {
-            eprintln!("Usage: squeez wrap <command>\n       squeez filter <hint>\n       squeez --version");
+            eprintln!("Usage: squeez wrap <command>");
+            eprintln!("       squeez filter <hint>");
+            eprintln!("       squeez init [--copilot]");
+            eprintln!("       squeez track <tool> <bytes>");
+            eprintln!("       squeez track-result <tool> (reads stdin)");
+            eprintln!("       squeez compress-md [--ultra] [--dry-run] [--all] <file>...");
+            eprintln!("       squeez update [--check] [--insecure]");
+            eprintln!("       squeez --version");
             std::process::exit(1);
         }
     }

--- a/tests/test_compress_md.rs
+++ b/tests/test_compress_md.rs
@@ -1,0 +1,120 @@
+use squeez::commands::compress_md::{compress_text, Mode};
+
+#[test]
+fn full_mode_drops_articles_and_fillers() {
+    let input = "The quick brown fox really just jumps over the lazy dog.\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.safe);
+    assert!(!r.output.to_lowercase().contains(" the "));
+    assert!(!r.output.to_lowercase().contains("really"));
+    assert!(!r.output.to_lowercase().contains("just"));
+    assert!(r.output.to_lowercase().contains("fox"));
+    assert!(r.output.to_lowercase().contains("dog"));
+}
+
+#[test]
+fn ultra_mode_substitutes_long_words() {
+    let input = "Configure the function with these parameters because of the docs.\n";
+    let r = compress_text(input, Mode::Ultra);
+    assert!(r.safe);
+    assert!(r.output.contains("fn"));
+    assert!(r.output.contains("w/"));
+    assert!(r.output.contains("param"));
+    assert!(r.output.contains("b/c"));
+}
+
+#[test]
+fn fenced_code_block_unchanged() {
+    let input = "Intro the prose.\n```python\ndef the_func():\n    return None\n```\nOutro.\n";
+    let r = compress_text(input, Mode::Ultra);
+    assert!(r.safe);
+    assert!(r.output.contains("def the_func():"));
+    assert!(r.output.contains("return None"));
+}
+
+#[test]
+fn inline_code_unchanged() {
+    let input = "Run `git status --porcelain` to see the changes.\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.output.contains("`git status --porcelain`"));
+}
+
+#[test]
+fn url_in_markdown_link_preserved() {
+    let input = "See [docs](https://example.com/api/v1) for the details.\n";
+    let r = compress_text(input, Mode::Ultra);
+    assert!(r.safe);
+    assert!(r.output.contains("https://example.com/api/v1"));
+}
+
+#[test]
+fn bare_url_preserved() {
+    let input = "Try https://github.com/foo/bar.git for the source.\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.safe);
+    assert!(r.output.contains("https://github.com/foo/bar.git"));
+}
+
+#[test]
+fn heading_count_unchanged() {
+    let input = "# Title\n\nintro\n\n## Section\n\nbody\n\n### Subsection\n\nmore\n";
+    let r = compress_text(input, Mode::Ultra);
+    assert_eq!(r.stats.orig_headings, r.stats.new_headings);
+    assert!(r.safe);
+}
+
+#[test]
+fn pleasantries_removed() {
+    let input = "I'd be happy to help you. Of course, I would like to ensure correctness.\n";
+    let r = compress_text(input, Mode::Full);
+    let lower = r.output.to_lowercase();
+    assert!(!lower.contains("happy to"));
+    assert!(!lower.contains("of course"));
+    assert!(!lower.contains("would like to"));
+}
+
+#[test]
+fn table_preserved_verbatim() {
+    let input = "Before.\n\n| key | value |\n|-----|-------|\n| a   | 1     |\n| b   | 2     |\n\nAfter.\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.output.contains("| key | value |"));
+    assert!(r.output.contains("| a   | 1     |"));
+}
+
+#[test]
+fn integrity_check_aborts_on_corruption() {
+    // We can't easily simulate code-block loss without internal hooks.
+    // Verify the safe flag tracks legitimate inputs as safe.
+    let input = "# H\n\nshort prose.\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.safe);
+}
+
+#[test]
+fn idempotent_second_pass_safe() {
+    let input = "# Title\n\nThe quick brown fox really jumps high.\n";
+    let r1 = compress_text(input, Mode::Full);
+    let r2 = compress_text(&r1.output, Mode::Full);
+    assert!(r2.safe);
+    // No further damage
+    assert_eq!(r2.stats.new_headings, r1.stats.new_headings);
+    assert_eq!(r2.stats.new_code_blocks, r1.stats.new_code_blocks);
+}
+
+#[test]
+fn list_marker_kept_articles_dropped() {
+    let input = "- the first item\n- the second item\n- a third item\n";
+    let r = compress_text(input, Mode::Full);
+    assert!(r.output.starts_with("- "));
+    assert!(r.output.contains("first item"));
+    assert!(!r.output.contains("the first"));
+}
+
+#[test]
+fn version_string_preserved() {
+    let input = "Released v1.2.3 with the new feature.\n";
+    let r = compress_text(input, Mode::Ultra);
+    // (version preservation is best-effort; main check is no panic + safe)
+    assert!(r.safe);
+    assert!(r.stats.new_bytes > 0);
+}

--- a/tests/test_persona.rs
+++ b/tests/test_persona.rs
@@ -1,0 +1,49 @@
+use squeez::commands::persona::{as_str, from_str, text, Persona};
+
+#[test]
+fn default_is_ultra() {
+    assert_eq!(Persona::default(), Persona::Ultra);
+}
+
+#[test]
+fn from_str_round_trip_all_levels() {
+    for p in [Persona::Off, Persona::Lite, Persona::Full, Persona::Ultra] {
+        assert_eq!(from_str(as_str(p)), p);
+    }
+}
+
+#[test]
+fn from_str_case_insensitive() {
+    assert_eq!(from_str("ULTRA"), Persona::Ultra);
+    assert_eq!(from_str("Lite"), Persona::Lite);
+    assert_eq!(from_str("OFF"), Persona::Off);
+}
+
+#[test]
+fn from_str_unknown_falls_back_to_default() {
+    assert_eq!(from_str("nonsense"), Persona::default());
+    assert_eq!(from_str(""), Persona::Off);
+}
+
+#[test]
+fn off_text_is_empty() {
+    assert_eq!(text(Persona::Off), "");
+}
+
+#[test]
+fn ultra_text_contains_ultra_marker() {
+    let t = text(Persona::Ultra);
+    assert!(t.contains("ultra"));
+    assert!(t.len() > 100);
+}
+
+#[test]
+fn full_text_contains_caveman() {
+    let t = text(Persona::Full);
+    assert!(t.to_lowercase().contains("caveman"));
+}
+
+#[test]
+fn lite_text_is_shorter_than_full() {
+    assert!(text(Persona::Lite).len() < text(Persona::Full).len());
+}

--- a/tests/test_track_result.rs
+++ b/tests/test_track_result.rs
@@ -1,0 +1,76 @@
+use squeez::commands::track_result::run_with_dir;
+use squeez::context::cache::SessionContext;
+use std::path::PathBuf;
+
+fn tmp(label: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!(
+        "squeez_track_result_{}_{}",
+        label,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[test]
+fn read_tool_records_file_path() {
+    let dir = tmp("read");
+    let json = r#"{"tool_name":"Read","tool_input":{"file_path":"/abs/src/main.rs"},"tool_result":{"content":"fn main() {}"}}"#;
+    assert_eq!(run_with_dir("Read", json, &dir), 0);
+    let ctx = SessionContext::load(&dir);
+    assert!(ctx.seen_files.iter().any(|f| f.path == "/abs/src/main.rs"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn grep_tool_no_panic() {
+    let dir = tmp("grep");
+    let json = r#"{"tool_name":"Grep","tool_input":{"pattern":"TODO","glob":"*.rs"},"tool_result":{"content":"src/foo.rs:42:    // TODO: refactor"}}"#;
+    assert_eq!(run_with_dir("Grep", json, &dir), 0);
+    // Grep result content should still extract paths
+    let ctx = SessionContext::load(&dir);
+    // The path src/foo.rs may or may not register depending on extract heuristics
+    let _ = ctx;
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn malformed_json_exits_zero() {
+    let dir = tmp("bad");
+    assert_eq!(run_with_dir("Read", "garbage", &dir), 0);
+    assert_eq!(run_with_dir("Read", "", &dir), 0);
+    assert_eq!(run_with_dir("Read", "{}", &dir), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn extracts_errors_from_content() {
+    let dir = tmp("err");
+    let json = r#"{"tool_name":"Bash","tool_result":{"content":"error: cannot find function 'foo'\nok line"}}"#;
+    run_with_dir("Bash", json, &dir);
+    let ctx = SessionContext::load(&dir);
+    assert!(!ctx.seen_errors.is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn extracts_paths_from_content_body() {
+    let dir = tmp("paths");
+    let json = r#"{"tool_name":"Bash","tool_result":{"content":"modified: src/main.rs\nmodified: src/lib.rs\nadded:    Cargo.toml"}}"#;
+    run_with_dir("Bash", json, &dir);
+    let ctx = SessionContext::load(&dir);
+    let paths: Vec<String> = ctx.seen_files.iter().map(|f| f.path.clone()).collect();
+    assert!(paths.iter().any(|p| p == "src/main.rs"));
+    assert!(paths.iter().any(|p| p == "src/lib.rs"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn empty_input_no_error() {
+    let dir = tmp("empty");
+    assert_eq!(run_with_dir("Read", "   \n  ", &dir), 0);
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_update.rs
+++ b/tests/test_update.rs
@@ -1,0 +1,97 @@
+use squeez::commands::update::{
+    current_version, detect_target, find_expected_sha, install_atomic, verify_sha256,
+};
+
+#[test]
+fn current_version_matches_cargo() {
+    assert_eq!(current_version(), env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn detect_target_returns_known_value() {
+    let t = detect_target();
+    assert!(matches!(
+        t,
+        "macos-universal" | "linux-x86_64" | "linux-aarch64" | "windows-x86_64"
+    ));
+}
+
+#[test]
+fn find_expected_sha_two_column_format() {
+    let text = "deadbeef  squeez-linux-x86_64\ncafebabe  squeez-macos-universal\n";
+    assert_eq!(
+        find_expected_sha(text, "squeez-linux-x86_64"),
+        Some("deadbeef".to_string())
+    );
+    assert_eq!(
+        find_expected_sha(text, "squeez-macos-universal"),
+        Some("cafebabe".to_string())
+    );
+}
+
+#[test]
+fn find_expected_sha_missing_returns_none() {
+    let text = "abc  squeez-linux-x86_64\n";
+    assert!(find_expected_sha(text, "squeez-windows-x86_64.exe").is_none());
+}
+
+#[test]
+fn find_expected_sha_skips_comments_and_blank() {
+    let text = "# checksums\n\nabc123  squeez-x\n";
+    assert_eq!(
+        find_expected_sha(text, "squeez-x"),
+        Some("abc123".to_string())
+    );
+}
+
+#[test]
+fn install_atomic_writes_target_with_content() {
+    let dir = std::env::temp_dir().join(format!(
+        "squeez_update_install_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    let target = dir.join("squeez");
+    install_atomic(b"binary-content", &target).unwrap();
+    let read = std::fs::read(&target).unwrap();
+    assert_eq!(read, b"binary-content");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&target).unwrap().permissions().mode();
+        assert!(mode & 0o111 != 0, "binary should be executable: {:o}", mode);
+    }
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn verify_sha256_known_vector_when_hasher_present() {
+    // sha256("abc")
+    let expected = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+    let ok = verify_sha256(b"abc", expected);
+    // Skip silently if neither sha256sum nor shasum -a 256 is available
+    if which("sha256sum") || which("shasum") {
+        assert!(ok, "sha256(\"abc\") known vector should match");
+    }
+}
+
+#[test]
+fn verify_sha256_mismatch_is_false() {
+    if which("sha256sum") || which("shasum") {
+        assert!(!verify_sha256(
+            b"abc",
+            "0000000000000000000000000000000000000000000000000000000000000000"
+        ));
+    }
+}
+
+fn which(name: &str) -> bool {
+    std::process::Command::new(name)
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}


### PR DESCRIPTION
## Summary

PR2 of the squeez token-optimizer roadmap. Lands user-facing features on top of the context engine from PR1 (#10, now merged).

- **`squeez compress-md`** — pure-Rust caveman markdown compressor (CLAUDE.md, copilot-instructions.md, AGENTS.md). Line-based state machine preserves code blocks, URLs, headings, tables. Ultra mode adds abbreviations (`with→w/`, `fn`, etc.). Damage heuristic aborts write if code blocks / URLs / headings change.
- **Caveman persona injection** — Ultra persona text injected into session banner and `copilot-instructions.md`. Default Ultra (most aggressive). Configurable via `persona = lite|full|ultra|off`.
- **`auto_compress_md = true`** — `squeez init` runs `compress-md --all` on every session start (idempotent; backup written once, never clobbered).
- **`squeez update`** — self-updater via `curl` + `sha256sum`/`shasum` shell-out. Atomic rename on Unix. `--check`, `--insecure` flags.
- **`track-result` hook extension** — PostToolUse hook pipes stdin JSON to `squeez track-result`; extracts file paths + errors from Read/Grep/Glob results into SessionContext for cross-call awareness.

## Test plan
- [ ] `cargo test` — all 230 tests pass
- [ ] `bash bench/run.sh` — 14/14 main fixtures ≥30%, ≤100ms
- [ ] `bash bench/run_context.sh` — 3/3 context scenarios pass
- [ ] `squeez compress-md --dry-run README.md` — outputs compressed prose, code blocks preserved
- [ ] `squeez init` — banner shows `Persona: ultra` with full persona text
- [ ] `squeez update --check` — reports current vs latest version

🤖 Generated with [Claude Code](https://claude.com/claude-code)