### PR TITLE
docs: five-host matrix + squeez setup/uninstall flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,11 @@ No Makefile — all build tooling is Cargo-native.
 
 ## Architecture
 
-**squeez** is hook-based bash output compressor for Claude Code / Copilot CLI / OpenCode. It intercepts every tool invocation via Claude Code hooks (PreToolUse → wrap, SessionStart → init, PostToolUse → track-result) and runs output through 4-stage compression pipeline before Claude sees it.
+**squeez** is hook-based bash output compressor for five CLI agent hosts: Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI. It intercepts every tool invocation via host-specific hooks (PreToolUse / BeforeTool → wrap, SessionStart → init, PostToolUse / AfterTool → track-result) and runs output through 4-stage compression pipeline before the model sees it.
+
+### Host adapters (`src/hosts/`)
+
+One adapter per supported CLI, all implementing the `HostAdapter` trait. `squeez setup` iterates the registry via `all_hosts()` + `is_installed()` probes; `squeez init --host=<slug>` targets a single host. Capability bitflags (`HostCaps::{BASH_WRAP, SESSION_MEM, BUDGET_HARD, BUDGET_SOFT}`) describe what each host supports natively — Claude/Copilot/OpenCode get BUDGET_HARD; Gemini/Codex ship BUDGET_SOFT (prose hints in `GEMINI.md` / `AGENTS.md`) pending upstream expansion.
 
 ### Compression pipeline (per command invocation)
 
@@ -48,7 +52,10 @@ Cross-call awareness across 16 recent invocations:
 |------|------|
 | `src/commands/wrap.rs` | Main orchestrator: spawn subprocess, capture, compress, inject header |
 | `src/commands/compress_md/` | Markdown compressor module: `mod.rs` (core logic), `locale.rs` (Locale struct + `from_code`), `locales/en.rs` + `locales/pt_br.rs` (word lists). Exposes `compress_text` (EN default) and `compress_text_with_locale`. Select locale via `lang=` in config or `--lang` CLI flag. |
-| `src/commands/init.rs` | Session start: finalize previous session memory, inject persona prompt |
+| `src/commands/init.rs` | Session start orchestrator: finalizes previous session, prints banner, delegates memory injection to `HostAdapter.inject_memory()` via `run_for_host(slug)` |
+| `src/hosts/` | Per-host adapters (`claude_code.rs` / `copilot.rs` / `opencode.rs` / `gemini.rs` / `codex.rs`) implementing the `HostAdapter` trait + `HostCaps` bitflags + `all_hosts()` / `find()` registry. Each adapter owns install/uninstall + memory-file injection for its CLI. |
+| `src/commands/setup.rs` | `squeez setup` — thin orchestrator over the adapter registry |
+| `src/commands/uninstall.rs` | `squeez uninstall` — reverse registration, preserves session data |
 | `src/commands/benchmark.rs` | 22-scenario reproducible benchmark suite (incl. 3 economy scenarios); `--baseline` flag prints C0 vs C4 A/B table |
 | `src/config.rs` | Config struct + `~/.claude/squeez/config.ini` parser; all fields have defaults. Key tunable: `state_warn_calls` (default 5) — calls-remaining threshold that triggers State-First Pattern warning |
 | `src/session.rs` | Session state: token accounting, JSONL event log at `~/.claude/squeez/sessions/` |
@@ -62,7 +69,7 @@ Cross-call awareness across 16 recent invocations:
 
 ### Tests
 
-35 integration test files under `tests/`. Each strategy and handler has dedicated test file. Notable new ones: `test_redundancy_shingle.rs` (8 fuzzy-match tests), `test_mcp_server.rs` (10 JSON-RPC tests). Benchmark fixtures live in `bench/fixtures/`capture new ones w/ `bash bench/capture.sh`.
+38+ integration test files under `tests/`. Each strategy, handler, and host adapter has dedicated test file. Notable: `test_redundancy_shingle.rs` (fuzzy-match), `test_mcp_server.rs` (JSON-RPC), `test_hosts_{registry,opencode,gemini,codex}.rs` (adapter install/uninstall). Benchmark fixtures live in `bench/fixtures/`capture new ones w/ `bash bench/capture.sh`.
 
 ### Release & distribution
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,36 @@ Builds from [crates.io](https://crates.io/crates/squeez). Requires Rust stable. 
 
 ---
 
-### After install
+### Supported hosts
 
-| Platform | What to do |
-|----------|-----------|
-| **Claude Code** | Restart Claude Code — hooks activate automatically |
-| **OpenCode** | Restart OpenCode — plugin auto-loads from `~/.config/opencode/plugins/` |
-| **Copilot CLI** | Restart Copilot CLI — hooks registered in `~/.copilot/settings.json` |
+`squeez setup` auto-detects every CLI present on disk and registers the hooks. `squeez uninstall` removes them. Session data and `config.ini` are preserved so reinstall is lossless.
+
+| Host | Memory file | Bash wrap | Session memory | Budget inject (Read/Grep) | Notes |
+|---|---|---|---|---|---|
+| **Claude Code** | `~/.claude/CLAUDE.md` | ✅ native | ✅ native | ✅ native | Restart Claude Code to pick up hooks |
+| **Copilot CLI** | `~/.copilot/copilot-instructions.md` | ✅ native | ✅ native | ✅ native | Restart Copilot CLI after setup |
+| **OpenCode** | `~/.config/opencode/AGENTS.md` | ✅ native | ✅ native | ✅ native | Plugin at `~/.config/opencode/plugins/squeez.js`; MCP tool calls skip hooks (upstream sst/opencode#2319) |
+| **Gemini CLI** | `~/.gemini/GEMINI.md` | ✅ native | ✅ native | 🟡 soft via `GEMINI.md` | `BeforeTool` rewrite schema pending upstream docs ([google-gemini/gemini-cli#14449](https://github.com/google-gemini/gemini-cli/issues/14449)) |
+| **Codex CLI** | `~/.codex/AGENTS.md` | ✅ native | ✅ native | 🟡 soft via `AGENTS.md` | Codex `PreToolUse` is Bash-only until upstream expands ([openai/codex#2150](https://github.com/openai/codex/discussions/2150)) |
+
+### Manage
+
+```bash
+squeez setup                  # register into every detected host
+squeez setup --host=<slug>    # register into one host
+squeez uninstall              # remove squeez entries from every detected host
+squeez uninstall --host=<slug>
+```
+
+Slugs: `claude-code` / `copilot` / `opencode` / `gemini` / `codex`.
+
+After install, restart the CLI you use to pick up the new hooks.
 
 ### Uninstall
 
 ```bash
-bash ~/.claude/squeez/uninstall.sh
-# or, if you cloned the repo:
-bash uninstall.sh
+squeez uninstall              # preserves session data + config.ini
+bash ~/.claude/squeez/uninstall.sh   # (legacy) full wipe, if the script exists
 ```
 
 ### Self-update


### PR DESCRIPTION
## Linked issue

Closes #62

## Type of change

- [x] \`chore:\` / \`docs:\` / \`ci:\` / \`test:\` / \`refactor:\` — no release

## Area

- [x] Docs

## Summary

Brings README + CLAUDE.md in line with the CLI host coverage program that landed in #42, #48, #52, #55, #58, #60.

### README changes

- Legacy "After install" table replaced with a five-host capability matrix (memory-file path, bash wrap, session memory, budget inject, notes)
- Soft-budget caveats for Gemini and Codex link the upstream tracking issues
- New "Manage" section documents `squeez setup` / `squeez uninstall` with the available `--host=<slug>` slugs
- Uninstall section rewritten — legacy `uninstall.sh` demoted to a fallback

### CLAUDE.md changes

- Architecture summary reframed to mention all five hosts and the `HostAdapter` trait + `HostCaps` bitflags
- New "Host adapters (\`src/hosts/\`)" subsection
- Key-files table gains `src/hosts/`, `src/commands/setup.rs`, `src/commands/uninstall.rs`
- `init.rs` description updated — session-start orchestrator, delegates via `run_for_host`
- Integration-test count bumped to reflect the new adapter test files

## Test plan

- [x] No code changes — docs only
- [x] \`cargo build --release\` unaffected
- [x] All GitHub-flavored Markdown tables render correctly (validated by eye — nothing exotic)

## Follow-ups (separate PR)

- File upstream issues at openai/codex (PreToolUse expansion + updatedInput) and google-gemini/gemini-cli (BeforeTool rewrite schema docs)

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No \`Co-Authored-By:\` trailers in commit messages
- [x] Zero-dependency constraint respected (docs-only change)