### PR TITLE
feat(hosts): Codex CLI adapter (hooks + AGENTS.md soft-budget)

### DIFF
--- a/hooks/codex-posttooluse.sh
+++ b/hooks/codex-posttooluse.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# squeez Codex CLI PostToolUse hook — records results into SessionContext.
+#
+# Registered in ~/.codex/hooks.json under hooks.PostToolUse.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.codex/squeez"
+
+python3 -c "
+import json, sys, subprocess, os
+
+data = sys.stdin.read()
+if not data.strip():
+    sys.exit(0)
+try:
+    d = json.loads(data)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+tool = d.get('tool_name') or d.get('tool') or 'unknown'
+try:
+    subprocess.run(
+        [os.environ.get('SQUEEZ') or '$SQUEEZ', 'track-result', tool],
+        input=data,
+        timeout=3,
+        check=False,
+    )
+except Exception:
+    pass
+"

--- a/hooks/codex-pretooluse.sh
+++ b/hooks/codex-pretooluse.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# squeez Codex CLI PreToolUse hook — rewrites bash/shell commands with
+# `squeez wrap` before execution.
+#
+# Codex's PreToolUse is Bash-only as of 2026-04 (openai/codex discussion
+# #2150); read_file / grep / apply_patch have no hook surface. Soft budget
+# for those tools is communicated via ~/.codex/AGENTS.md, written by
+# `squeez init --host=codex`.
+#
+# Registered in ~/.codex/hooks.json under hooks.PreToolUse.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+SQUEEZ_BIN="$SQUEEZ" python3 -c "
+import json, os, shlex, sys
+
+data = sys.stdin.read()
+if not data.strip():
+    sys.exit(0)
+try:
+    d = json.loads(data)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+tool = d.get('tool_name') or d.get('tool') or ''
+if tool not in ('bash', 'Bash', 'shell', 'run_shell_command'):
+    sys.exit(0)
+
+inp = d.get('tool_input') or {}
+cmd = inp.get('command')
+if not cmd or not isinstance(cmd, str):
+    sys.exit(0)
+
+squeez = os.environ['SQUEEZ_BIN']
+if cmd.startswith(squeez) or 'squeez wrap' in cmd or cmd.startswith('--no-squeez'):
+    sys.exit(0)
+
+inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)
+# Codex docs describe a decision/updatedInput response shape; keep it
+# forward-compatible even though updatedInput is not yet implemented
+# upstream — worst case Codex ignores the rewrite and the hook no-ops.
+print(json.dumps({'decision': 'allow', 'updatedInput': inp}))
+"

--- a/hooks/codex-session-start.sh
+++ b/hooks/codex-session-start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# squeez Codex CLI SessionStart hook — finalizes previous session and
+# refreshes ~/.codex/AGENTS.md, which Codex CLI auto-loads at session start.
+#
+# Registered in ~/.codex/hooks.json under hooks.SessionStart.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+export SQUEEZ_DIR="$HOME/.codex/squeez"
+"$SQUEEZ" init --host=codex 2>/dev/null || true

--- a/src/hosts/codex.rs
+++ b/src/hosts/codex.rs
@@ -1,0 +1,278 @@
+//! Codex CLI adapter.
+//!
+//! OpenAI's `codex` CLI (the open-source agentic coder, not the retired
+//! Codex model) exposes a Claude-Code-style hook system via
+//! `~/.codex/hooks.json` and auto-loads `~/.codex/AGENTS.md` at session
+//! start.
+//!
+//! Capability ceiling: `BASH_WRAP | SESSION_MEM | BUDGET_SOFT`.
+//!
+//! `PreToolUse` fires on Bash only (no Read/Grep/apply_patch hook surface),
+//! and `updatedInput` is parsed-but-unimplemented in Codex as of
+//! 2026-04-18 — tracked in openai/codex discussion #2150. Until upstream
+//! expands the surface, Read/Grep enforcement ships as **soft** via a
+//! prose hint in the AGENTS.md block written by `inject_memory`.
+//!
+//! JSON patching of `hooks.json` uses a python3 subprocess, consistent
+//! with every other adapter in this crate.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::persona;
+use crate::config::Config;
+use crate::memory::Summary;
+use crate::session::home_dir;
+
+use super::{HostAdapter, HostCaps};
+
+const SESSION_START_SCRIPT: &str = include_str!("../../hooks/codex-session-start.sh");
+const PRE_TOOL_USE_SCRIPT: &str = include_str!("../../hooks/codex-pretooluse.sh");
+const POST_TOOL_USE_SCRIPT: &str = include_str!("../../hooks/codex-posttooluse.sh");
+
+const PATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+settings = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            settings = json.load(f)
+    except Exception:
+        settings = {}
+
+hooks = settings.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
+    settings["hooks"] = hooks
+
+def ensure_entry(event, matcher, script_name, timeout_ms):
+    arr = hooks.get(event)
+    if not isinstance(arr, list):
+        arr = []
+        hooks[event] = arr
+    for m in arr:
+        try:
+            for h in m.get("hooks", []):
+                if "squeez" in str(h.get("command", "")):
+                    return
+        except Exception:
+            continue
+    arr.append({
+        "matcher": matcher,
+        "hooks": [{
+            "type": "command",
+            "command": os.path.join(hooks_dir, script_name),
+            "timeout": timeout_ms,
+        }],
+    })
+
+ensure_entry("SessionStart",  ".*",                 "codex-session-start.sh", 5000)
+ensure_entry("PreToolUse",    ".*",                 "codex-pretooluse.sh",    5000)
+ensure_entry("PostToolUse",   ".*",                 "codex-posttooluse.sh",   3000)
+
+tmp = path + ".tmp"
+os.makedirs(os.path.dirname(path), exist_ok=True)
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+const UNPATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    sys.exit(0)
+try:
+    with open(path) as f:
+        settings = json.load(f)
+except Exception:
+    sys.exit(0)
+
+hooks = settings.get("hooks")
+if isinstance(hooks, dict):
+    for event in ("SessionStart", "PreToolUse", "PostToolUse"):
+        arr = hooks.get(event)
+        if isinstance(arr, list):
+            hooks[event] = [
+                m for m in arr
+                if not any("squeez" in str(h.get("command", "")) for h in m.get("hooks", []))
+            ]
+            if not hooks[event]:
+                del hooks[event]
+    if not hooks:
+        settings.pop("hooks", None)
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+pub struct CodexCliAdapter;
+
+impl CodexCliAdapter {
+    fn codex_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.codex", home_dir()))
+    }
+    fn hooks_dir() -> PathBuf {
+        Self::codex_dir().join("squeez").join("hooks")
+    }
+    fn hooks_json_path() -> PathBuf {
+        Self::codex_dir().join("hooks.json")
+    }
+    fn agents_md_path() -> PathBuf {
+        Self::codex_dir().join("AGENTS.md")
+    }
+
+    fn write_hook_scripts(hooks_dir: &Path) -> std::io::Result<()> {
+        std::fs::create_dir_all(hooks_dir)?;
+        for (name, body) in [
+            ("codex-session-start.sh", SESSION_START_SCRIPT),
+            ("codex-pretooluse.sh", PRE_TOOL_USE_SCRIPT),
+            ("codex-posttooluse.sh", POST_TOOL_USE_SCRIPT),
+        ] {
+            let path = hooks_dir.join(name);
+            std::fs::write(&path, body)?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(0o755);
+                let _ = std::fs::set_permissions(&path, perms);
+            }
+        }
+        Ok(())
+    }
+
+    fn run_python(script: &str, args: &[&str]) -> std::io::Result<()> {
+        let status = std::process::Command::new("python3")
+            .arg("-c")
+            .arg(script)
+            .args(args)
+            .status()?;
+        if !status.success() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("python3 hooks.json patch exited {status}"),
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl HostAdapter for CodexCliAdapter {
+    fn name(&self) -> &'static str {
+        "codex"
+    }
+
+    fn is_installed(&self) -> bool {
+        Self::codex_dir().exists()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        Self::codex_dir().join("squeez")
+    }
+
+    fn capabilities(&self) -> HostCaps {
+        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_SOFT
+    }
+
+    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
+        let hooks_dir = Self::hooks_dir();
+        Self::write_hook_scripts(&hooks_dir)?;
+        let hooks_json = Self::hooks_json_path();
+        Self::run_python(
+            PATCH_SCRIPT,
+            &[
+                hooks_json.to_str().unwrap_or(""),
+                hooks_dir.to_str().unwrap_or(""),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn uninstall(&self) -> std::io::Result<()> {
+        let hooks_dir = Self::hooks_dir();
+        if hooks_dir.exists() {
+            let _ = std::fs::remove_dir_all(&hooks_dir);
+        }
+        let hooks_json = Self::hooks_json_path();
+        if hooks_json.exists() {
+            Self::run_python(UNPATCH_SCRIPT, &[hooks_json.to_str().unwrap_or("")])?;
+        }
+        let agents = Self::agents_md_path();
+        if agents.exists() {
+            let existing = std::fs::read_to_string(&agents).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            let _ = std::fs::write(&agents, cleaned);
+        }
+        Ok(())
+    }
+
+    fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
+        let path = Self::agents_md_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+
+        let mut block = String::from("<!-- squeez:start -->\n");
+        block.push_str("## squeez — session context\n");
+        let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
+        block.push_str(&format!(
+            "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}\n",
+            budget_k,
+            persona::as_str(cfg.persona)
+        ));
+        for s in summaries {
+            block.push_str(&format!("- {}\n", s.display_line()));
+        }
+        if summaries.is_empty() {
+            block.push_str("- No prior sessions recorded yet.\n");
+        }
+        // Soft budget hint — Codex PreToolUse fires on Bash only (upstream
+        // openai/codex#2150), so we nudge the model via AGENTS.md prose.
+        block.push_str(&format!(
+            "\n## Tool-output budget (soft enforcement)\nWhen using read_file / grep, cap output to ~{} lines unless the user explicitly asks for more.\nWhen using apply_patch on large files, target minimal diffs instead of rewriting whole files.\n",
+            cfg.read_max_lines
+        ));
+        let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
+        if !persona_text.is_empty() {
+            block.push('\n');
+            block.push_str(persona_text);
+        }
+        block.push_str("<!-- squeez:end -->\n");
+
+        let cleaned = strip_squeez_block(&existing);
+        let contents = format!("{}\n{}", block, cleaned.trim_start());
+        std::fs::write(&path, contents)
+    }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_squeez_block_inside_existing_agents_md() {
+        let s = "# repo rules\n<!-- squeez:start -->\nfoo\n<!-- squeez:end -->\n## after\n";
+        let out = strip_squeez_block(s);
+        assert!(!out.contains("<!-- squeez:start -->"));
+        assert!(out.contains("# repo rules"));
+        assert!(out.contains("## after"));
+    }
+}

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -11,10 +11,12 @@
 //! keep their stub impl at the bottom of this file.
 
 pub mod claude_code;
+pub mod codex;
 pub mod copilot;
 pub mod gemini;
 pub mod opencode;
 pub use claude_code::ClaudeCodeAdapter;
+pub use codex::CodexCliAdapter;
 pub use copilot::CopilotCliAdapter;
 pub use gemini::GeminiCliAdapter;
 pub use opencode::OpenCodeAdapter;
@@ -23,7 +25,6 @@ use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::memory::Summary;
-use crate::session::home_dir;
 
 // ── Capability bitflags (zero-dep: plain u8 newtype) ───────────────────────
 
@@ -99,36 +100,6 @@ pub fn all_hosts() -> Vec<Box<dyn HostAdapter>> {
 /// Look up an adapter by its `name()` slug.
 pub fn find(slug: &str) -> Option<Box<dyn HostAdapter>> {
     all_hosts().into_iter().find(|h| h.name() == slug)
-}
-
-// ── Stub implementations (US-006 fills this in) ────────────────────────────
-
-pub struct CodexCliAdapter;
-impl HostAdapter for CodexCliAdapter {
-    fn name(&self) -> &'static str {
-        "codex"
-    }
-    fn is_installed(&self) -> bool {
-        Path::new(&format!("{}/.codex", home_dir())).exists()
-    }
-    fn data_dir(&self) -> PathBuf {
-        PathBuf::from(format!("{}/.codex/squeez", home_dir()))
-    }
-    fn capabilities(&self) -> HostCaps {
-        // BUDGET_HARD blocked upstream: Codex PreToolUse is Bash-only and
-        // `updatedInput` is parsed but not implemented.
-        // Upstream: https://github.com/openai/codex/discussions/2150
-        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_SOFT
-    }
-    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn uninstall(&self) -> std::io::Result<()> {
-        Ok(())
-    }
-    fn inject_memory(&self, _cfg: &Config, _summaries: &[Summary]) -> std::io::Result<()> {
-        Ok(())
-    }
 }
 
 #[cfg(test)]

--- a/tests/test_hosts_codex.rs
+++ b/tests/test_hosts_codex.rs
@@ -1,0 +1,193 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use squeez::config::Config;
+use squeez::hosts::{find, CodexCliAdapter, HostAdapter, HostCaps};
+
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn tmp_home() -> PathBuf {
+    let uniq = format!(
+        "{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        std::process::id()
+    );
+    let path = std::env::temp_dir().join(format!("squeez-codex-test-{uniq}"));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn with_home<F: FnOnce(&PathBuf) -> R, R>(f: F) -> R {
+    let guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tmp_home();
+    let prev_home = std::env::var("HOME").ok();
+    let prev_userprofile = std::env::var("USERPROFILE").ok();
+    std::env::set_var("HOME", &home);
+    std::env::remove_var("USERPROFILE");
+    let r = f(&home);
+    if let Some(h) = prev_home {
+        std::env::set_var("HOME", h);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(u) = prev_userprofile {
+        std::env::set_var("USERPROFILE", u);
+    }
+    drop(guard);
+    r
+}
+
+fn python3_missing() -> bool {
+    std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+}
+
+#[test]
+fn codex_capabilities_bash_wrap_session_mem_soft_budget() {
+    let a = find("codex").expect("codex adapter");
+    let caps = a.capabilities();
+    assert!(caps.contains(HostCaps::BASH_WRAP));
+    assert!(caps.contains(HostCaps::SESSION_MEM));
+    assert!(caps.contains(HostCaps::BUDGET_SOFT));
+    assert!(!caps.contains(HostCaps::BUDGET_HARD));
+}
+
+#[test]
+fn codex_data_dir_under_home_codex_squeez() {
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        assert_eq!(a.data_dir(), home.join(".codex/squeez"));
+    });
+}
+
+#[test]
+fn codex_inject_memory_writes_block_with_soft_budget_hints() {
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let agents = home.join(".codex/AGENTS.md");
+        assert!(agents.exists(), "AGENTS.md not created");
+        let body = std::fs::read_to_string(&agents).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("<!-- squeez:end -->"));
+        assert!(body.contains("soft enforcement"));
+        assert!(body.contains("read_file"));
+        assert!(body.contains("apply_patch"));
+    });
+}
+
+#[test]
+fn codex_inject_memory_idempotent() {
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let body = std::fs::read_to_string(home.join(".codex/AGENTS.md")).unwrap();
+        assert_eq!(body.matches("<!-- squeez:start -->").count(), 1);
+    });
+}
+
+#[test]
+fn codex_inject_memory_preserves_existing_content() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let agents = home.join(".codex/AGENTS.md");
+        std::fs::write(&agents, "# existing rules\nuse 2-space indent\n").unwrap();
+        CodexCliAdapter
+            .inject_memory(&Config::default(), &[])
+            .unwrap();
+        let body = std::fs::read_to_string(&agents).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("# existing rules"));
+        assert!(body.contains("use 2-space indent"));
+    });
+}
+
+#[test]
+fn codex_install_writes_hooks_and_patches_hooks_json() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez"))
+            .expect("install");
+        let hooks_dir = home.join(".codex/squeez/hooks");
+        for script in [
+            "codex-session-start.sh",
+            "codex-pretooluse.sh",
+            "codex-posttooluse.sh",
+        ] {
+            assert!(hooks_dir.join(script).exists(), "{} missing", script);
+        }
+        let hooks_json = home.join(".codex/hooks.json");
+        assert!(hooks_json.exists());
+        let body = std::fs::read_to_string(&hooks_json).unwrap();
+        assert!(body.contains("SessionStart"));
+        assert!(body.contains("PreToolUse"));
+        assert!(body.contains("PostToolUse"));
+        assert!(body.contains("codex-pretooluse.sh"));
+    });
+}
+
+#[test]
+fn codex_install_preserves_existing_hooks_json_keys() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        std::fs::write(
+            home.join(".codex/hooks.json"),
+            r#"{"user_field": 42, "hooks": {"PreToolUse": [{"matcher": "special", "hooks": [{"type": "command", "command": "/tmp/mine.sh"}]}]}}"#,
+        )
+        .unwrap();
+        CodexCliAdapter
+            .install(&PathBuf::from("/usr/local/bin/squeez"))
+            .unwrap();
+        let body = std::fs::read_to_string(home.join(".codex/hooks.json")).unwrap();
+        assert!(body.contains("user_field"), "unrelated key dropped");
+        assert!(body.contains("/tmp/mine.sh"), "existing hook dropped");
+        assert!(body.contains("codex-pretooluse.sh"), "squeez hook missing");
+    });
+}
+
+#[test]
+fn codex_install_idempotent_no_dup_entries() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        let body = std::fs::read_to_string(home.join(".codex/hooks.json")).unwrap();
+        assert_eq!(body.matches("codex-session-start.sh").count(), 1);
+        assert_eq!(body.matches("codex-pretooluse.sh").count(), 1);
+    });
+}
+
+#[test]
+fn codex_uninstall_removes_hooks_and_strips_memory_block() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        a.uninstall().unwrap();
+
+        assert!(!home.join(".codex/squeez/hooks").exists());
+        let body = std::fs::read_to_string(home.join(".codex/hooks.json")).unwrap();
+        assert!(!body.contains("codex-pretooluse.sh"));
+        let md = std::fs::read_to_string(home.join(".codex/AGENTS.md")).unwrap();
+        assert!(!md.contains("<!-- squeez:start -->"));
+    });
+}


### PR DESCRIPTION
## Linked issue

Closes #54

## Type of change

- [x] `feat:` — new functionality (→ minor bump)

## Area

- [x] Handler (`src/commands/*`)
- [x] CI / release / tooling

## Summary

Ships `CodexCliAdapter` (OpenAI's `codex` CLI) as the fifth and final host in the CLI coverage program:

- **Capabilities**: `BASH_WRAP | SESSION_MEM | BUDGET_SOFT`. Codex PreToolUse is Bash-only and `updatedInput` is parsed-but-unimplemented (openai/codex discussion #2150), so budget enforcement for `read_file` / `grep` / `apply_patch` is soft (prose hints in AGENTS.md) until upstream expands
- **install()** drops three hook scripts into `~/.codex/squeez/hooks/` and patches `~/.codex/hooks.json` via python3 — idempotent, preserves unrelated keys AND pre-existing non-squeez hook entries
- **uninstall()** reverses both + strips the squeez block from `AGENTS.md`
- **inject_memory()** writes a `<!-- squeez:start --> … <!-- squeez:end -->` block into `~/.codex/AGENTS.md` with persona, session summaries, and soft-budget hints targeting `read_file` / `grep` / `apply_patch`

### Hook scripts (`hooks/codex-*.sh`)

- `SessionStart` → `squeez init --host=codex`
- `PreToolUse` → for bash/shell commands, emits `{"decision":"allow","updatedInput":...}` rewriting to `squeez wrap` (forward-compatible with pending Codex rewrite feature); no-op for other tools
- `PostToolUse` → `squeez track-result <tool>` with result piped on stdin

## Test plan

- [x] `cargo test --release` — **440 passed / 0 failed** (+10 new: 9 Codex integration + 1 strip_squeez_block unit)
- [x] `cargo build --release` clean (including the unused-import cleanup in `src/hosts/mod.rs` that came out of removing the final stub)
- [x] python3-gated tests skip gracefully when the interpreter is absent
- [x] Parallel-test safety via `Mutex` around HOME env mutation

## Host coverage status after this PR

| Host | Bash wrap | Session memory | Budget inject |
|---|---|---|---|
| Claude Code | ✅ native | ✅ native | ✅ native |
| Copilot CLI | ✅ native | ✅ native | ✅ native |
| OpenCode | ✅ native | ✅ native | ✅ native |
| Gemini CLI | ✅ native | ✅ native | 🟡 soft (upstream pending) |
| Codex CLI | ✅ native | ✅ native | 🟡 soft (upstream pending) |

## Follow-ups (separate PRs)

- `squeez setup` / `squeez uninstall` subcommands wiring `adapter.install()` across detected hosts
- `install.sh` refactor to delegate to `squeez setup` (removes inline Python patching for Claude/Copilot)
- README + CLAUDE.md update with the five-host matrix + soft-budget caveats
- File upstream issues: openai/codex (PreToolUse expansion + updatedInput) and google-gemini/gemini-cli (rewrite schema docs)

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (python3 was already required by existing hook scripts)