### PR TITLE
fix(ci): startsWith guard for auto-release recursion

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -10,14 +10,13 @@ permissions:
 jobs:
   tag-and-release:
     # Recursion guards:
-    # 1. `[squeez-release-bot]` is a distinctive marker the bot puts on its own
-    #    bump commits. We use a namespaced token instead of the generic
-    #    `[skip release]` because the latter shows up in prose inside commit
-    #    bodies (e.g. when documenting release automation) and would falsely
-    #    skip real releases.
+    # 1. Subject-prefix match: the bot's own bump commits always begin with
+    #    "chore(release): bump version to". Using startsWith here (not
+    #    contains) means prose in PR bodies that mentions the phrase cannot
+    #    trip the guard — only the actual commit subject can.
     # 2. Fallback: match by the bot's author email.
     if: |
-      !contains(github.event.head_commit.message, '[squeez-release-bot]') &&
+      !startsWith(github.event.head_commit.message, 'chore(release): bump version to') &&
       github.event.head_commit.author.email != 'github-actions[bot]@users.noreply.github.com'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Linked issue

Closes #45

## Type of change

- [x] `fix:` / `perf:` — bug fix or perf improvement (→ patch bump)

## Area

- [x] CI / release / tooling

## Summary

The previous recursion guard used substring `contains(...)` against the full commit message, so any PR body that mentioned the marker token matched and falsely skipped the workflow — the exact failure mode observed after #44 merged.

Switch to `startsWith(...)` against the bot's canonical subject prefix. The bot's commits always begin with that exact text; PR-body prose cannot reproduce a subject-prefix match, so the guard activates only on real bot commits.

Kept the author-email check as belt-and-suspenders.

## Test plan

- [x] YAML validates
- [x] Manual trace: subject `fix(ci): ...` with the old marker token in the PR body → prefix does NOT match the bot's subject → run ✓
- [ ] First real trigger on this merge — confirms bump + tag push end-to-end

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (workflow-only change)