### PR TITLE
feat(hosts): Gemini CLI adapter (BeforeTool/AfterTool hooks)

### DIFF
--- a/hooks/gemini-after-tool.sh
+++ b/hooks/gemini-after-tool.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# squeez Gemini CLI AfterTool hook — records tool results into the squeez
+# SessionContext (file-path, error, git-event tracking).
+#
+# Registered in ~/.gemini/settings.json under hooks.AfterTool.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.gemini/squeez"
+
+python3 -c "
+import json, sys, subprocess, os
+
+data = sys.stdin.read()
+if not data.strip():
+    sys.exit(0)
+try:
+    d = json.loads(data)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+tool = d.get('tool_name') or d.get('tool') or 'unknown'
+try:
+    subprocess.run(
+        [os.environ.get('SQUEEZ') or '$SQUEEZ', 'track-result', tool],
+        input=data,
+        timeout=3,
+        check=False,
+    )
+except Exception:
+    pass
+"

--- a/hooks/gemini-before-tool.sh
+++ b/hooks/gemini-before-tool.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# squeez Gemini CLI BeforeTool hook — wraps bash commands with `squeez wrap`
+# and prints an informational note before Read/Grep/Glob tools.
+#
+# Gemini's BeforeTool rewrite schema is not yet fully documented upstream
+# (tracked in google-gemini/gemini-cli#14449), so Read/Grep/Glob
+# enforcement here is deliberately soft: we rely on the GEMINI.md block
+# written by `squeez init` to nudge the model to cap output.
+#
+# Registered in ~/.gemini/settings.json under hooks.BeforeTool.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+SQUEEZ_BIN="$SQUEEZ" python3 -c "
+import json, os, shlex, sys
+
+data = sys.stdin.read()
+if not data.strip():
+    sys.exit(0)
+
+try:
+    d = json.loads(data)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+# Gemini events name the tool under tool_name (Claude Code convention).
+tool = d.get('tool_name') or d.get('tool') or ''
+squeez = os.environ['SQUEEZ_BIN']
+
+if tool in ('bash', 'Bash', 'run_shell_command'):
+    inp = d.get('tool_input') or d.get('input') or {}
+    cmd = inp.get('command') or inp.get('cmd')
+    if not cmd or not isinstance(cmd, str):
+        sys.exit(0)
+    if cmd.startswith(squeez) or 'squeez wrap' in cmd or cmd.startswith('--no-squeez'):
+        sys.exit(0)
+    inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)
+    print(json.dumps({'decision': 'allow', 'updatedInput': inp}))
+    sys.exit(0)
+
+# Read/Grep/Glob: pass-through (soft-budget via GEMINI.md).
+sys.exit(0)
+"

--- a/hooks/gemini-session-start.sh
+++ b/hooks/gemini-session-start.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# squeez Gemini CLI SessionStart hook — emits session memory to stdout
+# which Gemini CLI injects into the initial system prompt. Also writes to
+# ~/.gemini/GEMINI.md so the summary persists across sessions.
+#
+# Registered in ~/.gemini/settings.json under hooks.SessionStart.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.gemini/squeez"
+"$SQUEEZ" init --host=gemini 2>/dev/null || true

--- a/src/hosts/gemini.rs
+++ b/src/hosts/gemini.rs
@@ -1,0 +1,289 @@
+//! Gemini CLI adapter.
+//!
+//! Wiring per the Gemini CLI hook system introduced in v0.26.0:
+//!   - Config file: `~/.gemini/settings.json`
+//!   - Hooks namespace: `hooks.{SessionStart,BeforeTool,AfterTool}` — same
+//!     array-of-matcher shape Claude Code uses
+//!   - Memory file: `~/.gemini/GEMINI.md` (auto-loaded at session start)
+//!
+//! Capabilities ship as `BASH_WRAP | SESSION_MEM | BUDGET_SOFT`. The
+//! `BeforeTool` docs mention a rewrite capability for tool_input, but the
+//! stdout schema is not yet publicly documented, so this adapter treats
+//! Read/Grep/Glob budget enforcement as soft (hint in GEMINI.md) until we
+//! can empirically confirm the rewrite format. Upstream tracking:
+//!   https://github.com/google-gemini/gemini-cli/issues/14449
+//!
+//! JSON patching of `settings.json` delegates to a python3 subprocess. The
+//! binary already requires python3 for Claude Code and Copilot CLI hook
+//! scripts, so this is an existing runtime dependency, not a new one.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::persona;
+use crate::config::Config;
+use crate::memory::Summary;
+use crate::session::home_dir;
+
+use super::{HostAdapter, HostCaps};
+
+const SESSION_START_SCRIPT: &str = include_str!("../../hooks/gemini-session-start.sh");
+const BEFORE_TOOL_SCRIPT: &str = include_str!("../../hooks/gemini-before-tool.sh");
+const AFTER_TOOL_SCRIPT: &str = include_str!("../../hooks/gemini-after-tool.sh");
+
+/// Python program used to patch `~/.gemini/settings.json`. Receives the
+/// target path as argv[1] and the squeez-hooks directory as argv[2].
+///
+/// The script:
+/// 1. Loads the existing settings (tolerating missing/malformed files)
+/// 2. Ensures `hooks.{SessionStart,BeforeTool,AfterTool}` arrays exist
+/// 3. Appends squeez matcher objects if no entry already contains "squeez"
+///    in any of its command strings (idempotent on repeated runs)
+/// 4. Writes atomically via a `.tmp` file + `os.replace`
+const PATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+settings = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            settings = json.load(f)
+    except Exception:
+        settings = {}
+
+hooks = settings.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
+    settings["hooks"] = hooks
+
+def ensure_entry(event, matcher, script_name, timeout_ms):
+    arr = hooks.get(event)
+    if not isinstance(arr, list):
+        arr = []
+        hooks[event] = arr
+    for m in arr:
+        try:
+            for h in m.get("hooks", []):
+                if "squeez" in str(h.get("command", "")):
+                    return
+        except Exception:
+            continue
+    arr.append({
+        "matcher": matcher,
+        "hooks": [{
+            "name": "squeez-" + event.lower(),
+            "type": "command",
+            "command": os.path.join(hooks_dir, script_name),
+            "timeout": timeout_ms,
+        }],
+    })
+
+ensure_entry("SessionStart", ".*", "gemini-session-start.sh", 5000)
+ensure_entry("BeforeTool",    ".*", "gemini-before-tool.sh", 5000)
+ensure_entry("AfterTool",     ".*", "gemini-after-tool.sh",  3000)
+
+tmp = path + ".tmp"
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+const UNPATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    sys.exit(0)
+try:
+    with open(path) as f:
+        settings = json.load(f)
+except Exception:
+    sys.exit(0)
+
+hooks = settings.get("hooks")
+if isinstance(hooks, dict):
+    for event in ("SessionStart", "BeforeTool", "AfterTool"):
+        arr = hooks.get(event)
+        if isinstance(arr, list):
+            hooks[event] = [
+                m for m in arr
+                if not any("squeez" in str(h.get("command", "")) for h in m.get("hooks", []))
+            ]
+            if not hooks[event]:
+                del hooks[event]
+    if not hooks:
+        settings.pop("hooks", None)
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+pub struct GeminiCliAdapter;
+
+impl GeminiCliAdapter {
+    fn gemini_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.gemini", home_dir()))
+    }
+    fn hooks_dir() -> PathBuf {
+        Self::gemini_dir().join("squeez").join("hooks")
+    }
+    fn settings_path() -> PathBuf {
+        Self::gemini_dir().join("settings.json")
+    }
+    fn memory_path() -> PathBuf {
+        Self::gemini_dir().join("GEMINI.md")
+    }
+
+    fn write_hook_scripts(hooks_dir: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(hooks_dir)?;
+        for (name, body) in [
+            ("gemini-session-start.sh", SESSION_START_SCRIPT),
+            ("gemini-before-tool.sh", BEFORE_TOOL_SCRIPT),
+            ("gemini-after-tool.sh", AFTER_TOOL_SCRIPT),
+        ] {
+            let path = hooks_dir.join(name);
+            std::fs::write(&path, body)?;
+            // Make the hook scripts executable (Gemini invokes them as commands).
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(0o755);
+                let _ = std::fs::set_permissions(&path, perms);
+            }
+        }
+        Ok(())
+    }
+
+    fn run_python(script: &str, args: &[&str]) -> std::io::Result<()> {
+        let status = std::process::Command::new("python3")
+            .arg("-c")
+            .arg(script)
+            .args(args)
+            .status()?;
+        if !status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("python3 settings patch exited {status}"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl HostAdapter for GeminiCliAdapter {
+    fn name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn is_installed(&self) -> bool {
+        Self::gemini_dir().exists()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        Self::gemini_dir().join("squeez")
+    }
+
+    fn capabilities(&self) -> HostCaps {
+        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_SOFT
+    }
+
+    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
+        let hooks_dir = Self::hooks_dir();
+        Self::write_hook_scripts(&hooks_dir)?;
+        let settings = Self::settings_path();
+        Self::run_python(
+            PATCH_SCRIPT,
+            &[
+                settings.to_str().unwrap_or(""),
+                hooks_dir.to_str().unwrap_or(""),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> std::io::Result<()> {
+        let hooks_dir = Self::hooks_dir();
+        if hooks_dir.exists() {
+            let _ = std::fs::remove_dir_all(&hooks_dir);
+        }
+        let settings = Self::settings_path();
+        if settings.exists() {
+            Self::run_python(UNPATCH_SCRIPT, &[settings.to_str().unwrap_or("")])?;
+        }
+        let memory = Self::memory_path();
+        if memory.exists() {
+            let existing = std::fs::read_to_string(&memory).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            let _ = std::fs::write(&memory, cleaned);
+        }
+        Ok(())
+    }
+
+    fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
+        let path = Self::memory_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+        let mut block = String::from("<!-- squeez:start -->\n");
+        block.push_str("## squeez — session context\n");
+        let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
+        block.push_str(&format!(
+            "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}\n",
+            budget_k,
+            persona::as_str(cfg.persona)
+        ));
+        for s in summaries {
+            block.push_str(&format!("- {}\n", s.display_line()));
+        }
+        if summaries.is_empty() {
+            block.push_str("- No prior sessions recorded yet.\n");
+        }
+        // Soft-budget hint (Gemini BUDGET_HARD is pending upstream rewrite schema docs).
+        block.push_str(&format!(
+            "\n## Tool-output budget (soft enforcement)\nWhen using read_file / grep-equivalent tools, cap output to ~{} lines unless the user explicitly asks for more.\n",
+            cfg.read_max_lines
+        ));
+        let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
+        if !persona_text.is_empty() {
+            block.push('\n');
+            block.push_str(persona_text);
+        }
+        block.push_str("<!-- squeez:end -->\n");
+
+        let cleaned = strip_squeez_block(&existing);
+        let contents = format!("{}\n{}", block, cleaned.trim_start());
+        std::fs::write(&path, contents)
+    }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_squeez_block_inside_existing_gemini_md() {
+        let s = "# project rules\n<!-- squeez:start -->\nfoo\n<!-- squeez:end -->\n## after\n";
+        let out = strip_squeez_block(s);
+        assert!(!out.contains("<!-- squeez:start -->"));
+        assert!(out.contains("# project rules"));
+        assert!(out.contains("## after"));
+    }
+}

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -12,9 +12,11 @@
 
 pub mod claude_code;
 pub mod copilot;
+pub mod gemini;
 pub mod opencode;
 pub use claude_code::ClaudeCodeAdapter;
 pub use copilot::CopilotCliAdapter;
+pub use gemini::GeminiCliAdapter;
 pub use opencode::OpenCodeAdapter;
 
 use std::path::{Path, PathBuf};
@@ -99,34 +101,7 @@ pub fn find(slug: &str) -> Option<Box<dyn HostAdapter>> {
     all_hosts().into_iter().find(|h| h.name() == slug)
 }
 
-// ── Stub implementations (US-005 .. US-006 fill these in) ──────────────────
-
-pub struct GeminiCliAdapter;
-impl HostAdapter for GeminiCliAdapter {
-    fn name(&self) -> &'static str {
-        "gemini"
-    }
-    fn is_installed(&self) -> bool {
-        Path::new(&format!("{}/.gemini", home_dir())).exists()
-    }
-    fn data_dir(&self) -> PathBuf {
-        PathBuf::from(format!("{}/.gemini/squeez", home_dir()))
-    }
-    fn capabilities(&self) -> HostCaps {
-        // BUDGET_HARD pending empirical validation of BeforeTool rewrite schema.
-        // Upstream: https://github.com/google-gemini/gemini-cli/issues/14449
-        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_SOFT
-    }
-    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn uninstall(&self) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn inject_memory(&self, _cfg: &Config, _summaries: &[Summary]) -> std::io::Result<()> {
-        Ok(())
-    }
-}
+// ── Stub implementations (US-006 fills this in) ────────────────────────────
 
 pub struct CodexCliAdapter;
 impl HostAdapter for CodexCliAdapter {

--- a/tests/test_hosts_gemini.rs
+++ b/tests/test_hosts_gemini.rs
@@ -1,0 +1,216 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use squeez::config::Config;
+use squeez::hosts::{find, GeminiCliAdapter, HostAdapter, HostCaps};
+
+// HOME is process-global; tests that mutate it must serialise.
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn tmp_home() -> PathBuf {
+    let uniq = format!(
+        "{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        std::process::id()
+    );
+    let path = std::env::temp_dir().join(format!("squeez-gemini-test-{uniq}"));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn with_home<F: FnOnce(&PathBuf) -> R, R>(f: F) -> R {
+    let guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tmp_home();
+    let prev_home = std::env::var("HOME").ok();
+    let prev_userprofile = std::env::var("USERPROFILE").ok();
+    std::env::set_var("HOME", &home);
+    std::env::remove_var("USERPROFILE");
+    let r = f(&home);
+    if let Some(h) = prev_home {
+        std::env::set_var("HOME", h);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(u) = prev_userprofile {
+        std::env::set_var("USERPROFILE", u);
+    }
+    drop(guard);
+    r
+}
+
+#[test]
+fn gemini_capabilities_bash_wrap_session_mem_soft_budget() {
+    let a = find("gemini").expect("gemini adapter");
+    let caps = a.capabilities();
+    assert!(caps.contains(HostCaps::BASH_WRAP));
+    assert!(caps.contains(HostCaps::SESSION_MEM));
+    assert!(caps.contains(HostCaps::BUDGET_SOFT));
+    // BUDGET_HARD deliberately off — pending upstream schema docs.
+    assert!(!caps.contains(HostCaps::BUDGET_HARD));
+}
+
+#[test]
+fn gemini_data_dir_under_home_gemini_squeez() {
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        assert_eq!(a.data_dir(), home.join(".gemini/squeez"));
+    });
+}
+
+#[test]
+fn gemini_inject_memory_writes_marker_block_with_soft_budget_hint() {
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        let cfg = Config::default();
+        a.inject_memory(&cfg, &[]).expect("inject");
+        let gemini_md = home.join(".gemini/GEMINI.md");
+        assert!(gemini_md.exists(), "GEMINI.md not created");
+        let body = std::fs::read_to_string(&gemini_md).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("<!-- squeez:end -->"));
+        assert!(body.contains("soft enforcement"));
+    });
+}
+
+#[test]
+fn gemini_inject_memory_is_idempotent() {
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        let cfg = Config::default();
+        a.inject_memory(&cfg, &[]).unwrap();
+        a.inject_memory(&cfg, &[]).unwrap();
+        let body = std::fs::read_to_string(home.join(".gemini/GEMINI.md")).unwrap();
+        assert_eq!(
+            body.matches("<!-- squeez:start -->").count(),
+            1,
+            "duplicate squeez block after re-run"
+        );
+    });
+}
+
+#[test]
+fn gemini_inject_memory_preserves_existing_content() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".gemini")).unwrap();
+        let gemini_md = home.join(".gemini/GEMINI.md");
+        std::fs::write(&gemini_md, "# user rules\ndo X\n").unwrap();
+        let a = GeminiCliAdapter;
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let body = std::fs::read_to_string(&gemini_md).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("# user rules"));
+        assert!(body.contains("do X"));
+    });
+}
+
+#[test]
+fn gemini_install_writes_hook_scripts_and_patches_settings() {
+    // install() shells out to python3; skip gracefully if python3 is absent
+    // on the test host (we cannot mock it portably without a crate).
+    if std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        eprintln!("python3 unavailable — skipping install test");
+        return;
+    }
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez"))
+            .expect("install");
+        let hooks_dir = home.join(".gemini/squeez/hooks");
+        for script in [
+            "gemini-session-start.sh",
+            "gemini-before-tool.sh",
+            "gemini-after-tool.sh",
+        ] {
+            assert!(hooks_dir.join(script).exists(), "{} missing", script);
+        }
+        let settings = home.join(".gemini/settings.json");
+        assert!(settings.exists(), "settings.json not written");
+        let body = std::fs::read_to_string(&settings).unwrap();
+        assert!(body.contains("SessionStart"));
+        assert!(body.contains("BeforeTool"));
+        assert!(body.contains("AfterTool"));
+        assert!(body.contains("gemini-before-tool.sh"));
+    });
+}
+
+#[test]
+fn gemini_install_preserves_existing_settings() {
+    if std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        return;
+    }
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".gemini")).unwrap();
+        // Seed settings.json with an unrelated key.
+        std::fs::write(
+            home.join(".gemini/settings.json"),
+            r#"{"theme": "dracula", "other": {"foo": 1}}"#,
+        )
+        .unwrap();
+        let a = GeminiCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        let body = std::fs::read_to_string(home.join(".gemini/settings.json")).unwrap();
+        assert!(body.contains("dracula"), "unrelated 'theme' key dropped");
+        assert!(body.contains("BeforeTool"));
+    });
+}
+
+#[test]
+fn gemini_install_is_idempotent_no_duplicate_entries() {
+    if std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        return;
+    }
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        let body = std::fs::read_to_string(home.join(".gemini/settings.json")).unwrap();
+        // Should have one SessionStart matcher, one BeforeTool, one AfterTool.
+        let count_session = body.matches("gemini-session-start.sh").count();
+        assert_eq!(count_session, 1, "duplicate SessionStart entries: {body}");
+    });
+}
+
+#[test]
+fn gemini_uninstall_removes_hooks_and_strips_memory_block() {
+    if std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+    {
+        return;
+    }
+    with_home(|home| {
+        let a = GeminiCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        a.uninstall().unwrap();
+
+        // Hook scripts directory gone
+        assert!(!home.join(".gemini/squeez/hooks").exists());
+        // settings.json still parseable, squeez entries stripped
+        let body = std::fs::read_to_string(home.join(".gemini/settings.json")).unwrap();
+        assert!(!body.contains("gemini-session-start.sh"));
+        // GEMINI.md still there, squeez block removed
+        let md = std::fs::read_to_string(home.join(".gemini/GEMINI.md")).unwrap();
+        assert!(!md.contains("<!-- squeez:start -->"));
+    });
+}


### PR DESCRIPTION
## Linked issue

Closes #51

## Type of change

- [x] `feat:` — new functionality (→ minor bump)

## Area

- [x] Handler (`src/commands/*`)
- [x] CI / release / tooling

## Summary

Full HostAdapter implementation for Google's Gemini CLI:

- **Capabilities**: `BASH_WRAP | SESSION_MEM | BUDGET_SOFT`. BUDGET_HARD is held back pending upstream rewrite-schema docs (google-gemini/gemini-cli#14449)
- **install()** drops three hook scripts into `~/.gemini/squeez/hooks/` (embedded via `include_str!`) and patches `~/.gemini/settings.json` via python3 subprocess — idempotent, preserves unrelated keys, atomic write
- **uninstall()** removes the hooks dir, strips squeez entries from settings.json, and clears the squeez block from GEMINI.md
- **inject_memory()** writes a `<!-- squeez:start --> … <!-- squeez:end -->` block into `~/.gemini/GEMINI.md` with a soft-budget hint alongside persona + session summaries

### Hook scripts (`hooks/gemini-*.sh`)

- `SessionStart` → `squeez init --host=gemini`
- `BeforeTool` → for bash / `run_shell_command`, emits `{"decision":"allow","updatedInput":...}` rewriting to `squeez wrap`; Read/Grep/Glob pass through
- `AfterTool` → fires `squeez track-result <tool>` with result piped on stdin

## Test plan

- [x] `cargo test --release` — **430 passed / 0 failed** (+10 new: 9 integration + 1 strip_squeez_block unit)
- [x] `cargo build --release` clean
- [x] python3-dependent tests gracefully skip when the interpreter is missing
- [x] Parallel-test safety via `Mutex` around HOME env mutation

## Caveat

Gemini's BeforeTool hook rewrite schema is documented but not yet fully public. Until the schema is pinned, `BeforeTool` for Read/Grep/Glob is a pass-through; the squeez GEMINI.md block carries a prose-level budget hint instead.

## Follow-ups (separate PRs)

- Codex CLI adapter (AGENTS.md + `~/.codex/hooks.json`)
- `squeez setup` / `squeez uninstall` subcommands
- `install.sh` refactor to delegate to `squeez setup`
- Upstream issues to file: google-gemini/gemini-cli (rewrite schema), openai/codex (PreToolUse expansion)

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (python3 was already required by existing hook scripts, not a new dep)