### PR TITLE
refactor(install): delegate host registration to 'squeez setup'

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
+# squeez installer — downloads the release binary and delegates all host
+# registration to `squeez setup`, which iterates the HostAdapter registry
+# (Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI).
+#
+# Flags:
+#   --setup-only   Skip binary download; use an existing `squeez` from PATH
+#                  (for cargo-install / cargo-update users).
 set -euo pipefail
-REPO_RAW="https://raw.githubusercontent.com/claudioemmanuel/squeez/main"
+
 RELEASES="https://github.com/claudioemmanuel/squeez/releases/latest/download"
 INSTALL_DIR="$HOME/.claude/squeez"
 
-# Parse flags
 SETUP_ONLY=0
 for arg in "$@"; do
   case "$arg" in
@@ -12,7 +18,7 @@ for arg in "$@"; do
   esac
 done
 
-# Detect OS and architecture
+# ── Detect OS and architecture ─────────────────────────────────────────
 OS=$(uname -s)
 ARCH=$(uname -m)
 
@@ -31,56 +37,17 @@ case "$OS" in
   *) echo "ERROR: unsupported OS $OS" >&2; exit 1 ;;
 esac
 
-# Local binary name: squeez.exe on Windows, squeez elsewhere
 case "$OS" in
   Windows*|MINGW*|MSYS*|CYGWIN*) BIN_NAME="squeez.exe" ;;
   *) BIN_NAME="squeez" ;;
 esac
 
-mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/hooks" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
-chmod 700 "$INSTALL_DIR" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory" 2>/dev/null || true
+mkdir -p "$INSTALL_DIR/bin"
+chmod 700 "$INSTALL_DIR" 2>/dev/null || true
 
-# Create default config.ini only if it doesn't exist (never overwrite user customizations)
-CONFIG_FILE="$INSTALL_DIR/config.ini"
-if [ ! -f "$CONFIG_FILE" ]; then
-  cat > "$CONFIG_FILE" <<'CONFIG_EOF'
-# squeez configuration — edit to customize
-# https://github.com/claudioemmanuel/squeez
-
-enabled = true
-show_header = true
-
-# Persona: off | lite | full | ultra
-# full  = caveman mode (~75% token cut, drop articles, fragments OK)
-# ultra = max compression + abbreviation substitutions (default)
-persona = ultra
-
-# Compression limits
-max_lines = 200
-git_log_max_commits = 20
-git_diff_max_lines = 150
-docker_logs_max_lines = 100
-find_max_results = 50
-
-# Context engine
-adaptive_intensity = true
-context_cache_enabled = true
-redundancy_cache_enabled = true
-summarize_threshold_lines = 500
-
-# Memory
-memory_retention_days = 30
-auto_compress_md = true
-lang = en
-CONFIG_EOF
-  echo "Config created at $CONFIG_FILE"
-else
-  echo "Existing config preserved at $CONFIG_FILE"
-fi
-
+# ── Stage 1: obtain the binary ─────────────────────────────────────────
 if [ "$SETUP_ONLY" -eq 1 ]; then
-  # --setup-only: skip download, use existing squeez binary from PATH
-  echo "Setup-only mode: skipping binary download..."
+  echo "Setup-only mode: using existing squeez from PATH..."
   EXISTING=$(command -v squeez 2>/dev/null || true)
   if [ -z "$EXISTING" ]; then
     echo "ERROR: squeez not found in PATH." >&2
@@ -90,7 +57,6 @@ if [ "$SETUP_ONLY" -eq 1 ]; then
   echo "Found squeez at: $EXISTING"
   cp "$EXISTING" "$INSTALL_DIR/bin/$BIN_NAME"
   chmod +x "$INSTALL_DIR/bin/$BIN_NAME" 2>/dev/null || true
-  echo "Binary copied to $INSTALL_DIR/bin/$BIN_NAME"
 else
   echo "Downloading squeez binary for $OS/$ARCH..."
   curl -fsSL "$RELEASES/$BINARY" -o "$INSTALL_DIR/bin/$BIN_NAME"
@@ -105,7 +71,6 @@ else
       exit 1
   fi
 
-  # Use sha256sum if available (Linux/Windows Git Bash), otherwise fall back to shasum (macOS)
   if command -v sha256sum >/dev/null 2>&1; then
       actual=$(sha256sum "$INSTALL_DIR/bin/$BIN_NAME" | awk '{print $1}')
   else
@@ -118,159 +83,17 @@ else
       exit 1
   fi
   echo "Checksum verified."
-
   chmod +x "$INSTALL_DIR/bin/$BIN_NAME" 2>/dev/null || true
 fi
 
-echo "Installing hooks..."
-curl -fsSL "$REPO_RAW/hooks/pretooluse.sh"     -o "$INSTALL_DIR/hooks/pretooluse.sh"
-curl -fsSL "$REPO_RAW/hooks/session-start.sh"  -o "$INSTALL_DIR/hooks/session-start.sh"
-curl -fsSL "$REPO_RAW/hooks/posttooluse.sh"    -o "$INSTALL_DIR/hooks/posttooluse.sh"
-chmod +x "$INSTALL_DIR/hooks/pretooluse.sh" "$INSTALL_DIR/hooks/session-start.sh" "$INSTALL_DIR/hooks/posttooluse.sh"
-
-echo "Installing status line script..."
-curl -fsSL "$REPO_RAW/scripts/statusline.sh" -o "$INSTALL_DIR/bin/statusline.sh"
-chmod +x "$INSTALL_DIR/bin/statusline.sh"
-
-echo "Installing OpenCode plugin..."
-OPENCODE_PLUGIN_DIR="$HOME/.config/opencode/plugins"
-mkdir -p "$OPENCODE_PLUGIN_DIR"
-curl -fsSL "$REPO_RAW/opencode-plugin/squeez.js" -o "$OPENCODE_PLUGIN_DIR/squeez.js" 2>/dev/null || {
-    cat > "$OPENCODE_PLUGIN_DIR/squeez.js" <<'PLUGIN_EOF'
-const SQUEEZ_BIN = `${process.env.HOME}/.claude/squeez/bin/squeez`;
-
-export const SqueezPlugin = async () => {
-  return {
-    "tool.execute.before": async (input, output) => {
-      if (input.tool === "bash") {
-        const command = output.args?.command;
-        if (!command || typeof command !== "string") return;
-        if (command.startsWith(SQUEEZ_BIN)) return;
-        if (command.includes("squeez wrap")) return;
-        if (command.startsWith("--no-squeez")) return;
-        output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
-      }
-    },
-  };
-};
-PLUGIN_EOF
-}
-
-echo "Registering hooks in ~/.claude/settings.json..."
-python3 - <<'EOF'
-import json, os, sys
-path = os.path.expanduser("~/.claude/settings.json")
-settings = {}
-try:
-    if os.path.exists(path):
-        with open(path) as f:
-            settings = json.load(f)
-except (json.JSONDecodeError, IOError) as e:
-    print(f"Warning: could not read settings.json: {e}", file=sys.stderr)
-
-# PreToolUse — Bash compression
-if not isinstance(settings.get("PreToolUse"), list):
-    settings["PreToolUse"] = []
-pre_hook = {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/pretooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PreToolUse"]):
-    settings["PreToolUse"].append(pre_hook)
-
-# SessionStart — init + memory banner
-if not isinstance(settings.get("SessionStart"), list):
-    settings["SessionStart"] = []
-start_hook = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/session-start.sh"}]}
-if not any("squeez" in str(h) for h in settings["SessionStart"]):
-    settings["SessionStart"].append(start_hook)
-
-# PostToolUse — token tracking (no matcher = fires after all tools, not just Bash)
-if not isinstance(settings.get("PostToolUse"), list):
-    settings["PostToolUse"] = []
-post_hook = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/posttooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PostToolUse"]):
-    settings["PostToolUse"].append(post_hook)
-
-
-# StatusLine — show squeez stats in Claude Code status bar
-# Appends to existing statusLine command if claude-hud is present, otherwise sets standalone
-existing_status = settings.get("statusLine", {})
-existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
-squeez_status_cmd = "bash ~/.claude/squeez/bin/statusline.sh"
-if "squeez" not in existing_cmd:
-    if existing_cmd:
-        # Append squeez after existing status (e.g., claude-hud)
-        new_cmd = f"bash -c 'input=$(cat); echo \"$input\" | {{ {existing_cmd.rstrip()}; }} 2>/dev/null; echo \"$input\" | {squeez_status_cmd}'"
-        settings["statusLine"] = {"type": "command", "command": new_cmd}
-    else:
-        settings["statusLine"] = {"type": "command", "command": squeez_status_cmd}
-
-tmp = path + ".tmp"
-with open(tmp, "w") as f:
-    json.dump(settings, f, indent=2)
-os.replace(tmp, path)
-EOF
-
-echo "Installing Copilot CLI hooks..."
-COPILOT_SQUEEZ_DIR="$HOME/.copilot/squeez"
-mkdir -p "$COPILOT_SQUEEZ_DIR/bin" "$COPILOT_SQUEEZ_DIR/hooks" \
-         "$COPILOT_SQUEEZ_DIR/sessions" "$COPILOT_SQUEEZ_DIR/memory"
-chmod 700 "$COPILOT_SQUEEZ_DIR" "$COPILOT_SQUEEZ_DIR/sessions" "$COPILOT_SQUEEZ_DIR/memory" 2>/dev/null || true
-
-# Symlink the same binary so SQUEEZ_DIR-aware calls work
-ln -sf "$INSTALL_DIR/bin/$BIN_NAME" "$COPILOT_SQUEEZ_DIR/bin/$BIN_NAME" 2>/dev/null || \
-    cp "$INSTALL_DIR/bin/$BIN_NAME" "$COPILOT_SQUEEZ_DIR/bin/$BIN_NAME"
-
-curl -fsSL "$REPO_RAW/hooks/copilot-pretooluse.sh"     -o "$INSTALL_DIR/hooks/copilot-pretooluse.sh"
-curl -fsSL "$REPO_RAW/hooks/copilot-session-start.sh"  -o "$INSTALL_DIR/hooks/copilot-session-start.sh"
-curl -fsSL "$REPO_RAW/hooks/copilot-posttooluse.sh"    -o "$INSTALL_DIR/hooks/copilot-posttooluse.sh"
-chmod +x "$INSTALL_DIR/hooks/copilot-pretooluse.sh" \
-         "$INSTALL_DIR/hooks/copilot-session-start.sh" \
-         "$INSTALL_DIR/hooks/copilot-posttooluse.sh"
-
-# Seed Copilot instructions (writes ~/.copilot/copilot-instructions.md)
-"$INSTALL_DIR/bin/$BIN_NAME" init --copilot 2>/dev/null || true
-
-# Register hooks in ~/.copilot/settings.json (Copilot CLI hook format mirrors Claude Code)
-if [ -d "$HOME/.copilot" ]; then
-python3 - <<'COPILOT_EOF'
-import json, os, sys
-path = os.path.expanduser("~/.copilot/settings.json")
-settings = {}
-try:
-    if os.path.exists(path):
-        with open(path) as f:
-            settings = json.load(f)
-except (json.JSONDecodeError, IOError) as e:
-    print(f"Warning: could not read ~/.copilot/settings.json: {e}", file=sys.stderr)
-
-if not isinstance(settings.get("PreToolUse"), list):
-    settings["PreToolUse"] = []
-pre = {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-pretooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PreToolUse"]):
-    settings["PreToolUse"].append(pre)
-
-if not isinstance(settings.get("SessionStart"), list):
-    settings["SessionStart"] = []
-start = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-session-start.sh"}]}
-if not any("squeez" in str(h) for h in settings["SessionStart"]):
-    settings["SessionStart"].append(start)
-
-if not isinstance(settings.get("PostToolUse"), list):
-    settings["PostToolUse"] = []
-post = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/copilot-posttooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PostToolUse"]):
-    settings["PostToolUse"].append(post)
-
-tmp = path + ".tmp"
-with open(tmp, "w") as f:
-    json.dump(settings, f, indent=2)
-os.replace(tmp, path)
-COPILOT_EOF
-fi
+# ── Stage 2: delegate host registration to `squeez setup` ──────────────
+# The Rust binary owns every host-specific concern now: config.ini writing,
+# hook-script emission, settings.json patching, AGENTS.md / GEMINI.md /
+# CLAUDE.md / copilot-instructions.md injection. install.sh is just the
+# bootstrap.
+echo ""
+"$INSTALL_DIR/bin/$BIN_NAME" setup
 
 version=$("$INSTALL_DIR/bin/$BIN_NAME" --version 2>/dev/null || echo "squeez")
-echo "✅ $version installed."
 echo ""
-echo "Claude Code:  Restart Claude Code to activate."
-echo "OpenCode:     Restart OpenCode to activate the plugin (automatic Bash compression)."
-echo "Copilot CLI:  Memory injected into ~/.copilot/copilot-instructions.md."
-echo "              Restart Copilot CLI to activate hook-based bash compression."
+echo "✅ $version installed. Restart your CLI (Claude Code / Copilot CLI / OpenCode / Gemini / Codex) to activate."


### PR DESCRIPTION
## Linked issue

Closes #59

## Type of change

- [x] \`chore:\` / \`docs:\` / \`ci:\` / \`test:\` / \`refactor:\` — no release

## Area

- [x] CI / release / tooling

## Summary

\`install.sh\` is now a thin bootstrap — 99 lines, down from 276. All host-specific logic lives in the Rust HostAdapter registry, called by \`squeez setup\`.

### Removed from install.sh

- Inline Python block patching \`~/.claude/settings.json\` (now in \`ClaudeCodeAdapter.install\`)
- Inline Python block patching \`~/.copilot/settings.json\` (now in \`CopilotCliAdapter.install\`)
- Six \`curl\` calls fetching hook scripts from GitHub at install time (all embedded via \`include_str!\` in the Rust binary)
- OpenCode plugin download + inline fallback (embedded in \`OpenCodeAdapter\`)
- Per-host \`mkdir\` + \`chmod 700\` + \`config.ini\` seeding (\`squeez setup\` handles)
- \`squeez init --copilot\` invocation (session-start hook takes over)

### Kept

- OS/arch detection
- Binary download from the GitHub release
- sha256 checksum verification
- \`--setup-only\` flag (for cargo-install users who already have \`squeez\` in PATH)

### New final step

\`\`\`bash
"\$INSTALL_DIR/bin/\$BIN_NAME" setup
\`\`\`

That single invocation enumerates the adapter registry, probes \`is_installed()\` on each host, and calls \`install()\` on the ones present.

## Test plan

- [x] \`bash -n install.sh\` — syntax check passes
- [x] Dry-read: install.sh no longer contains \`python3 - <<\` heredocs
- [x] Existing installations continue to work — the adapters' \`install()\` methods are idempotent (substring-match skip on "squeez" in settings.json entries), so a re-run is a no-op not a rewrite

## Follow-ups (separate PRs)

- README + CLAUDE.md update describing the five-host matrix and the new \`squeez uninstall\`
- File upstream issues for OpenAI Codex + Google Gemini

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No \`Co-Authored-By:\` trailers in commit messages
- [x] Zero-dependency constraint respected (shell-only change)