### PR TITLE
feat(setup): auto-detect language from CLAUDE.md/locale + stderr update notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ This project uses [Semantic Versioning](https://semver.org/).
 - `install_atomic` now returns `Ok(bool)` distinguishing immediate vs deferred installs; success message no longer appears when install was only staged
 
 ### Added
-- `session-start.sh`: rate-limited update check (once per day) — injects `[squeez] Update available` notification into Claude session context when a new version is detected
+- `session-start.sh`: rate-limited daily update check — prints `[squeez] Update available` to stderr (visible in terminal) when a new version is detected
+- `squeez setup`: auto-detects user language from `~/.claude/CLAUDE.md` and system locale (`LANG`/`LC_ALL`) and writes correct `lang =` into `config.ini` on first install
 
 ## [0.3.0] - 2026-04-14
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -19,6 +19,6 @@ if [ "$_diff" -gt 86400 ]; then
     echo "$_now" > "$_uc_ts" 2>/dev/null || true
     _uc_out=$("$SQUEEZ" update --check 2>/dev/null || true)
     if echo "$_uc_out" | grep -q "→"; then
-        printf "\n[squeez] Update available: %s\nRun: squeez update\n" "$_uc_out"
+        printf "\n[squeez] Update available: %s\nRun: squeez update\n" "$_uc_out" >&2
     fi
 fi

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -106,6 +106,36 @@ os.replace(tmp, path)
 print("settings.json updated.")
 "#;
 
+/// Detect the user's preferred language by inspecting ~/.claude/CLAUDE.md
+/// and system locale env vars. Returns a squeez lang code (e.g. "pt-BR", "en").
+fn detect_lang(home: &str) -> &'static str {
+    // 1. ~/.claude/CLAUDE.md — most reliable signal for Claude Code users
+    let claude_md = format!("{}/.claude/CLAUDE.md", home);
+    if let Ok(content) = std::fs::read_to_string(&claude_md) {
+        let lower = content.to_lowercase();
+        if lower.contains("pt-br") || lower.contains("pt_br")
+            || lower.contains("português") || lower.contains("portugues")
+        {
+            return "pt-BR";
+        }
+    }
+
+    // 2. System locale env vars
+    for var in &["LANG", "LC_ALL", "LANGUAGE"] {
+        if let Ok(val) = std::env::var(var) {
+            let lower = val.to_lowercase();
+            if lower.starts_with("pt_br") || lower.starts_with("pt-br") {
+                return "pt-BR";
+            }
+            if lower.starts_with("pt") {
+                return "pt-BR"; // treat any pt locale as pt-BR (only variant with assets)
+            }
+        }
+    }
+
+    "en"
+}
+
 pub fn run(args: &[String]) -> i32 {
     let force = args.iter().any(|a| a == "--force" || a == "-f");
 
@@ -124,7 +154,11 @@ pub fn run(args: &[String]) -> i32 {
     // 2. Write default config.ini if not present (never overwrite user customizations)
     let config_path = format!("{}/config.ini", install_dir);
     if !std::path::Path::new(&config_path).exists() {
-        let content = DEFAULT_CONFIG_INI;
+        let lang = detect_lang(&home);
+        let content = DEFAULT_CONFIG_INI.replace("lang = en", &format!("lang = {}", lang));
+        if lang != "en" {
+            println!("squeez setup: detected language → {}", lang);
+        }
         if let Err(e) = std::fs::write(&config_path, content) {
             eprintln!("squeez setup: warning: could not write config.ini: {}", e);
         } else {


### PR DESCRIPTION
Closes #28

## Summary

- `squeez setup` now detects the user's language automatically during first install:
  1. Reads `~/.claude/CLAUDE.md` for `pt-BR`, `português` keywords
  2. Falls back to `LANG`/`LC_ALL`/`LANGUAGE` env vars
  3. Writes correct `lang =` to `config.ini` (previously always `en`)
- `session-start.sh` update notification now outputs to **stderr** so it is visible in the terminal when Claude Code starts (was stdout/context only, invisible to user)

## Test plan

- [x] `cargo build` passes
- [x] All tests pass (0 failures)
- [x] User with `pt-BR` in CLAUDE.md gets `lang = pt-BR` on `squeez setup`
- [x] User with `LANG=pt_BR.UTF-8` and no CLAUDE.md also gets `lang = pt-BR`
- [x] User with no Portuguese signals gets `lang = en` (unchanged default)
- [x] Update notification appears in terminal (stderr) on session start