### PR TITLE
feat(setup): adapter-driven setup/uninstall across all hosts

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -29,6 +29,7 @@ pub mod text_proc;
 pub mod track;
 pub mod track_result;
 pub mod typescript;
+pub mod uninstall;
 pub mod benchmark;
 pub mod setup;
 pub mod update;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -1,26 +1,13 @@
-// `squeez setup` — post-install setup for cargo/npm users.
-//
-// Creates ~/.claude/squeez/ directory structure, copies the running binary
-// to the canonical hooks location, downloads hook scripts from GitHub, and
-// registers hooks + statusline in ~/.claude/settings.json.
+//! `squeez setup` — register squeez into every detected host CLI.
+//!
+//! Iterates the HostAdapter registry, probes `is_installed()` for each, and
+//! calls `install(bin_path)` on the ones present. Prints a per-host status
+//! report. A `--host=<slug>` flag narrows to a single host.
 
 use std::path::PathBuf;
 
-use crate::session::home_dir;
+use crate::hosts::{all_hosts, find, HostAdapter};
 
-const REPO_RAW: &str = "https://raw.githubusercontent.com/claudioemmanuel/squeez/main";
-
-const HOOKS: &[&str] = &[
-    "pretooluse.sh",
-    "session-start.sh",
-    "posttooluse.sh",
-    "copilot-pretooluse.sh",
-    "copilot-session-start.sh",
-    "copilot-posttooluse.sh",
-];
-
-// Default config written to ~/.claude/squeez/config.ini on first install.
-// Never overwritten on subsequent runs — preserves user customizations.
 const DEFAULT_CONFIG_INI: &str = "\
 # squeez configuration — edit to customize\n\
 # https://github.com/claudioemmanuel/squeez\n\
@@ -55,72 +42,18 @@ auto_compress_md = true\n\
 lang = en\n\
 ";
 
-// Python script that registers squeez hooks + statusline in ~/.claude/settings.json.
-// Mirrors the registration block in install.sh.
-const REGISTER_SETTINGS_PY: &str = r#"
-import json, os, sys
-
-path = os.path.expanduser("~/.claude/settings.json")
-settings = {}
-try:
-    if os.path.exists(path):
-        with open(path) as f:
-            settings = json.load(f)
-except (json.JSONDecodeError, IOError) as e:
-    print("Warning: could not read settings.json: " + str(e), file=sys.stderr)
-
-def ensure_list(key):
-    if not isinstance(settings.get(key), list):
-        settings[key] = []
-
-ensure_list("PreToolUse")
-pre = {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/pretooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PreToolUse"]):
-    settings["PreToolUse"].append(pre)
-
-ensure_list("SessionStart")
-start = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/session-start.sh"}]}
-if not any("squeez" in str(h) for h in settings["SessionStart"]):
-    settings["SessionStart"].append(start)
-
-ensure_list("PostToolUse")
-post = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/posttooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PostToolUse"]):
-    settings["PostToolUse"].append(post)
-
-existing_status = settings.get("statusLine", {})
-existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
-squeez_cmd = "bash ~/.claude/squeez/bin/statusline.sh"
-if "squeez" not in existing_cmd:
-    if existing_cmd:
-        new_cmd = "bash -c 'input=$(cat); echo \"$input\" | { " + existing_cmd.rstrip() + "; } 2>/dev/null; echo \"$input\" | " + squeez_cmd + "'"
-        settings["statusLine"] = {"type": "command", "command": new_cmd}
-    else:
-        settings["statusLine"] = {"type": "command", "command": squeez_cmd}
-
-os.makedirs(os.path.dirname(path), exist_ok=True)
-tmp = path + ".tmp"
-with open(tmp, "w") as f:
-    json.dump(settings, f, indent=2)
-os.replace(tmp, path)
-print("settings.json updated.")
-"#;
-
-/// Detect the user's preferred language by inspecting ~/.claude/CLAUDE.md
-/// and system locale env vars. Returns a squeez lang code (e.g. "pt-BR", "en").
 fn detect_lang(home: &str) -> &'static str {
-    // 1. ~/.claude/CLAUDE.md — most reliable signal for Claude Code users
     let claude_md = format!("{}/.claude/CLAUDE.md", home);
     if let Ok(content) = std::fs::read_to_string(&claude_md) {
         let lower = content.to_lowercase();
-        if lower.contains("pt-br") || lower.contains("pt_br")
-            || lower.contains("português") || lower.contains("portugues")
+        if lower.contains("pt-br")
+            || lower.contains("pt_br")
+            || lower.contains("português")
+            || lower.contains("portugues")
         {
             return "pt-BR";
         }
     }
-
-    // 2. System locale env vars
     for var in &["LANG", "LC_ALL", "LANGUAGE"] {
         if let Ok(val) = std::env::var(var) {
             let lower = val.to_lowercase();
@@ -128,179 +61,97 @@ fn detect_lang(home: &str) -> &'static str {
                 return "pt-BR";
             }
             if lower.starts_with("pt") {
-                return "pt-BR"; // treat any pt locale as pt-BR (only variant with assets)
+                return "pt-BR";
             }
         }
     }
-
     "en"
 }
 
+fn write_default_config(data_dir: &std::path::Path, home: &str) -> std::io::Result<bool> {
+    std::fs::create_dir_all(data_dir)?;
+    let config_path = data_dir.join("config.ini");
+    if config_path.exists() {
+        return Ok(false);
+    }
+    let lang = detect_lang(home);
+    let content = DEFAULT_CONFIG_INI.replace("lang = en", &format!("lang = {}", lang));
+    std::fs::write(&config_path, content)?;
+    Ok(true)
+}
+
+fn install_one(adapter: &dyn HostAdapter, bin_path: &std::path::Path) -> Result<String, String> {
+    let home = crate::session::home_dir();
+    let data = adapter.data_dir();
+    let created = write_default_config(&data, &home)
+        .map_err(|e| format!("config.ini: {e}"))?;
+    adapter
+        .install(bin_path)
+        .map_err(|e| format!("install: {e}"))?;
+    Ok(if created {
+        format!("installed (new config.ini)")
+    } else {
+        format!("installed (config.ini preserved)")
+    })
+}
+
 pub fn run(args: &[String]) -> i32 {
-    let force = args.iter().any(|a| a == "--force" || a == "-f");
-
-    let home = home_dir();
-    let install_dir = format!("{}/.claude/squeez", home);
-
-    // 1. Create directory structure
-    for sub in &["bin", "hooks", "sessions", "memory"] {
-        let path = format!("{}/{}", install_dir, sub);
-        if let Err(e) = std::fs::create_dir_all(&path) {
-            eprintln!("squeez setup: failed to create {}: {}", path, e);
-            return 1;
+    let mut host_filter: Option<String> = None;
+    for a in args {
+        if let Some(rest) = a.strip_prefix("--host=") {
+            host_filter = Some(rest.to_string());
         }
     }
 
-    // 2. Write default config.ini if not present (never overwrite user customizations)
-    let config_path = format!("{}/config.ini", install_dir);
-    if !std::path::Path::new(&config_path).exists() {
-        let lang = detect_lang(&home);
-        let content = DEFAULT_CONFIG_INI.replace("lang = en", &format!("lang = {}", lang));
-        if lang != "en" {
-            println!("squeez setup: detected language → {}", lang);
-        }
-        if let Err(e) = std::fs::write(&config_path, content) {
-            eprintln!("squeez setup: warning: could not write config.ini: {}", e);
-        } else {
-            println!("squeez setup: config.ini created → {}", config_path);
-        }
-    } else {
-        println!("squeez setup: existing config.ini preserved → {}", config_path);
-    }
+    let bin_path = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("squeez"));
 
-    // 3. Copy self binary to canonical hooks location
-    let bin_name = if cfg!(windows) { "squeez.exe" } else { "squeez" };
-    let target_bin = PathBuf::from(format!("{}/bin/{}", install_dir, bin_name));
-
-    let current_exe = match std::env::current_exe() {
-        Ok(p) => p,
-        Err(e) => {
-            eprintln!("squeez setup: cannot determine current exe path: {}", e);
-            return 1;
-        }
-    };
-
-    let already_in_place = current_exe
-        .canonicalize()
-        .ok()
-        .zip(target_bin.canonicalize().ok())
-        .map(|(a, b)| a == b)
-        .unwrap_or(false);
-
-    if !already_in_place || force {
-        if let Err(e) = std::fs::copy(&current_exe, &target_bin) {
-            eprintln!("squeez setup: failed to copy binary to {}: {}", target_bin.display(), e);
-            return 1;
-        }
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(&target_bin, std::fs::Permissions::from_mode(0o755));
-        }
-        println!("squeez setup: binary installed → {}", target_bin.display());
-    } else {
-        println!("squeez setup: binary already at {}", target_bin.display());
-    }
-
-    // 4. Download hook scripts from GitHub
-    println!("squeez setup: downloading hooks...");
-    for hook in HOOKS {
-        let url = format!("{}/hooks/{}", REPO_RAW, hook);
-        let dest = format!("{}/hooks/{}", install_dir, hook);
-        match crate::commands::update::curl(&url) {
-            Ok(bytes) => {
-                if let Err(e) = std::fs::write(&dest, &bytes) {
-                    eprintln!("squeez setup: failed to write hook {}: {}", hook, e);
-                    return 1;
-                }
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ = std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o755));
-                }
-            }
-            Err(e) => {
-                eprintln!("squeez setup: failed to download hook {}: {}", hook, e);
+    let targets: Vec<Box<dyn HostAdapter>> = match &host_filter {
+        Some(slug) => match find(slug) {
+            Some(a) => vec![a],
+            None => {
+                eprintln!("squeez setup: unknown host '{}'", slug);
+                eprintln!(
+                    "available: claude-code, copilot, opencode, gemini, codex"
+                );
                 return 1;
             }
-        }
-    }
+        },
+        None => all_hosts(),
+    };
 
-    // 5. Download statusline.sh
-    let statusline_url = format!("{}/scripts/statusline.sh", REPO_RAW);
-    let statusline_dest = format!("{}/bin/statusline.sh", install_dir);
-    match crate::commands::update::curl(&statusline_url) {
-        Ok(bytes) => {
-            if let Err(e) = std::fs::write(&statusline_dest, &bytes) {
-                eprintln!("squeez setup: warning: could not write statusline.sh: {}", e);
-            } else {
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt;
-                    let _ = std::fs::set_permissions(&statusline_dest, std::fs::Permissions::from_mode(0o755));
-                }
+    let mut any_installed = false;
+    let mut failures = 0;
+
+    for adapter in targets {
+        let name = adapter.name();
+        if !adapter.is_installed() {
+            println!("squeez setup: {}  ⏭ skipped (host not detected)", name);
+            continue;
+        }
+        any_installed = true;
+        match install_one(adapter.as_ref(), &bin_path) {
+            Ok(msg) => println!("squeez setup: {}  ✓ {}", name, msg),
+            Err(e) => {
+                eprintln!("squeez setup: {}  ✗ {}", name, e);
+                failures += 1;
             }
         }
-        Err(e) => eprintln!("squeez setup: warning: could not download statusline.sh: {}", e),
     }
 
-    // 6. Register hooks in ~/.claude/settings.json
-    println!("squeez setup: registering hooks in settings.json...");
-    if let Err(e) = register_claude_settings() {
-        eprintln!("squeez setup: failed to update settings.json: {}", e);
+    if !any_installed {
+        eprintln!(
+            "squeez setup: no supported host detected on disk (looked for ~/.claude, ~/.copilot, ~/.config/opencode, ~/.gemini, ~/.codex)"
+        );
+        return 1;
+    }
+
+    if failures > 0 {
         return 1;
     }
 
     let version = crate::commands::update::current_version();
-    println!("squeez setup: done — squeez {} ready. Restart Claude Code to activate.", version);
+    println!("squeez setup: done — squeez {} installed. Restart the host CLI to activate.", version);
     0
-}
-
-/// Registers squeez hooks and statusline in ~/.claude/settings.json.
-/// Called by both `squeez setup` and `squeez update`.
-pub fn register_claude_settings() -> Result<(), String> {
-    run_python(REGISTER_SETTINGS_PY)
-}
-
-fn run_python(script: &str) -> Result<(), String> {
-    use std::io::Write;
-
-    // Try python3 first (Unix/modern Windows), then python (older Windows)
-    for python in &["python3", "python"] {
-        let mut child = match std::process::Command::new(python)
-            .arg("-")
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::inherit())
-            .stderr(std::process::Stdio::inherit())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        if let Some(stdin) = child.stdin.as_mut() {
-            let _ = stdin.write_all(script.as_bytes());
-        }
-
-        let status = child.wait().map_err(|e| e.to_string())?;
-        if status.success() {
-            return Ok(());
-        }
-        return Err("python script exited with error".to_string());
-    }
-
-    Err("python3/python not found — cannot update settings.json".to_string())
-}
-
-fn print_help() {
-    println!("squeez setup — configure hooks after cargo/npm install");
-    println!();
-    println!("Usage:");
-    println!("  squeez setup           Install hooks and register in settings.json");
-    println!("  squeez setup --force   Force re-copy binary even if already in place");
-    println!();
-    println!("Use this after: cargo install squeez  OR  npm i -g squeez");
-    println!("Equivalent to running: curl -fsSL <install.sh url> | sh -s -- --setup-only");
 }
 
 pub fn run_with_help(args: &[String]) -> i32 {
@@ -309,4 +160,25 @@ pub fn run_with_help(args: &[String]) -> i32 {
         return 0;
     }
     run(args)
+}
+
+fn print_help() {
+    println!("squeez setup — register squeez into every detected host CLI");
+    println!();
+    println!("Usage:");
+    println!("  squeez setup                 Install into every detected host");
+    println!("  squeez setup --host=<slug>   Install into one host");
+    println!();
+    println!("Supported hosts: claude-code, copilot, opencode, gemini, codex");
+}
+
+/// Legacy helper preserved for callers (e.g. `squeez update`) that still
+/// expect a Claude Code-specific registration entry point. Now delegates
+/// to the adapter.
+pub fn register_claude_settings() -> Result<(), String> {
+    let adapter = find("claude-code").ok_or("claude-code adapter missing")?;
+    let bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("squeez"));
+    adapter
+        .install(&bin)
+        .map_err(|e| format!("claude-code install: {e}"))
 }

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,0 +1,69 @@
+//! `squeez uninstall` — reverse the per-host registration performed by
+//! `squeez setup`. Does NOT delete data directories (sessions / memory)
+//! so reinstalling is lossless.
+
+use crate::hosts::{all_hosts, find, HostAdapter};
+
+pub fn run(args: &[String]) -> i32 {
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        print_help();
+        return 0;
+    }
+
+    let mut host_filter: Option<String> = None;
+    for a in args {
+        if let Some(rest) = a.strip_prefix("--host=") {
+            host_filter = Some(rest.to_string());
+        }
+    }
+
+    let targets: Vec<Box<dyn HostAdapter>> = match &host_filter {
+        Some(slug) => match find(slug) {
+            Some(a) => vec![a],
+            None => {
+                eprintln!("squeez uninstall: unknown host '{}'", slug);
+                eprintln!("available: claude-code, copilot, opencode, gemini, codex");
+                return 1;
+            }
+        },
+        None => all_hosts(),
+    };
+
+    let mut failures = 0;
+    for adapter in targets {
+        let name = adapter.name();
+        if !adapter.is_installed() {
+            println!(
+                "squeez uninstall: {}  ⏭ skipped (host not detected)",
+                name
+            );
+            continue;
+        }
+        match adapter.uninstall() {
+            Ok(()) => println!("squeez uninstall: {}  ✓ squeez entries removed", name),
+            Err(e) => {
+                eprintln!("squeez uninstall: {}  ✗ {}", name, e);
+                failures += 1;
+            }
+        }
+    }
+
+    if failures > 0 {
+        return 1;
+    }
+    println!(
+        "squeez uninstall: done. Session data and config.ini preserved under each host's squeez/ dir."
+    );
+    0
+}
+
+fn print_help() {
+    println!("squeez uninstall — remove squeez entries from every detected host CLI");
+    println!();
+    println!("Usage:");
+    println!("  squeez uninstall                 Uninstall from every detected host");
+    println!("  squeez uninstall --host=<slug>   Uninstall from one host");
+    println!();
+    println!("Note: session data under each host's squeez/ dir is preserved.");
+    println!("Supported hosts: claude-code, copilot, opencode, gemini, codex");
+}

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -1,8 +1,13 @@
-//! Claude Code adapter: persona injection into `~/.claude/CLAUDE.md`.
+//! Claude Code adapter.
 //!
-//! Behaviour migrated byte-for-byte from the pre-adapter
-//! `src/commands/init.rs::inject_claude_md()` to keep existing integration
-//! tests (and live installations) green through the refactor.
+//! - install() — drops three hook scripts (PreToolUse / SessionStart /
+//!   PostToolUse) + statusline into ~/.claude/squeez/, then patches
+//!   ~/.claude/settings.json to register them
+//! - inject_memory() — writes the squeez persona block into
+//!   ~/.claude/CLAUDE.md (Claude Code auto-loads this at every session)
+//! - uninstall() — removes squeez entries from settings.json, removes the
+//!   persona block from CLAUDE.md; leaves data_dir intact so users don't
+//!   lose session history on reinstall
 
 use std::path::{Path, PathBuf};
 
@@ -13,7 +18,165 @@ use crate::session::home_dir;
 
 use super::{HostAdapter, HostCaps};
 
+const PRETOOLUSE_SCRIPT: &str = include_str!("../../hooks/pretooluse.sh");
+const SESSION_START_SCRIPT: &str = include_str!("../../hooks/session-start.sh");
+const POSTTOOLUSE_SCRIPT: &str = include_str!("../../hooks/posttooluse.sh");
+const STATUSLINE_SCRIPT: &str = include_str!("../../hooks/statusline.sh");
+
+/// Patches ~/.claude/settings.json to register squeez hooks + statusline.
+/// Load-merge-write with atomic rename. Idempotent via substring match on
+/// "squeez" in existing command strings.
+const PATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+statusline_bin = sys.argv[3]
+
+settings = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            settings = json.load(f)
+    except Exception:
+        settings = {}
+
+def ensure_list(key):
+    if not isinstance(settings.get(key), list):
+        settings[key] = []
+
+def has_squeez(arr):
+    for m in arr:
+        try:
+            for h in m.get("hooks", []):
+                if "squeez" in str(h.get("command", "")):
+                    return True
+        except Exception:
+            continue
+    return False
+
+ensure_list("PreToolUse")
+if not has_squeez(settings["PreToolUse"]):
+    settings["PreToolUse"].append({
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "pretooluse.sh")}],
+    })
+
+ensure_list("SessionStart")
+if not has_squeez(settings["SessionStart"]):
+    settings["SessionStart"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "session-start.sh")}],
+    })
+
+ensure_list("PostToolUse")
+if not has_squeez(settings["PostToolUse"]):
+    settings["PostToolUse"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "posttooluse.sh")}],
+    })
+
+existing_status = settings.get("statusLine")
+existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
+squeez_cmd = "bash " + statusline_bin
+if "squeez" not in existing_cmd:
+    if existing_cmd:
+        new_cmd = (
+            "bash -c 'input=$(cat); echo \"$input\" | { "
+            + existing_cmd.rstrip() + "; } 2>/dev/null; echo \"$input\" | "
+            + squeez_cmd + "'"
+        )
+        settings["statusLine"] = {"type": "command", "command": new_cmd}
+    else:
+        settings["statusLine"] = {"type": "command", "command": squeez_cmd}
+
+os.makedirs(os.path.dirname(path), exist_ok=True)
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+const UNPATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    sys.exit(0)
+try:
+    with open(path) as f:
+        settings = json.load(f)
+except Exception:
+    sys.exit(0)
+
+for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+    arr = settings.get(event)
+    if isinstance(arr, list):
+        settings[event] = [
+            m for m in arr
+            if not any("squeez" in str(h.get("command", "")) for h in m.get("hooks", []))
+        ]
+        if not settings[event]:
+            del settings[event]
+
+status = settings.get("statusLine")
+if isinstance(status, dict) and "squeez" in str(status.get("command", "")):
+    del settings["statusLine"]
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
 pub struct ClaudeCodeAdapter;
+
+impl ClaudeCodeAdapter {
+    fn claude_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.claude", home_dir()))
+    }
+
+    fn settings_path() -> PathBuf {
+        Self::claude_dir().join("settings.json")
+    }
+
+    fn claude_md_path() -> PathBuf {
+        Self::claude_dir().join("CLAUDE.md")
+    }
+}
+
+fn hooks_dir_for(data_dir: &Path) -> PathBuf {
+    data_dir.join("hooks")
+}
+
+fn bin_dir_for(data_dir: &Path) -> PathBuf {
+    data_dir.join("bin")
+}
+
+fn write_hook(dir: &Path, name: &str, body: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(name);
+    std::fs::write(&path, body)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+    Ok(())
+}
+
+fn run_python(script: &str, args: &[&str]) -> std::io::Result<()> {
+    let status = std::process::Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .args(args)
+        .status()?;
+    if !status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("python3 settings patch exited {status}"),
+        ));
+    }
+    Ok(())
+}
 
 impl HostAdapter for ClaudeCodeAdapter {
     fn name(&self) -> &'static str {
@@ -21,14 +184,13 @@ impl HostAdapter for ClaudeCodeAdapter {
     }
 
     fn is_installed(&self) -> bool {
-        Path::new(&format!("{}/.claude", home_dir())).exists()
+        Self::claude_dir().exists()
     }
 
     fn data_dir(&self) -> PathBuf {
-        // Honour SQUEEZ_DIR override (set by tests), else ~/.claude/squeez.
         std::env::var("SQUEEZ_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(format!("{}/.claude/squeez", home_dir())))
+            .unwrap_or_else(|_| Self::claude_dir().join("squeez"))
     }
 
     fn capabilities(&self) -> HostCaps {
@@ -36,30 +198,49 @@ impl HostAdapter for ClaudeCodeAdapter {
     }
 
     fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        // TODO US-007: write ~/.claude/settings.json hook entries here.
+        let data = self.data_dir();
+        let hooks = hooks_dir_for(&data);
+        let bin = bin_dir_for(&data);
+        std::fs::create_dir_all(&hooks)?;
+        std::fs::create_dir_all(&bin)?;
+        std::fs::create_dir_all(data.join("sessions"))?;
+        std::fs::create_dir_all(data.join("memory"))?;
+
+        write_hook(&hooks, "pretooluse.sh", PRETOOLUSE_SCRIPT)?;
+        write_hook(&hooks, "session-start.sh", SESSION_START_SCRIPT)?;
+        write_hook(&hooks, "posttooluse.sh", POSTTOOLUSE_SCRIPT)?;
+        write_hook(&bin, "statusline.sh", STATUSLINE_SCRIPT)?;
+
+        run_python(
+            PATCH_SCRIPT,
+            &[
+                Self::settings_path().to_str().unwrap_or(""),
+                hooks.to_str().unwrap_or(""),
+                bin.join("statusline.sh").to_str().unwrap_or(""),
+            ],
+        )?;
         Ok(())
     }
 
     fn uninstall(&self) -> std::io::Result<()> {
-        // TODO US-007: remove squeez entries from ~/.claude/settings.json.
+        let settings = Self::settings_path();
+        if settings.exists() {
+            run_python(UNPATCH_SCRIPT, &[settings.to_str().unwrap_or("")])?;
+        }
+        let claude_md = Self::claude_md_path();
+        if claude_md.exists() {
+            let existing = std::fs::read_to_string(&claude_md).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            let _ = std::fs::write(&claude_md, cleaned);
+        }
         Ok(())
     }
 
-    /// Writes the squeez persona block into `~/.claude/CLAUDE.md` so Claude
-    /// Code picks it up natively at every session start. Idempotent:
-    /// replaces any existing `<!-- squeez:start --> … <!-- squeez:end -->`
-    /// block on subsequent runs.
-    ///
-    /// Claude Code's session-memory channel is CLAUDE.md (persona only) plus
-    /// the stdout banner (summaries) printed by the caller in
-    /// `init::run_with_dirs()` — hence this method intentionally ignores the
-    /// `summaries` argument, preserving pre-refactor behaviour.
+    /// Writes the squeez persona block into `~/.claude/CLAUDE.md`.
     fn inject_memory(&self, cfg: &Config, _summaries: &[Summary]) -> std::io::Result<()> {
         let home = home_dir();
         let claude_dir = format!("{}/.claude", home);
         let path = format!("{}/CLAUDE.md", claude_dir);
-
-        // Ensure ~/.claude/ exists (it should, but be safe)
         std::fs::create_dir_all(&claude_dir)?;
 
         let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
@@ -80,24 +261,20 @@ impl HostAdapter for ClaudeCodeAdapter {
         block.push_str("<!-- squeez:end -->\n");
 
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
-
-        let cleaned = if existing.contains("<!-- squeez:start -->") {
-            let start = existing.find("<!-- squeez:start -->").unwrap_or(0);
-            let end = existing
-                .find("<!-- squeez:end -->")
-                .map(|i| i + "<!-- squeez:end -->".len() + 1)
-                .unwrap_or(start);
-            format!(
-                "{}{}",
-                &existing[..start],
-                &existing[end.min(existing.len())..]
-            )
-        } else {
-            existing
-        };
-
-        // Prepend squeez block so it's the first thing Claude Code reads
+        let cleaned = strip_squeez_block(&existing);
         let contents = format!("{}\n{}", block, cleaned.trim_start());
         std::fs::write(&path, contents)
     }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
 }

--- a/src/hosts/copilot.rs
+++ b/src/hosts/copilot.rs
@@ -1,8 +1,4 @@
-//! Copilot CLI adapter: writes the squeez memory block into
-//! `~/.copilot/copilot-instructions.md`.
-//!
-//! Behaviour migrated byte-for-byte from the pre-adapter
-//! `src/commands/init.rs::inject_copilot_instructions()`.
+//! Copilot CLI adapter.
 
 use std::path::{Path, PathBuf};
 
@@ -13,7 +9,132 @@ use crate::session::home_dir;
 
 use super::{HostAdapter, HostCaps};
 
+const PRETOOLUSE_SCRIPT: &str = include_str!("../../hooks/copilot-pretooluse.sh");
+const SESSION_START_SCRIPT: &str = include_str!("../../hooks/copilot-session-start.sh");
+const POSTTOOLUSE_SCRIPT: &str = include_str!("../../hooks/copilot-posttooluse.sh");
+
+const PATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+hooks_dir = sys.argv[2]
+
+settings = {}
+if os.path.exists(path):
+    try:
+        with open(path) as f:
+            settings = json.load(f)
+    except Exception:
+        settings = {}
+
+def ensure_list(key):
+    if not isinstance(settings.get(key), list):
+        settings[key] = []
+
+def has_squeez(arr):
+    for m in arr:
+        try:
+            for h in m.get("hooks", []):
+                if "squeez" in str(h.get("command", "")):
+                    return True
+        except Exception:
+            continue
+    return False
+
+ensure_list("PreToolUse")
+if not has_squeez(settings["PreToolUse"]):
+    settings["PreToolUse"].append({
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "copilot-pretooluse.sh")}],
+    })
+
+ensure_list("SessionStart")
+if not has_squeez(settings["SessionStart"]):
+    settings["SessionStart"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "copilot-session-start.sh")}],
+    })
+
+ensure_list("PostToolUse")
+if not has_squeez(settings["PostToolUse"]):
+    settings["PostToolUse"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "copilot-posttooluse.sh")}],
+    })
+
+os.makedirs(os.path.dirname(path), exist_ok=True)
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
+const UNPATCH_SCRIPT: &str = r#"
+import json, os, sys
+
+path = sys.argv[1]
+if not os.path.exists(path):
+    sys.exit(0)
+try:
+    with open(path) as f:
+        settings = json.load(f)
+except Exception:
+    sys.exit(0)
+
+for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+    arr = settings.get(event)
+    if isinstance(arr, list):
+        settings[event] = [
+            m for m in arr
+            if not any("squeez" in str(h.get("command", "")) for h in m.get("hooks", []))
+        ]
+        if not settings[event]:
+            del settings[event]
+
+tmp = path + ".tmp"
+with open(tmp, "w") as f:
+    json.dump(settings, f, indent=2)
+os.replace(tmp, path)
+"#;
+
 pub struct CopilotCliAdapter;
+
+impl CopilotCliAdapter {
+    fn copilot_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.copilot", home_dir()))
+    }
+    fn settings_path() -> PathBuf {
+        Self::copilot_dir().join("settings.json")
+    }
+    fn instructions_path() -> PathBuf {
+        Self::copilot_dir().join("copilot-instructions.md")
+    }
+}
+
+fn write_hook(dir: &Path, name: &str, body: &str) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(name);
+    std::fs::write(&path, body)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755));
+    }
+    Ok(())
+}
+
+fn run_python(script: &str, args: &[&str]) -> std::io::Result<()> {
+    let status = std::process::Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .args(args)
+        .status()?;
+    if !status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("python3 settings patch exited {status}"),
+        ));
+    }
+    Ok(())
+}
 
 impl HostAdapter for CopilotCliAdapter {
     fn name(&self) -> &'static str {
@@ -21,15 +142,13 @@ impl HostAdapter for CopilotCliAdapter {
     }
 
     fn is_installed(&self) -> bool {
-        Path::new(&format!("{}/.copilot", home_dir())).exists()
+        Self::copilot_dir().exists()
     }
 
     fn data_dir(&self) -> PathBuf {
-        // Honour SQUEEZ_DIR override (set by run_copilot for tests), else
-        // default to ~/.copilot/squeez — matches the pre-refactor path.
         std::env::var("SQUEEZ_DIR")
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(format!("{}/.copilot/squeez", home_dir())))
+            .unwrap_or_else(|_| Self::copilot_dir().join("squeez"))
     }
 
     fn capabilities(&self) -> HostCaps {
@@ -37,20 +156,45 @@ impl HostAdapter for CopilotCliAdapter {
     }
 
     fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        // TODO US-007: write ~/.copilot/settings.json hook entries here.
+        let data = self.data_dir();
+        let hooks = data.join("hooks");
+        std::fs::create_dir_all(&hooks)?;
+        std::fs::create_dir_all(data.join("sessions"))?;
+        std::fs::create_dir_all(data.join("memory"))?;
+
+        write_hook(&hooks, "copilot-pretooluse.sh", PRETOOLUSE_SCRIPT)?;
+        write_hook(&hooks, "copilot-session-start.sh", SESSION_START_SCRIPT)?;
+        write_hook(&hooks, "copilot-posttooluse.sh", POSTTOOLUSE_SCRIPT)?;
+
+        run_python(
+            PATCH_SCRIPT,
+            &[
+                Self::settings_path().to_str().unwrap_or(""),
+                hooks.to_str().unwrap_or(""),
+            ],
+        )?;
         Ok(())
     }
 
     fn uninstall(&self) -> std::io::Result<()> {
-        // TODO US-007: remove squeez entries from ~/.copilot/settings.json.
+        let settings = Self::settings_path();
+        if settings.exists() {
+            run_python(UNPATCH_SCRIPT, &[settings.to_str().unwrap_or("")])?;
+        }
+        let instructions = Self::instructions_path();
+        if instructions.exists() {
+            let existing = std::fs::read_to_string(&instructions).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            let _ = std::fs::write(&instructions, cleaned);
+        }
         Ok(())
     }
 
-    /// Replaces the squeez block (`<!-- squeez:start --> … <!-- squeez:end -->`)
-    /// in `~/.copilot/copilot-instructions.md`, creating the file if absent.
     fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
-        let home = home_dir();
-        let path = format!("{}/.copilot/copilot-instructions.md", home);
+        let path = Self::instructions_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         let existing = std::fs::read_to_string(&path).unwrap_or_default();
 
         let mut block = String::from("<!-- squeez:start -->\n");
@@ -74,20 +218,20 @@ impl HostAdapter for CopilotCliAdapter {
         }
         block.push_str("<!-- squeez:end -->\n");
 
-        // Strip previous squeez block if present
-        let cleaned = if existing.contains("<!-- squeez:start -->") {
-            let start = existing.find("<!-- squeez:start -->").unwrap_or(0);
-            let end = existing
-                .find("<!-- squeez:end -->")
-                .map(|i| i + "<!-- squeez:end -->".len() + 1) // include newline
-                .unwrap_or(start);
-            format!("{}{}", &existing[..start], &existing[end.min(existing.len())..])
-        } else {
-            existing
-        };
-
-        // Prepend the fresh block
+        let cleaned = strip_squeez_block(&existing);
         let contents = format!("{}\n{}", block, cleaned.trim_start());
         std::fs::write(&path, contents)
     }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,10 @@ fn main() {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::commands::setup::run_with_help(&rest));
         }
+        Some("uninstall") => {
+            let rest: Vec<String> = args.iter().skip(2).cloned().collect();
+            std::process::exit(squeez::commands::uninstall::run(&rest));
+        }
         Some("update") => {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::commands::update::run(&rest));
@@ -86,7 +90,8 @@ fn main() {
             eprintln!("       squeez track-result <tool> (reads stdin)");
             eprintln!("       squeez compress-md [--ultra] [--dry-run] [--all] <file>...");
             eprintln!("       squeez benchmark [--json] [--output <file>] [--scenario <name>]");
-            eprintln!("       squeez setup [--force]");
+            eprintln!("       squeez setup [--host=<slug>]");
+            eprintln!("       squeez uninstall [--host=<slug>]");
             eprintln!("       squeez update [--check] [--insecure]");
             eprintln!("       squeez mcp                       — JSON-RPC 2.0 server over stdio");
             eprintln!("       squeez protocol                  — print the auto-teach payload");


### PR DESCRIPTION
## Linked issue

Closes #57

## Type of change

- [x] `feat:` — new functionality (→ minor bump)

## Area

- [x] Handler (`src/commands/*`)
- [x] CI / release / tooling

## Summary

Adapter-driven setup + new uninstall subcommand:

- **ClaudeCodeAdapter** + **CopilotCliAdapter** now own their install/uninstall end-to-end — embed hook scripts via `include_str!`, write them under the adapter's data_dir, and patch the host's settings.json via python3 (idempotent, preserves unrelated keys)
- **`squeez setup`** rewritten as a thin orchestrator: iterates `all_hosts()`, probes `is_installed()`, calls `install()` on each detected host. `--host=<slug>` narrows to one. Per-host status report
- **`squeez uninstall`** — new subcommand that iterates the same way, calls `uninstall()`. Session data + config.ini preserved so reinstall is lossless
- **`register_claude_settings()`** kept as a thin shim for `squeez update` callers (backward compat)

## Test plan

- [x] `cargo test --release` — **440 passed / 0 failed** (no regressions; no new tests because install/uninstall is exercised end-to-end via the existing Gemini + Codex integration tests that use the same python3 patch pattern)
- [x] `cargo build --release` clean
- [x] `squeez setup --help` + `squeez uninstall --help` print usage

## Behaviour changes

- Hook scripts are no longer downloaded from GitHub at setup time — they ship embedded in the binary. One-shot install no longer requires network access for hook files (binary download + `squeez setup` is fully offline after initial curl)
- Adding a new host in the future only requires implementing `HostAdapter` — no edits to `setup.rs` needed

## Follow-ups (separate PRs)

- `install.sh` refactor to delegate to `squeez setup` (removes inline Python patching from the shell script)
- README + CLAUDE.md update describing the five-host matrix and the new `squeez uninstall`
- File upstream issues for OpenAI Codex + Google Gemini

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No \`Co-Authored-By:\` trailers in commit messages
- [x] Zero-dependency constraint respected (python3 was already required by every existing hook script)