### PR TITLE
chore: promote v0.2.0 to main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "squeez"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "squeez"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
+description = "End-to-end token optimizer for Claude Code, Copilot CLI, and OpenCode. Compresses bash output up to 95%, collapses redundant calls, injects caveman persona, and compresses memory files. Zero new dependencies."
+repository = "https://github.com/claudioemmanuel/squeez"
+license = "MIT"
+keywords = ["claude-code", "token", "compression", "llm", "cli"]
+categories = ["command-line-utilities", "development-tools"]
+readme = "README.md"
 
 [[bin]]
 name = "squeez"


### PR DESCRIPTION
## Summary

- Bumps version `0.1.0 → 0.2.0` in `Cargo.toml`
- Adds project metadata: description, repository, license, keywords, categories, readme

Closes #17

## Test plan

- [x] `cargo test` passes on develop
- [x] `cargo build --release` produces working binary
- [x] `squeez --version` reports `0.2.0`