### PR TITLE
feat(hosts): full-parity OpenCode adapter + plugin rewrite

### DIFF
--- a/opencode-plugin/squeez.js
+++ b/opencode-plugin/squeez.js
@@ -1,16 +1,112 @@
-const SQUEEZ_BIN = `${process.env.HOME}/.claude/squeez/bin/squeez`;
+// squeez OpenCode plugin — full-parity integration.
+//
+// Capabilities:
+//   - session.created → finalize previous session and refresh AGENTS.md via
+//     `squeez init --host=opencode`.
+//   - tool.execute.before (bash) → rewrite command to `squeez wrap <cmd>`.
+//   - tool.execute.before (read/grep) → inject budget limits so Read and
+//     Grep respect the squeez config.
+//   - tool.execute.after (any) → fire-and-forget `squeez track-result` for
+//     post-execution context tracking.
+//
+// Caveat (upstream sst/opencode#2319): MCP tool calls do NOT trigger these
+// hooks. That's a host limitation, not something this plugin can work around.
 
-export const SqueezPlugin = async () => {
-  return {
-    "tool.execute.before": async (input, output) => {
-      if (input.tool === "bash") {
-        const command = output.args?.command;
-        if (!command || typeof command !== "string") return;
-        if (command.startsWith(SQUEEZ_BIN)) return;
-        if (command.includes("squeez wrap")) return;
-        if (command.startsWith("--no-squeez")) return;
-        output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+import { execSync, spawn } from "child_process";
+
+const HOME = process.env.HOME || process.env.USERPROFILE || "";
+const SQUEEZ_BIN = `${HOME}/.claude/squeez/bin/squeez`;
+
+// Map OpenCode's lowercase tool names to the capitalized slugs the squeez
+// budget-params subcommand expects (Read / Grep).
+const BUDGET_TOOL_SLUG = {
+  read: "Read",
+  grep: "Grep",
+};
+
+function squeezExists() {
+  try {
+    execSync(`test -x "${SQUEEZ_BIN}"`, { timeout: 500 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runInit() {
+  try {
+    execSync(`"${SQUEEZ_BIN}" init --host=opencode`, { timeout: 5000 });
+  } catch {
+    // best-effort — don't break the session if squeez init fails
+  }
+}
+
+function budgetPatch(tool) {
+  const slug = BUDGET_TOOL_SLUG[tool];
+  if (!slug) return null;
+  try {
+    const out = execSync(`"${SQUEEZ_BIN}" budget-params ${slug}`, {
+      timeout: 2000,
+      encoding: "utf8",
+    }).trim();
+    if (!out) return null;
+    return JSON.parse(out);
+  } catch {
+    return null;
+  }
+}
+
+function trackResult(tool) {
+  // Fire-and-forget — don't block the tool pipeline.
+  try {
+    spawn(SQUEEZ_BIN, ["track-result", tool], {
+      stdio: "ignore",
+      detached: true,
+    }).unref();
+  } catch {
+    // best-effort
+  }
+}
+
+export const SqueezPlugin = async (ctx) => {
+  if (!squeezExists()) {
+    // squeez not installed locally — plugin becomes a no-op rather than
+    // throwing on every hook.
+    return;
+  }
+
+  ctx.hook?.("session.created", async () => {
+    runInit();
+  });
+
+  ctx.hook?.("tool.execute.before", async (input, output) => {
+    if (!input || !output || !output.args) return;
+
+    if (input.tool === "bash") {
+      const command = output.args.command;
+      if (!command || typeof command !== "string") return;
+      if (command.startsWith(SQUEEZ_BIN)) return;
+      if (command.includes("squeez wrap")) return;
+      if (command.startsWith("--no-squeez")) return;
+      output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+      return;
+    }
+
+    const patch = budgetPatch(input.tool);
+    if (!patch) return;
+    for (const [k, v] of Object.entries(patch)) {
+      // Do not override fields the user (or agent) already set explicitly.
+      if (output.args[k] === undefined) {
+        output.args[k] = v;
       }
-    },
-  };
+    }
+  });
+
+  ctx.hook?.("tool.execute.after", async (input) => {
+    if (!input || !input.tool) return;
+    // Only track tools we know about — keeps the noise down.
+    if (["bash", "read", "grep", "glob"].includes(input.tool)) {
+      trackResult(input.tool);
+    }
+  });
 };

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -66,6 +66,39 @@ fn load_config_from(base: &str) -> Config {
         .unwrap_or_default()
 }
 
+/// Generic entry point for any `HostAdapter`. Resolves the adapter by slug,
+/// prepares its data directory (sessions/memory), runs the shared session
+/// finalize + banner flow, then delegates host-specific memory injection to
+/// the adapter.
+///
+/// Backs `squeez init --host=<name>` in `main.rs`.
+pub fn run_for_host(host_name: &str) -> i32 {
+    let adapter = match crate::hosts::find(host_name) {
+        Some(a) => a,
+        None => {
+            eprintln!("squeez init: unknown host '{}'", host_name);
+            return 1;
+        }
+    };
+    let data_dir = adapter.data_dir();
+    let sessions = data_dir.join("sessions");
+    let mem = data_dir.join("memory");
+    let _ = std::fs::create_dir_all(&sessions);
+    let _ = std::fs::create_dir_all(&mem);
+    let cfg = load_config_from(&data_dir.to_string_lossy());
+
+    let code = run_with_dirs(&sessions, &mem, &cfg);
+
+    let summaries = memory::read_last_n(&mem, 3);
+    let _ = adapter.inject_memory(&cfg, &summaries);
+
+    if cfg.auto_compress_md {
+        let _ = compress_md::run_all_quietly();
+    }
+
+    code
+}
+
 /// Testable version with explicit directories.
 pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) -> i32 {
     // 1. Finalise previous session → memory (best-effort)

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -12,8 +12,10 @@
 
 pub mod claude_code;
 pub mod copilot;
+pub mod opencode;
 pub use claude_code::ClaudeCodeAdapter;
 pub use copilot::CopilotCliAdapter;
+pub use opencode::OpenCodeAdapter;
 
 use std::path::{Path, PathBuf};
 
@@ -97,36 +99,7 @@ pub fn find(slug: &str) -> Option<Box<dyn HostAdapter>> {
     all_hosts().into_iter().find(|h| h.name() == slug)
 }
 
-// ── Stub implementations (US-004 .. US-006 fill these in) ──────────────────
-
-pub struct OpenCodeAdapter;
-impl HostAdapter for OpenCodeAdapter {
-    fn name(&self) -> &'static str {
-        "opencode"
-    }
-    fn is_installed(&self) -> bool {
-        let xdg = std::env::var("XDG_CONFIG_HOME")
-            .unwrap_or_else(|_| format!("{}/.config", home_dir()));
-        Path::new(&format!("{}/opencode", xdg)).exists()
-    }
-    fn data_dir(&self) -> PathBuf {
-        let xdg = std::env::var("XDG_CONFIG_HOME")
-            .unwrap_or_else(|_| format!("{}/.config", home_dir()));
-        PathBuf::from(format!("{}/opencode/squeez", xdg))
-    }
-    fn capabilities(&self) -> HostCaps {
-        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_HARD
-    }
-    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn uninstall(&self) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn inject_memory(&self, _cfg: &Config, _summaries: &[Summary]) -> std::io::Result<()> {
-        Ok(())
-    }
-}
+// ── Stub implementations (US-005 .. US-006 fill these in) ──────────────────
 
 pub struct GeminiCliAdapter;
 impl HostAdapter for GeminiCliAdapter {

--- a/src/hosts/opencode.rs
+++ b/src/hosts/opencode.rs
@@ -1,0 +1,157 @@
+//! OpenCode adapter: drops squeez's ESM plugin into `~/.config/opencode/plugins/`
+//! and seeds `~/.config/opencode/AGENTS.md` with the squeez memory block.
+//!
+//! Research on OpenCode hook surface (2026-04-18):
+//!   - `tool.execute.before` can mutate `output.args` for ANY tool (bash,
+//!     read, grep, glob) — enough for BASH_WRAP + BUDGET_HARD.
+//!   - `session.created` fires once per session — the plugin shells out to
+//!     `squeez init --host=opencode` to finalize the previous session and
+//!     refresh AGENTS.md before OpenCode builds its first prompt.
+//!   - OpenCode auto-loads `~/.config/opencode/AGENTS.md` at session start,
+//!     which is the channel we use for SESSION_MEM.
+//!
+//! See docs/superpowers/specs/2026-04-18-cli-host-coverage-design.md.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::persona;
+use crate::config::Config;
+use crate::memory::Summary;
+use crate::session::home_dir;
+
+use super::{HostAdapter, HostCaps};
+
+const PLUGIN_FILENAME: &str = "squeez.js";
+
+/// The ESM plugin bundled by squeez (source of truth lives in
+/// `opencode-plugin/squeez.js`). When `install()` runs it copies the file
+/// from the on-disk source location or, if that's not accessible (e.g. the
+/// binary is distributed via npm/curl without the repo), falls back to this
+/// embedded copy.
+const PLUGIN_SOURCE: &str = include_str!("../../opencode-plugin/squeez.js");
+
+pub struct OpenCodeAdapter;
+
+impl OpenCodeAdapter {
+    fn opencode_config_dir() -> PathBuf {
+        let xdg = std::env::var("XDG_CONFIG_HOME")
+            .unwrap_or_else(|_| format!("{}/.config", home_dir()));
+        PathBuf::from(xdg).join("opencode")
+    }
+
+    fn plugin_path() -> PathBuf {
+        Self::opencode_config_dir().join("plugins").join(PLUGIN_FILENAME)
+    }
+
+    fn agents_md_path() -> PathBuf {
+        Self::opencode_config_dir().join("AGENTS.md")
+    }
+}
+
+impl HostAdapter for OpenCodeAdapter {
+    fn name(&self) -> &'static str {
+        "opencode"
+    }
+
+    fn is_installed(&self) -> bool {
+        Self::opencode_config_dir().exists()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        Self::opencode_config_dir().join("squeez")
+    }
+
+    fn capabilities(&self) -> HostCaps {
+        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_HARD
+    }
+
+    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
+        let plugins_dir = Self::opencode_config_dir().join("plugins");
+        std::fs::create_dir_all(&plugins_dir)?;
+        std::fs::write(Self::plugin_path(), PLUGIN_SOURCE)?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> std::io::Result<()> {
+        let plugin = Self::plugin_path();
+        if plugin.exists() {
+            std::fs::remove_file(&plugin)?;
+        }
+        // Strip the squeez block from AGENTS.md (leave the rest of the file intact).
+        let agents = Self::agents_md_path();
+        if agents.exists() {
+            let existing = std::fs::read_to_string(&agents).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            let _ = std::fs::write(&agents, cleaned);
+        }
+        Ok(())
+    }
+
+    /// Writes a `<!-- squeez:start --> … <!-- squeez:end -->` block into
+    /// `~/.config/opencode/AGENTS.md`, which OpenCode auto-loads at every
+    /// session start (confirmed by OpenCode docs on rules precedence).
+    fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
+        let path = Self::agents_md_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+        let mut block = String::from("<!-- squeez:start -->\n");
+        block.push_str("## squeez — session context\n");
+        let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
+        block.push_str(&format!(
+            "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}\n",
+            budget_k,
+            persona::as_str(cfg.persona)
+        ));
+        for s in summaries {
+            block.push_str(&format!("- {}\n", s.display_line()));
+        }
+        if summaries.is_empty() {
+            block.push_str("- No prior sessions recorded yet.\n");
+        }
+        let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
+        if !persona_text.is_empty() {
+            block.push('\n');
+            block.push_str(persona_text);
+        }
+        block.push_str("<!-- squeez:end -->\n");
+
+        let cleaned = strip_squeez_block(&existing);
+        let contents = format!("{}\n{}", block, cleaned.trim_start());
+        std::fs::write(&path, contents)
+    }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_squeez_block_removes_inline_block() {
+        let s = "# other rules\n<!-- squeez:start -->\nfoo\n<!-- squeez:end -->\n## remainder\n";
+        let out = strip_squeez_block(s);
+        assert!(!out.contains("<!-- squeez:start -->"));
+        assert!(out.contains("# other rules"));
+        assert!(out.contains("## remainder"));
+    }
+
+    #[test]
+    fn strip_squeez_block_preserves_file_without_block() {
+        let s = "# just regular content\n";
+        assert_eq!(strip_squeez_block(s), s);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,13 @@ fn main() {
             std::process::exit(exit_code);
         }
         Some("init") => {
-            let copilot = args.get(2).map(String::as_str) == Some("--copilot");
-            let exit_code = if copilot {
-                squeez::commands::init::run_copilot()
-            } else {
-                squeez::commands::init::run()
+            let flag = args.get(2).map(String::as_str);
+            let exit_code = match flag {
+                Some("--copilot") => squeez::commands::init::run_copilot(),
+                Some(s) if s.starts_with("--host=") => {
+                    squeez::commands::init::run_for_host(&s["--host=".len()..])
+                }
+                _ => squeez::commands::init::run(),
             };
             std::process::exit(exit_code);
         }

--- a/tests/test_hosts_opencode.rs
+++ b/tests/test_hosts_opencode.rs
@@ -1,0 +1,133 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use squeez::config::Config;
+use squeez::hosts::{find, HostCaps, OpenCodeAdapter};
+use squeez::hosts::HostAdapter;
+
+// XDG_CONFIG_HOME is process-global — serialise tests that mutate it so
+// parallel `cargo test` doesn't race.
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn tmp_home() -> PathBuf {
+    let uniq = format!(
+        "{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        std::process::id()
+    );
+    let path = std::env::temp_dir().join(format!("squeez-opencode-test-{uniq}"));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn with_xdg<F: FnOnce(&PathBuf) -> R, R>(f: F) -> R {
+    let guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tmp_home();
+    std::env::set_var("XDG_CONFIG_HOME", &home);
+    let r = f(&home);
+    std::env::remove_var("XDG_CONFIG_HOME");
+    drop(guard);
+    r
+}
+
+#[test]
+fn opencode_capabilities_full_parity() {
+    let a = find("opencode").expect("opencode adapter");
+    let caps = a.capabilities();
+    assert!(caps.contains(HostCaps::BASH_WRAP));
+    assert!(caps.contains(HostCaps::SESSION_MEM));
+    assert!(caps.contains(HostCaps::BUDGET_HARD));
+}
+
+#[test]
+fn opencode_data_dir_respects_xdg_config_home() {
+    with_xdg(|home| {
+        let a = OpenCodeAdapter;
+        let d = a.data_dir();
+        assert!(d.starts_with(home), "data_dir {:?} not under {:?}", d, home);
+        assert!(d.ends_with("opencode/squeez"), "unexpected suffix: {:?}", d);
+    });
+}
+
+#[test]
+fn opencode_install_drops_plugin_file() {
+    with_xdg(|home| {
+        let a = OpenCodeAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez"))
+            .expect("install should succeed");
+        let plugin = home.join("opencode/plugins/squeez.js");
+        assert!(plugin.exists(), "plugin file missing at {:?}", plugin);
+        let body = std::fs::read_to_string(&plugin).unwrap();
+        assert!(body.contains("SqueezPlugin"));
+        assert!(body.contains("tool.execute.before"));
+        assert!(body.contains("session.created"));
+    });
+}
+
+#[test]
+fn opencode_inject_memory_writes_marker_block() {
+    with_xdg(|home| {
+        let a = OpenCodeAdapter;
+        let cfg = Config::default();
+        a.inject_memory(&cfg, &[]).expect("inject_memory should succeed");
+        let agents = home.join("opencode/AGENTS.md");
+        assert!(agents.exists(), "AGENTS.md not created");
+        let body = std::fs::read_to_string(&agents).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("<!-- squeez:end -->"));
+        assert!(body.contains("squeez — session context"));
+    });
+}
+
+#[test]
+fn opencode_inject_memory_is_idempotent() {
+    with_xdg(|home| {
+        let a = OpenCodeAdapter;
+        let cfg = Config::default();
+        a.inject_memory(&cfg, &[]).expect("first run");
+        a.inject_memory(&cfg, &[]).expect("second run");
+        let agents = home.join("opencode/AGENTS.md");
+        let body = std::fs::read_to_string(&agents).unwrap();
+        assert_eq!(
+            body.matches("<!-- squeez:start -->").count(),
+            1,
+            "duplicate squeez block after idempotent re-run"
+        );
+    });
+}
+
+#[test]
+fn opencode_inject_memory_preserves_existing_content() {
+    with_xdg(|home| {
+        std::fs::create_dir_all(home.join("opencode")).unwrap();
+        let agents_path = home.join("opencode/AGENTS.md");
+        std::fs::write(&agents_path, "# My existing rules\nuse tabs\n").unwrap();
+        let a = OpenCodeAdapter;
+        let cfg = Config::default();
+        a.inject_memory(&cfg, &[]).expect("inject");
+        let body = std::fs::read_to_string(&agents_path).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("# My existing rules"));
+        assert!(body.contains("use tabs"));
+    });
+}
+
+#[test]
+fn opencode_uninstall_strips_marker_block_and_removes_plugin() {
+    with_xdg(|home| {
+        let a = OpenCodeAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let plugin = home.join("opencode/plugins/squeez.js");
+        let agents = home.join("opencode/AGENTS.md");
+        assert!(plugin.exists());
+        assert!(agents.exists());
+        a.uninstall().unwrap();
+        assert!(!plugin.exists(), "plugin should be removed");
+        let body = std::fs::read_to_string(&agents).unwrap();
+        assert!(!body.contains("<!-- squeez:start -->"));
+    });
+}


### PR DESCRIPTION
## Linked issue

Closes #47

## Type of change

- [x] `feat:` — new functionality (→ minor bump)

## Area

- [x] Handler (`src/commands/*`)
- [x] CI / release / tooling

## Summary

- `src/hosts/opencode.rs::OpenCodeAdapter` implements the full `HostAdapter` trait: `is_installed`, `data_dir`, `install` (drops the ESM plugin), `inject_memory` (writes the squeez marker block into `~/.config/opencode/AGENTS.md`), `uninstall` (reverses both). Capabilities: `BASH_WRAP | SESSION_MEM | BUDGET_HARD`
- `opencode-plugin/squeez.js` rewritten: registers `session.created` (calls `squeez init --host=opencode`), `tool.execute.before` for bash + read + grep, `tool.execute.after` for tracking. No-op when the binary is missing
- `src/commands/init.rs` gains `run_for_host(name)` — the generic entry point the adapter plugin calls
- `src/main.rs` accepts `squeez init --host=<name>`; legacy `--copilot` still works

## Test plan

- [x] `cargo test --release` — **420 passed / 0 failed** (up from 411; +7 opencode + 2 strip_squeez_block unit tests)
- [x] `cargo build --release` clean
- [x] 7 new tests in `tests/test_hosts_opencode.rs` cover capabilities, `data_dir` XDG handling, `install` drops the plugin, `inject_memory` creates + is idempotent + preserves existing content, `uninstall` removes plugin + strips marker block
- [x] Parallel-test safety: `XDG_CONFIG_HOME` mutation serialised via a shared `Mutex` (process-global env vars are not thread-safe across test runners)

## Caveat

OpenCode plugin hooks do NOT fire on MCP tool calls (upstream bug sst/opencode#2319). That's a host limitation, not something this adapter works around.

## Follow-ups (separate PRs)

- Gemini CLI adapter
- Codex CLI adapter (with AGENTS.md soft-budget hints)
- `squeez setup` / `squeez uninstall` subcommands
- `install.sh` refactor to delegate to `squeez setup`
- Upstream issues for OpenAI Codex + Google Gemini

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (plugin source is `include_str!`-ed, no runtime deps)