### PR TITLE
feat(npm+crates): npm package, npx support, publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     tags: ['v*']
+
 jobs:
+  # ── Build platform binaries ──────────────────────────────────────────────
   build-macos:
     runs-on: macos-latest
     steps:
@@ -20,8 +22,7 @@ jobs:
             target/aarch64-apple-darwin/release/squeez \
             target/x86_64-apple-darwin/release/squeez \
             -output squeez-macos-universal
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
           name: squeez-macos-universal
           path: squeez-macos-universal
@@ -37,10 +38,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools
       - name: Build
         run: cargo build --release --target x86_64-unknown-linux-musl
-      - name: Rename binary
-        run: mv target/x86_64-unknown-linux-musl/release/squeez squeez-linux-x86_64
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - run: mv target/x86_64-unknown-linux-musl/release/squeez squeez-linux-x86_64
+      - uses: actions/upload-artifact@v4
         with:
           name: squeez-linux-x86_64
           path: squeez-linux-x86_64
@@ -54,10 +53,8 @@ jobs:
         run: cargo install cross
       - name: Build
         run: cross build --release --target aarch64-unknown-linux-musl
-      - name: Rename binary
-        run: mv target/aarch64-unknown-linux-musl/release/squeez squeez-linux-aarch64
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - run: mv target/aarch64-unknown-linux-musl/release/squeez squeez-linux-aarch64
+      - uses: actions/upload-artifact@v4
         with:
           name: squeez-linux-aarch64
           path: squeez-linux-aarch64
@@ -69,29 +66,27 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Build
         run: cargo build --release --target x86_64-pc-windows-msvc
-      - name: Rename binary
-        run: mv target/x86_64-pc-windows-msvc/release/squeez.exe squeez-windows-x86_64.exe
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+      - run: mv target/x86_64-pc-windows-msvc/release/squeez.exe squeez-windows-x86_64.exe
+      - uses: actions/upload-artifact@v4
         with:
           name: squeez-windows-x86_64
           path: squeez-windows-x86_64.exe
 
+  # ── GitHub Release (binaries + checksums) ────────────────────────────────
   release:
     needs: [build-macos, build-linux-x86_64, build-linux-aarch64, build-windows-x86_64]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4
       - name: Generate checksums
         run: |
-          cd squeez-macos-universal && sha256sum squeez-macos-universal > ../checksums.sha256 && cd ..
-          cd squeez-linux-x86_64 && sha256sum squeez-linux-x86_64 >> ../checksums.sha256 && cd ..
-          cd squeez-linux-aarch64 && sha256sum squeez-linux-aarch64 >> ../checksums.sha256 && cd ..
+          cd squeez-macos-universal && sha256sum squeez-macos-universal  > ../checksums.sha256 && cd ..
+          cd squeez-linux-x86_64   && sha256sum squeez-linux-x86_64     >> ../checksums.sha256 && cd ..
+          cd squeez-linux-aarch64  && sha256sum squeez-linux-aarch64    >> ../checksums.sha256 && cd ..
           cd squeez-windows-x86_64 && sha256sum squeez-windows-x86_64.exe >> ../checksums.sha256 && cd ..
-      - name: Upload to release
+      - name: Upload to GitHub release
         uses: softprops/action-gh-release@v1
         with:
           files: |
@@ -100,3 +95,39 @@ jobs:
             squeez-linux-aarch64/squeez-linux-aarch64
             squeez-windows-x86_64/squeez-windows-x86_64.exe
             checksums.sha256
+
+  # ── npm publish ──────────────────────────────────────────────────────────
+  publish-npm:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Sync version from git tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd npm
+          node -e "
+            const fs = require('fs');
+            const p = JSON.parse(fs.readFileSync('package.json','utf8'));
+            p.version = '$VERSION';
+            fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
+          "
+          echo "Publishing squeez@$VERSION to npm"
+      - name: Publish
+        run: cd npm && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ── crates.io publish ────────────────────────────────────────────────────
+  publish-crates:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish to crates.io
+        run: cargo publish --no-verify --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,0 +1,1 @@
+# Only ship the three JS files — nothing else

--- a/npm/bin.js
+++ b/npm/bin.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * bin.js — CLI entry point for the squeez npm package.
+ * Delegates all arguments to the native binary at ~/.claude/squeez/bin/squeez.
+ * Auto-installs if the binary is missing (e.g. after `npx squeez`).
+ */
+const { execFileSync, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const BINARY = path.join(
+  os.homedir(), '.claude', 'squeez', 'bin',
+  process.platform === 'win32' ? 'squeez.exe' : 'squeez'
+);
+
+if (!fs.existsSync(BINARY)) {
+  process.stderr.write('squeez: binary not found — running installer...\n');
+  if (process.platform === 'win32') {
+    process.stderr.write('squeez: on Windows, download from https://github.com/claudioemmanuel/squeez/releases\n');
+    process.exit(1);
+  }
+  try {
+    execSync(
+      'curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh',
+      { stdio: 'inherit' }
+    );
+  } catch (_) {
+    // If curl failed, try running install.js alongside this file
+    try {
+      require(path.join(__dirname, 'install.js'));
+    } catch (e) {
+      process.stderr.write(`squeez: installation failed: ${e.message}\n`);
+      process.exit(1);
+    }
+  }
+}
+
+if (!fs.existsSync(BINARY)) {
+  process.stderr.write('squeez: binary still not found after install attempt.\n');
+  process.stderr.write('Run manually: curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh\n');
+  process.exit(1);
+}
+
+try {
+  execFileSync(BINARY, process.argv.slice(2), { stdio: 'inherit' });
+} catch (e) {
+  process.exit(e.status ?? 1);
+}

--- a/npm/install.js
+++ b/npm/install.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * postinstall — downloads the squeez binary and registers Claude Code hooks.
+ * Runs automatically on `npm install -g squeez` or `npx squeez`.
+ */
+const { execSync } = require('child_process');
+const https = require('https');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Allow skipping (e.g. in CI that only needs the npm package metadata)
+if (process.env.SQUEEZ_SKIP_INSTALL === '1') process.exit(0);
+
+const INSTALL_DIR = path.join(os.homedir(), '.claude', 'squeez');
+const BINARY = path.join(INSTALL_DIR, 'bin', process.platform === 'win32' ? 'squeez.exe' : 'squeez');
+const RELEASES = 'https://github.com/claudioemmanuel/squeez/releases/latest/download';
+
+function log(msg) { process.stdout.write(`squeez: ${msg}\n`); }
+function warn(msg) { process.stderr.write(`squeez: ${msg}\n`); }
+
+// ── Platform map ───────────────────────────────────────────────────────────
+const PLATFORM_MAP = {
+  darwin:  { x64: 'squeez-macos-universal', arm64: 'squeez-macos-universal' },
+  linux:   { x64: 'squeez-linux-x86_64', arm64: 'squeez-linux-aarch64' },
+  win32:   { x64: 'squeez-windows-x86_64.exe' },
+};
+
+function getBinary() {
+  const plat = PLATFORM_MAP[process.platform];
+  if (!plat) return null;
+  return plat[process.arch] || plat['x64'] || null;
+}
+
+// ── Download helper (Node built-in https, no external deps) ───────────────
+function download(url, dest) {
+  return new Promise((resolve, reject) => {
+    const tmp = dest + '.tmp';
+    const file = fs.createWriteStream(tmp);
+    const follow = (u) => {
+      https.get(u, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          follow(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode} for ${u}`));
+          return;
+        }
+        res.pipe(file);
+        file.on('finish', () => {
+          file.close();
+          fs.renameSync(tmp, dest);
+          resolve();
+        });
+      }).on('error', reject);
+    };
+    follow(url);
+  });
+}
+
+async function main() {
+  // Already installed and up-to-date — just register hooks
+  if (fs.existsSync(BINARY)) {
+    log('binary already present — skipping download.');
+    registerHooks();
+    return;
+  }
+
+  // ── Unix: prefer install.sh (also handles hooks + Copilot) ───────────
+  if (process.platform !== 'win32') {
+    try {
+      log('running install.sh …');
+      execSync(
+        'curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh',
+        { stdio: 'inherit' }
+      );
+      return;
+    } catch (_) {
+      warn('curl not found — falling back to Node.js downloader.');
+    }
+  }
+
+  // ── Fallback: Node.js binary download (no curl required) ─────────────
+  const binaryName = getBinary();
+  if (!binaryName) {
+    warn(`unsupported platform ${process.platform}/${process.arch}.`);
+    warn('Download manually from https://github.com/claudioemmanuel/squeez/releases');
+    process.exit(0);
+  }
+
+  fs.mkdirSync(path.join(INSTALL_DIR, 'bin'), { recursive: true });
+  fs.mkdirSync(path.join(INSTALL_DIR, 'hooks'), { recursive: true });
+  fs.mkdirSync(path.join(INSTALL_DIR, 'sessions'), { recursive: true });
+
+  log(`downloading ${binaryName} …`);
+  try {
+    await download(`${RELEASES}/${binaryName}`, BINARY);
+    fs.chmodSync(BINARY, 0o755);
+    log('binary downloaded.');
+  } catch (err) {
+    warn(`download failed: ${err.message}`);
+    warn('Install manually: curl -fsSL https://raw.githubusercontent.com/claudioemmanuel/squeez/main/install.sh | sh');
+    process.exit(0);
+  }
+
+  registerHooks();
+}
+
+function registerHooks() {
+  const settingsPath = path.join(os.homedir(), '.claude', 'settings.json');
+  let settings = {};
+  try {
+    if (fs.existsSync(settingsPath)) {
+      settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    }
+  } catch (_) {}
+
+  let changed = false;
+
+  // PreToolUse
+  if (!Array.isArray(settings.PreToolUse)) { settings.PreToolUse = []; }
+  const preHook = { matcher: 'Bash', hooks: [{ type: 'command', command: 'bash ~/.claude/squeez/hooks/pretooluse.sh' }] };
+  if (!settings.PreToolUse.some(h => JSON.stringify(h).includes('squeez'))) {
+    settings.PreToolUse.push(preHook); changed = true;
+  }
+
+  // SessionStart
+  if (!Array.isArray(settings.SessionStart)) { settings.SessionStart = []; }
+  const startHook = { hooks: [{ type: 'command', command: 'bash ~/.claude/squeez/hooks/session-start.sh' }] };
+  if (!settings.SessionStart.some(h => JSON.stringify(h).includes('squeez'))) {
+    settings.SessionStart.push(startHook); changed = true;
+  }
+
+  // PostToolUse
+  if (!Array.isArray(settings.PostToolUse)) { settings.PostToolUse = []; }
+  const postHook = { hooks: [{ type: 'command', command: 'bash ~/.claude/squeez/hooks/posttooluse.sh' }] };
+  if (!settings.PostToolUse.some(h => JSON.stringify(h).includes('squeez'))) {
+    settings.PostToolUse.push(postHook); changed = true;
+  }
+
+  // StatusLine
+  const squeezStatusCmd = 'bash ~/.claude/squeez/bin/statusline.sh';
+  const existingStatus = typeof settings.statusLine === 'object' ? settings.statusLine : {};
+  const existingCmd = existingStatus.command || '';
+  if (!existingCmd.includes('squeez')) {
+    settings.statusLine = existingCmd
+      ? { type: 'command', command: `bash -c 'input=$(cat); echo "$input" | { ${existingCmd}; } 2>/dev/null; echo "$input" | ${squeezStatusCmd}'` }
+      : { type: 'command', command: squeezStatusCmd };
+    changed = true;
+  }
+
+  if (changed) {
+    try {
+      fs.writeFileSync(settingsPath + '.tmp', JSON.stringify(settings, null, 2));
+      fs.renameSync(settingsPath + '.tmp', settingsPath);
+      log('Claude Code hooks registered.');
+    } catch (err) {
+      warn(`could not write settings.json: ${err.message}`);
+    }
+  }
+}
+
+main().catch(err => { warn(err.message); process.exit(0); });

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "squeez",
+  "version": "0.2.0",
+  "description": "Hook-based token compressor for Claude Code, Copilot CLI, and OpenCode. Compresses bash output up to 95%, collapses redundant calls, injects caveman persona.",
+  "keywords": [
+    "claude-code",
+    "token-optimizer",
+    "context-window",
+    "llm-tools",
+    "copilot-cli",
+    "compression"
+  ],
+  "homepage": "https://github.com/claudioemmanuel/squeez",
+  "bugs": {
+    "url": "https://github.com/claudioemmanuel/squeez/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/claudioemmanuel/squeez.git"
+  },
+  "license": "MIT",
+  "author": "claudioemmanuel",
+  "bin": {
+    "squeez": "bin.js"
+  },
+  "scripts": {
+    "postinstall": "node install.js"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ]
+}


### PR DESCRIPTION
## Summary

- **`npm/`** — new npm package enabling \`npm install -g squeez\` and \`npx squeez\`
  - \`bin.js\`: delegates all args to native binary; auto-installs if missing
  - \`install.js\`: postinstall downloads binary + registers Claude Code hooks (no curl fallback via Node https)
  - \`package.json\`: metadata, keywords, repo, license
- **\`release.yml\`** — two new publish jobs run after GitHub release:
  - \`publish-npm\`: syncs version from git tag → \`npm publish\`
  - \`publish-crates\`: \`cargo publish\` to crates.io

## Secrets required (add in repo Settings → Secrets)
- \`NPM_TOKEN\` — npm access token with publish permission
- \`CARGO_REGISTRY_TOKEN\` — crates.io API token

## Usage
\`\`\`bash
npm install -g squeez      # install + hooks
npx squeez wrap 'git log'  # one-shot, no global install needed
npx squeez update          # self-update
cargo install squeez       # Rust users
\`\`\`

Closes #20