### PR TITLE
feat(statusline): ship statusline.sh in repo; register via install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -67,6 +67,10 @@ curl -fsSL "$REPO_RAW/hooks/session-start.sh"  -o "$INSTALL_DIR/hooks/session-st
 curl -fsSL "$REPO_RAW/hooks/posttooluse.sh"    -o "$INSTALL_DIR/hooks/posttooluse.sh"
 chmod +x "$INSTALL_DIR/hooks/pretooluse.sh" "$INSTALL_DIR/hooks/session-start.sh" "$INSTALL_DIR/hooks/posttooluse.sh"
 
+echo "Installing status line script..."
+curl -fsSL "$REPO_RAW/scripts/statusline.sh" -o "$INSTALL_DIR/bin/statusline.sh"
+chmod +x "$INSTALL_DIR/bin/statusline.sh"
+
 echo "Installing OpenCode plugin..."
 OPENCODE_PLUGIN_DIR="$HOME/.config/opencode/plugins"
 mkdir -p "$OPENCODE_PLUGIN_DIR"
@@ -123,6 +127,20 @@ if not isinstance(settings.get("PostToolUse"), list):
 post_hook = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/posttooluse.sh"}]}
 if not any("squeez" in str(h) for h in settings["PostToolUse"]):
     settings["PostToolUse"].append(post_hook)
+
+
+# StatusLine — show squeez stats in Claude Code status bar
+# Appends to existing statusLine command if claude-hud is present, otherwise sets standalone
+existing_status = settings.get("statusLine", {})
+existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
+squeez_status_cmd = "bash ~/.claude/squeez/bin/statusline.sh"
+if "squeez" not in existing_cmd:
+    if existing_cmd:
+        # Append squeez after existing status (e.g., claude-hud)
+        new_cmd = f"bash -c 'input=$(cat); echo \"$input\" | {{ {existing_cmd.rstrip()}; }} 2>/dev/null; echo \"$input\" | {squeez_status_cmd}'"
+        settings["statusLine"] = {"type": "command", "command": new_cmd}
+    else:
+        settings["statusLine"] = {"type": "command", "command": squeez_status_cmd}
 
 tmp = path + ".tmp"
 with open(tmp, "w") as f:

--- a/scripts/statusline.sh
+++ b/scripts/statusline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# squeez status line for Claude Code
+# Shows current-session stats, falls back to all-time aggregate.
+
+SQUEEZ_DIR="${SQUEEZ_DIR:-$HOME/.claude/squeez}"
+
+python3 - "$SQUEEZ_DIR" << 'PYEOF'
+import json, os, sys, glob
+
+squeez_dir = sys.argv[1]
+sessions_dir = f'{squeez_dir}/sessions'
+curr_path = f'{sessions_dir}/current.json'
+
+hooks_ok = False
+try:
+    s = json.load(open(os.path.expanduser('~/.claude/settings.json')))
+    hooks_ok = bool(s.get('PreToolUse'))
+except:
+    pass
+
+def read_session(jsonl_path):
+    """Return (calls, total_in, total_out, redundant) from a session JSONL."""
+    calls = total_in = total_out = redundant = 0
+    try:
+        for line in open(jsonl_path):
+            try:
+                d = json.loads(line)
+                if d.get('type') == 'bash' and d.get('in_tk', 0) > 0:
+                    total_in  += d['in_tk']
+                    total_out += d.get('out_tk', 0)
+                    calls     += 1
+                    if d.get('out_tk', 0) < d['in_tk'] * 0.05:
+                        redundant += 1
+            except:
+                pass
+    except:
+        pass
+    return calls, total_in, total_out, redundant
+
+def fmt_k(n):
+    return f'{n/1000:.1f}K' if n >= 1000 else str(n)
+
+try:
+    curr = json.load(open(curr_path))
+    session_file = curr.get('session_file', '')
+
+    # --- Current session ---
+    cur_calls = cur_in = cur_out = cur_red = 0
+    if session_file:
+        jsonl = f'{sessions_dir}/{session_file}'
+        if os.path.exists(jsonl):
+            cur_calls, cur_in, cur_out, cur_red = read_session(jsonl)
+
+    # --- All-time aggregate (all *.jsonl files) ---
+    all_calls = all_in = all_out = all_red = 0
+    for f in glob.glob(f'{sessions_dir}/*.jsonl'):
+        c, i, o, r = read_session(f)
+        all_calls += c; all_in += i; all_out += o; all_red += r
+
+    all_saved = max(0, all_in - all_out)
+    all_pct   = int(all_saved * 100 / all_in) if all_in > 0 else 0
+
+    if cur_calls > 0:
+        # Show current session stats + all-time context
+        cur_saved = max(0, cur_in - cur_out)
+        cur_pct   = int(cur_saved * 100 / cur_in) if cur_in > 0 else 0
+        parts = [f'squeez ↓{cur_pct}%', f'{cur_calls} calls', f'{fmt_k(cur_saved)} tk saved']
+        if cur_red:
+            parts.append(f'{cur_red} deduped')
+        if all_calls > cur_calls:
+            parts.append(f'all-time: {fmt_k(all_saved)} saved')
+        print(' | '.join(parts))
+    elif all_calls > 0:
+        # No current-session data — show all-time stats with label
+        parts = [f'squeez ✓', f'all-time: ↓{all_pct}%', f'{all_calls} calls', f'{fmt_k(all_saved)} tk saved']
+        if all_red:
+            parts.append(f'{all_red} deduped')
+        print(' | '.join(parts))
+    else:
+        status = '✓ active' if hooks_ok else '⚠ restart to activate'
+        print(f'squeez {status}')
+
+except:
+    status = '✓ active' if hooks_ok else '⚠ restart to activate'
+    print(f'squeez {status}')
+PYEOF


### PR DESCRIPTION
## Summary

- `scripts/statusline.sh` added to source (was only a local file, not tracked in repo)
- `install.sh` now downloads and installs `statusline.sh` to `~/.claude/squeez/bin/`
- `install.sh` auto-registers `statusLine.command` in `~/.claude/settings.json` on fresh installs
- Statusline falls back to all-time aggregate across all session `.jsonl` files when current session has no data — fixes the `squeez ✓ active` fallback showing instead of real stats

Closes #18

## Test plan

- [x] `bash ~/.claude/squeez/bin/statusline.sh` outputs `squeez ✓ | all-time: ↓94% | 200 calls | 668.4K tk saved | 6 deduped`
- [x] Scripts tracked and downloadable from raw GitHub URL
- [x] `cargo test` passes