### PR TITLE
Add handlers for Cloudflare, Drizzle, Next.js, and Playwright

### DIFF
--- a/src/commands/cloudflare.rs
+++ b/src/commands/cloudflare.rs
@@ -1,0 +1,52 @@
+use crate::commands::Handler;
+use crate::config::Config;
+use crate::strategies::{dedup, smart_filter, truncation};
+
+pub struct CloudflareHandler;
+
+impl Handler for CloudflareHandler {
+    fn compress(&self, _cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
+        let lines = smart_filter::apply(lines);
+        let filtered: Vec<String> = lines
+            .into_iter()
+            .filter(|l| {
+                let t = l.trim();
+                if t.is_empty() {
+                    return false;
+                }
+                // Drop wrangler version banner and decorative separators
+                if t.starts_with("⛅") || t.starts_with('\u{26c5}') {
+                    return false;
+                }
+                if t.chars().all(|c| c == '─' || c == '-' || c == '=' || c == ' ') {
+                    return false;
+                }
+                // Drop boilerplate preamble lines
+                if t.starts_with("Retrieving cached") {
+                    return false;
+                }
+                if t.starts_with("Your worker has access to the following bindings") {
+                    return false;
+                }
+                // Drop individual binding detail lines (indented with "- " under bindings)
+                if t.starts_with("- KV:")
+                    || t.starts_with("- D1:")
+                    || t.starts_with("- R2:")
+                    || t.starts_with("- DO:")
+                    || t.starts_with("- AI:")
+                    || t.starts_with("- Queue:")
+                    || t.starts_with("- Vectorize:")
+                {
+                    return false;
+                }
+                // Drop update-available notices
+                if t.contains("update available") || t.contains("npm install wrangler") {
+                    return false;
+                }
+                true
+            })
+            .collect();
+        let filtered = dedup::apply(filtered, config.dedup_min);
+        truncation::apply(filtered, 60, truncation::Keep::Tail)
+    }
+}

--- a/src/commands/drizzle.rs
+++ b/src/commands/drizzle.rs
@@ -1,0 +1,47 @@
+use crate::commands::Handler;
+use crate::config::Config;
+use crate::strategies::{dedup, smart_filter, truncation};
+
+pub struct DrizzleHandler;
+
+impl Handler for DrizzleHandler {
+    fn compress(&self, _cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
+        let lines = smart_filter::apply(lines);
+
+        let filtered: Vec<String> = lines
+            .into_iter()
+            .filter(|l| {
+                let t = l.trim();
+                if t.is_empty() {
+                    return false;
+                }
+                // Drop drizzle-kit version/banner line
+                if t.starts_with("drizzle-kit:") && t.contains("v") && !t.contains("Error") {
+                    return false;
+                }
+                // Drop config-reading boilerplate
+                if t.starts_with("Reading config file") {
+                    return false;
+                }
+                if t.starts_with("No config path provided") {
+                    return false;
+                }
+                // Drop driver/dialect boilerplate
+                if t.starts_with("Using '") && t.contains("driver") {
+                    return false;
+                }
+                if t.starts_with("dialect is") {
+                    return false;
+                }
+                // Drop "database credentials from ..." line
+                if t.starts_with("database credentials from") {
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        let filtered = dedup::apply(filtered, config.dedup_min);
+        truncation::apply(filtered, 80, truncation::Keep::Tail)
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,10 +6,12 @@ pub trait Handler {
 
 pub mod build;
 pub mod cloud;
+pub mod cloudflare;
 pub mod compress_md;
 pub mod data_tool;
 pub mod database;
 pub mod docker;
+pub mod drizzle;
 pub mod filter_stdin;
 pub mod fs;
 pub mod generic;
@@ -17,8 +19,10 @@ pub mod git;
 pub mod init;
 pub mod mcp_server;
 pub mod network;
+pub mod nextjs;
 pub mod persona;
 pub mod package_mgr;
+pub mod playwright;
 pub mod protocol;
 pub mod runtime;
 pub mod test_runner;

--- a/src/commands/nextjs.rs
+++ b/src/commands/nextjs.rs
@@ -1,0 +1,51 @@
+use crate::commands::Handler;
+use crate::config::Config;
+use crate::strategies::{dedup, smart_filter, truncation};
+
+pub struct NextjsHandler;
+
+impl Handler for NextjsHandler {
+    fn compress(&self, cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
+        let lines = smart_filter::apply(lines);
+
+        let is_build = cmd.contains("build");
+
+        let filtered: Vec<String> = lines
+            .into_iter()
+            .filter(|l| {
+                let t = l.trim();
+                if t.is_empty() {
+                    return false;
+                }
+                // Drop the Next.js version banner line (▲ Next.js X.Y.Z)
+                if t.starts_with('▲') && t.contains("Next.js") && !t.contains("Error") {
+                    return false;
+                }
+                // Drop routine compilation progress lines when not a build
+                if !is_build && t.starts_with("○ Compiling") {
+                    return false;
+                }
+                // Drop verbose module counts from compiled lines
+                // e.g. "✓ Compiled / in 234ms (500 modules)" → keep
+                // "  - Environments: .env" → drop boilerplate
+                if t.starts_with("- Environments:") {
+                    return false;
+                }
+                // Drop "- Network: ..." dev-server info (redundant with Local)
+                if t.starts_with("- Network:") {
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        let filtered = dedup::apply(filtered, config.dedup_min);
+
+        // For builds prefer tail (errors appear at end); for dev keep head (URL first)
+        if is_build {
+            truncation::apply(filtered, 80, truncation::Keep::Tail)
+        } else {
+            truncation::apply(filtered, 60, truncation::Keep::Head)
+        }
+    }
+}

--- a/src/commands/playwright.rs
+++ b/src/commands/playwright.rs
@@ -1,0 +1,41 @@
+use crate::commands::Handler;
+use crate::config::Config;
+use crate::strategies::{dedup, smart_filter, truncation};
+
+pub struct PlaywrightHandler;
+
+impl Handler for PlaywrightHandler {
+    fn compress(&self, _cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
+        let lines = smart_filter::apply(lines);
+
+        let filtered: Vec<String> = lines
+            .into_iter()
+            .filter(|l| {
+                let t = l.trim();
+                // Drop passing test lines — keep failures, errors, and summaries
+                let is_passing = (t.starts_with('✓') || t.starts_with('·'))
+                    && !t.contains("fail")
+                    && !t.contains("Error");
+                if is_passing {
+                    return false;
+                }
+                // Drop browser launch / teardown noise
+                if t.starts_with("[chromium]") || t.starts_with("[firefox]") || t.starts_with("[webkit]") {
+                    // Keep only failure lines (contain ✗ or "fail")
+                    if !t.contains('✗') && !t.contains("fail") && !t.contains("Error") {
+                        return false;
+                    }
+                }
+                // Drop screenshot/video attachment lines for passing tests
+                if t.contains("screenshot") && !t.contains("fail") && !t.contains("Error") {
+                    return false;
+                }
+                true
+            })
+            .collect();
+
+        let filtered = dedup::apply(filtered, config.dedup_min);
+        // Tail: errors and summary appear at the end of playwright output
+        truncation::apply(filtered, 100, truncation::Keep::Tail)
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,10 +1,11 @@
 use crate::commands::Handler;
 use crate::commands::{
-    build::BuildHandler, cloud::CloudHandler, data_tool::DataToolHandler,
-    database::DatabaseHandler, docker::DockerHandler, fs::FsHandler, generic::GenericHandler,
-    git::GitHandler, network::NetworkHandler, package_mgr::PackageMgrHandler,
-    runtime::RuntimeHandler, test_runner::TestRunnerHandler, text_proc::TextProcHandler,
-    typescript::TypescriptHandler,
+    build::BuildHandler, cloud::CloudHandler, cloudflare::CloudflareHandler,
+    data_tool::DataToolHandler, database::DatabaseHandler, docker::DockerHandler,
+    drizzle::DrizzleHandler, fs::FsHandler, generic::GenericHandler, git::GitHandler,
+    network::NetworkHandler, nextjs::NextjsHandler, package_mgr::PackageMgrHandler,
+    playwright::PlaywrightHandler, runtime::RuntimeHandler, test_runner::TestRunnerHandler,
+    text_proc::TextProcHandler, typescript::TypescriptHandler,
 };
 use crate::config::Config;
 
@@ -18,7 +19,14 @@ fn detect(cmd: &str) -> Box<dyn Handler> {
     match name.as_str() {
         "git" => Box::new(GitHandler),
         "docker" | "docker-compose" | "podman" => Box::new(DockerHandler),
-        "npm" | "pnpm" | "bun" | "yarn" => Box::new(PackageMgrHandler),
+        "npm" | "pnpm" | "yarn" => Box::new(PackageMgrHandler),
+        "bun" => {
+            if cmd.split_whitespace().any(|a| a == "test") {
+                Box::new(TestRunnerHandler)
+            } else {
+                Box::new(PackageMgrHandler)
+            }
+        }
         "cargo" => {
             if cmd.split_whitespace().any(|a| a == "test") {
                 Box::new(TestRunnerHandler)
@@ -27,15 +35,25 @@ fn detect(cmd: &str) -> Box<dyn Handler> {
             }
         }
         "jest" | "vitest" | "pytest" | "py.test" | "nextest" => Box::new(TestRunnerHandler),
+        "playwright" => Box::new(PlaywrightHandler),
         "tsc" | "eslint" | "biome" => Box::new(TypescriptHandler),
         "make" | "cmake" | "gradle" | "mvn" | "xcodebuild" => Box::new(BuildHandler),
-        "vite" | "next" | "turbo" => {
+        "vite" | "turbo" => {
             if cmd.contains("build") {
                 Box::new(BuildHandler)
             } else {
                 Box::new(GenericHandler)
             }
         }
+        "next" => {
+            if cmd.contains("build") {
+                Box::new(BuildHandler)
+            } else {
+                Box::new(NextjsHandler)
+            }
+        }
+        "wrangler" => Box::new(CloudflareHandler),
+        "drizzle-kit" => Box::new(DrizzleHandler),
         "kubectl" | "gh" | "aws" | "gcloud" | "az" => Box::new(CloudHandler),
         "psql" | "prisma" | "mysql" => Box::new(DatabaseHandler),
         "curl" | "wget" | "http" => Box::new(NetworkHandler),

--- a/tests/test_bun_test_dispatch.rs
+++ b/tests/test_bun_test_dispatch.rs
@@ -1,0 +1,31 @@
+use squeez::filter;
+use squeez::config::Config;
+
+#[test]
+fn bun_test_routes_to_test_runner_keeps_failures() {
+    let mut lines: Vec<String> = (0..30)
+        .map(|i| format!("✓ utils > helper_{} (1ms)", i))
+        .collect();
+    lines.push("✗ auth > login [0.12ms]".to_string());
+    lines.push("  error: expect(received).toBe(expected)".to_string());
+    lines.push(" 31 tests 1 fail 30 pass".to_string());
+
+    let result = filter::compress("bun test", lines, &Config::default());
+    // Failures and summary must be present
+    assert!(result.iter().any(|l| l.contains('✗') || l.contains("fail")));
+    assert!(result.iter().any(|l| l.contains("31 tests") || l.contains("1 fail")));
+    // Passing tests should be suppressed (output much shorter than 30 lines)
+    assert!(result.len() < 10);
+}
+
+#[test]
+fn bun_install_routes_to_package_mgr() {
+    let lines = vec![
+        "bun install v1.1.0".to_string(),
+        "Resolving dependencies".to_string(),
+        "✓ 120 packages installed [1.23s]".to_string(),
+    ];
+    // Package manager handler: smart_filter + dedup + truncation — just verify no panic
+    let result = filter::compress("bun install", lines, &Config::default());
+    assert!(!result.is_empty());
+}

--- a/tests/test_cloudflare.rs
+++ b/tests/test_cloudflare.rs
@@ -1,0 +1,46 @@
+use squeez::commands::{cloudflare::CloudflareHandler, Handler};
+use squeez::config::Config;
+
+#[test]
+fn drops_banner_and_separators() {
+    let lines = vec![
+        "⛅️ wrangler 3.78.0".to_string(),
+        "──────────────────────────────────────────".to_string(),
+        "Retrieving cached values for the dev session...".to_string(),
+        "[mf:inf] Ready on http://127.0.0.1:8787".to_string(),
+    ];
+    let result = CloudflareHandler.compress("wrangler dev", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("Ready")));
+    assert!(!result.iter().any(|l| l.contains("wrangler 3")));
+    assert!(!result.iter().any(|l| l.contains("Retrieving cached")));
+}
+
+#[test]
+fn drops_binding_details() {
+    let lines = vec![
+        "Your worker has access to the following bindings:".to_string(),
+        "- KV: MY_KV (abc123)".to_string(),
+        "- D1: MY_DB (def456)".to_string(),
+        "Total Upload: 68 KiB / gzip: 18.9 KiB".to_string(),
+        "Deployed my-worker triggers (1.23 sec)".to_string(),
+        "  https://my-worker.example.workers.dev".to_string(),
+    ];
+    let result = CloudflareHandler.compress("wrangler deploy", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.contains("Your worker has access")));
+    assert!(!result.iter().any(|l| l.contains("- KV:")));
+    assert!(result.iter().any(|l| l.contains("Deployed")));
+    assert!(result.iter().any(|l| l.contains("workers.dev")));
+}
+
+#[test]
+fn drops_update_notice() {
+    let lines = vec![
+        "⛅️ wrangler 3.78.0 (update available 3.79.0)".to_string(),
+        "npm install wrangler@latest".to_string(),
+        "[mf:inf] Ready on http://127.0.0.1:8787".to_string(),
+    ];
+    let result = CloudflareHandler.compress("wrangler dev", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.contains("update available")));
+    assert!(!result.iter().any(|l| l.contains("npm install wrangler")));
+    assert!(result.iter().any(|l| l.contains("Ready")));
+}

--- a/tests/test_drizzle.rs
+++ b/tests/test_drizzle.rs
@@ -1,0 +1,49 @@
+use squeez::commands::{drizzle::DrizzleHandler, Handler};
+use squeez::config::Config;
+
+#[test]
+fn drops_boilerplate_keeps_migration_info() {
+    let lines = vec![
+        "drizzle-kit: v0.21.4".to_string(),
+        "database credentials from drizzle.config.ts".to_string(),
+        "Reading config file '/home/user/project/drizzle.config.ts'".to_string(),
+        "Using 'pg' driver for database querying".to_string(),
+        "dialect is 'postgresql'".to_string(),
+        "[✓] Your schema has 2 changes".to_string(),
+        "  - Added table 'users'".to_string(),
+        "  - Added column 'email' to 'accounts'".to_string(),
+        "[✓] 0001_init.sql generated".to_string(),
+    ];
+    let result = DrizzleHandler.compress("drizzle-kit generate", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.contains("drizzle-kit: v")));
+    assert!(!result.iter().any(|l| l.contains("database credentials from")));
+    assert!(!result.iter().any(|l| l.contains("Reading config file")));
+    assert!(!result.iter().any(|l| l.contains("Using 'pg' driver")));
+    assert!(!result.iter().any(|l| l.contains("dialect is")));
+    assert!(result.iter().any(|l| l.contains("0001_init.sql")));
+    assert!(result.iter().any(|l| l.contains("users")));
+}
+
+#[test]
+fn keeps_error_output() {
+    let lines = vec![
+        "drizzle-kit: v0.21.4".to_string(),
+        "Reading config file '/home/user/project/drizzle.config.ts'".to_string(),
+        "Error: Cannot connect to database: connection refused".to_string(),
+        "  at connect (drizzle-kit/src/index.ts:42:5)".to_string(),
+    ];
+    let result = DrizzleHandler.compress("drizzle-kit push", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("Error:")));
+    assert!(result.iter().any(|l| l.contains("connection refused")));
+}
+
+#[test]
+fn keeps_no_changes_message() {
+    let lines = vec![
+        "drizzle-kit: v0.21.4".to_string(),
+        "dialect is 'postgresql'".to_string(),
+        "[✓] Your schema has no changes, nothing to generate!".to_string(),
+    ];
+    let result = DrizzleHandler.compress("drizzle-kit generate", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("no changes")));
+}

--- a/tests/test_nextjs.rs
+++ b/tests/test_nextjs.rs
@@ -1,0 +1,44 @@
+use squeez::commands::{nextjs::NextjsHandler, Handler};
+use squeez::config::Config;
+
+#[test]
+fn drops_version_banner_keeps_ready() {
+    let lines = vec![
+        "  ▲ Next.js 14.2.5".to_string(),
+        "  - Local:        http://localhost:3000".to_string(),
+        "  - Environments: .env".to_string(),
+        "  - Network:      http://192.168.1.5:3000".to_string(),
+        " ✓ Ready in 2.3s".to_string(),
+    ];
+    let result = NextjsHandler.compress("next dev", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.contains("Next.js 14")));
+    assert!(!result.iter().any(|l| l.contains("Environments:")));
+    assert!(!result.iter().any(|l| l.contains("Network:")));
+    assert!(result.iter().any(|l| l.contains("localhost:3000")));
+    assert!(result.iter().any(|l| l.contains("Ready")));
+}
+
+#[test]
+fn drops_compiling_lines_in_dev_mode() {
+    let lines = vec![
+        " ✓ Ready in 2.3s".to_string(),
+        "○ Compiling /api/users ...".to_string(),
+        "○ Compiling /dashboard ...".to_string(),
+        " ✓ Compiled /api/users in 234ms (120 modules)".to_string(),
+        "GET /api/users 200 in 241ms".to_string(),
+    ];
+    let result = NextjsHandler.compress("next dev", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.starts_with("○ Compiling")));
+    assert!(result.iter().any(|l| l.contains("GET /api/users")));
+}
+
+#[test]
+fn build_mode_keeps_tail() {
+    let mut lines: Vec<String> = (0..60)
+        .map(|i| format!("verbose build step {}", i))
+        .collect();
+    lines.push("✓ Compiled successfully".to_string());
+    lines.push("Route (app)                              Size".to_string());
+    let result = NextjsHandler.compress("next build", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("Compiled successfully")));
+}

--- a/tests/test_playwright.rs
+++ b/tests/test_playwright.rs
@@ -1,0 +1,47 @@
+use squeez::commands::{playwright::PlaywrightHandler, Handler};
+use squeez::config::Config;
+
+#[test]
+fn drops_passing_keeps_failures_and_summary() {
+    let lines = vec![
+        "Running 3 tests using 3 workers".to_string(),
+        "  ✓  1 [chromium] › tests/login.spec.ts:5:5 › should login (234ms)".to_string(),
+        "  ✓  2 [firefox] › tests/login.spec.ts:5:5 › should login (312ms)".to_string(),
+        "  ✗  3 [webkit] › tests/auth.spec.ts:20:5 › should redirect (567ms)".to_string(),
+        "    Error: expect(received).toBe(expected)".to_string(),
+        "    Expected: 302, Received: 200".to_string(),
+        "  3 tests ran".to_string(),
+        "    1 failed".to_string(),
+        "    2 passed (2.3s)".to_string(),
+    ];
+    let result = PlaywrightHandler.compress("playwright test", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains('✗') || l.contains("fail")));
+    assert!(result.iter().any(|l| l.contains("Error")));
+    assert!(result.iter().any(|l| l.contains("3 tests ran") || l.contains("failed")));
+    // Passing test lines should be gone
+    assert!(!result.iter().any(|l| l.contains("should login") && l.contains('✓')));
+}
+
+#[test]
+fn all_passing_keeps_summary() {
+    let lines = vec![
+        "  ✓  1 [chromium] › tests/home.spec.ts:3:1 › loads homepage (100ms)".to_string(),
+        "  ✓  2 [chromium] › tests/home.spec.ts:8:1 › has title (80ms)".to_string(),
+        "  2 passed (1.2s)".to_string(),
+    ];
+    let result = PlaywrightHandler.compress("playwright test", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("passed")));
+    // Individual passing test lines should be filtered out
+    assert!(!result.iter().any(|l| l.contains('✓') && l.contains("homepage")));
+}
+
+#[test]
+fn drops_screenshot_lines_for_passing() {
+    let lines = vec![
+        "  ✓  1 [chromium] › tests/home.spec.ts:3:1 › ok (100ms)".to_string(),
+        "    screenshot: tests/home-chromium/screenshot.png".to_string(),
+        "  2 passed (1.2s)".to_string(),
+    ];
+    let result = PlaywrightHandler.compress("playwright test", lines, &Config::default());
+    assert!(!result.iter().any(|l| l.contains("screenshot") && l.contains(".png")));
+}


### PR DESCRIPTION
## Linked issue

Closes #<!-- REQUIRED: link to an open issue. PRs without a linked issue will not be merged. -->

## Summary

- Add four new command handlers: `CloudflareHandler` (wrangler), `DrizzleHandler` (drizzle-kit), `NextjsHandler` (next), and `PlaywrightHandler` (playwright)
- Each handler implements tool-specific filtering to remove boilerplate, banners, and verbose output while preserving actionable information
- Update command detection logic to route these tools to their specialized handlers
- Add comprehensive unit tests for each new handler covering common output scenarios

## Details

**Cloudflare (wrangler):** Drops version banners, decorative separators, binding details, and update notices while preserving deployment URLs and status messages.

**Drizzle:** Filters out version info, config-reading boilerplate, and driver/dialect details while keeping migration summaries and error messages.

**Next.js:** Removes version banners and environment/network boilerplate. In dev mode, drops compilation progress lines; in build mode, keeps tail output for error visibility.

**Playwright:** Suppresses passing test lines and screenshot attachments while preserving failures, errors, and test summaries.

Also improves `bun test` routing to use `TestRunnerHandler` instead of generic package manager handling.

## Test plan

- [x] Added unit tests for all four new handlers covering typical output scenarios
- [x] Added integration test for `bun test` dispatch logic
- [x] `cargo test` passes with new test suite

## Checklist

- [ ] Issue is linked above
- [ ] CI is green
- [ ] No `Co-Authored-By:` trailers in commit messages

https://claude.ai/code/session_01CKP4og2eiWtPE3JHETbC7B