### PR TITLE
fix: back Copilot BUDGET_HARD with Read/Grep hook + update upstream refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Changelog](https://img.shields.io/badge/changelog-📋-blue.svg)](CHANGELOG.md)
 
-End-to-end token optimizer for Claude Code, OpenCode, and GitHub Copilot CLI. Compresses bash output up to **95%**, collapses redundant calls, and injects a terse prompt persona — automatically, with zero new runtime dependencies.
+End-to-end token optimizer for Claude Code, GitHub Copilot CLI, OpenCode, Gemini CLI, and OpenAI Codex CLI. Compresses bash output up to **95%**, collapses redundant calls, and injects a terse prompt persona — automatically, with zero new runtime dependencies.
 
 ---
 
@@ -53,8 +53,8 @@ Builds from [crates.io](https://crates.io/crates/squeez). Requires Rust stable. 
 | **Claude Code** | `~/.claude/CLAUDE.md` | ✅ native | ✅ native | ✅ native | Restart Claude Code to pick up hooks |
 | **Copilot CLI** | `~/.copilot/copilot-instructions.md` | ✅ native | ✅ native | ✅ native | Restart Copilot CLI after setup |
 | **OpenCode** | `~/.config/opencode/AGENTS.md` | ✅ native | ✅ native | ✅ native | Plugin at `~/.config/opencode/plugins/squeez.js`; MCP tool calls skip hooks (upstream sst/opencode#2319) |
-| **Gemini CLI** | `~/.gemini/GEMINI.md` | ✅ native | ✅ native | 🟡 soft via `GEMINI.md` | `BeforeTool` rewrite schema pending upstream docs ([google-gemini/gemini-cli#14449](https://github.com/google-gemini/gemini-cli/issues/14449)) |
-| **Codex CLI** | `~/.codex/AGENTS.md` | ✅ native | ✅ native | 🟡 soft via `AGENTS.md` | Codex `PreToolUse` is Bash-only until upstream expands ([openai/codex#2150](https://github.com/openai/codex/discussions/2150)) |
+| **Gemini CLI** | `~/.gemini/GEMINI.md` | ✅ native | ✅ native | 🟡 soft via `GEMINI.md` | `BeforeTool` rewrite schema pending upstream docs ([google-gemini/gemini-cli#25629](https://github.com/google-gemini/gemini-cli/issues/25629)) |
+| **Codex CLI** | `~/.codex/AGENTS.md` | ✅ native | ✅ native | 🟡 soft via `AGENTS.md` | Codex `PreToolUse` is Bash-only until upstream expands ([openai/codex#18491](https://github.com/openai/codex/issues/18491)) |
 
 ### Manage
 

--- a/hooks/copilot-pretooluse.sh
+++ b/hooks/copilot-pretooluse.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# squeez Copilot CLI PreToolUse hook — compresses Bash tool output
-# Registered in ~/.copilot/settings.json (same format as Claude Code)
+# squeez Copilot CLI PreToolUse hook — compresses Bash output AND injects
+# size-budget limits for Read/Grep/Glob tool calls (parity with the Claude
+# Code hook at hooks/pretooluse.sh).
+#
+# Registered in ~/.copilot/settings.json under hooks.PreToolUse.
 set -euo pipefail
 
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
@@ -13,7 +16,7 @@ fi
 export SQUEEZ_DIR="$HOME/.copilot/squeez"
 
 SQUEEZ_BIN="$SQUEEZ" python3 -c "
-import sys, json, os, shlex
+import sys, json, os, shlex, subprocess
 
 data = sys.stdin.read()
 if not data.strip():
@@ -24,23 +27,51 @@ try:
 except json.JSONDecodeError:
     sys.exit(0)
 
-if d.get('tool_name') != 'Bash':
-    sys.exit(0)
-
-cmd = d.get('tool_input', {}).get('command')
-if cmd is None:
-    sys.exit(0)
-
+tool = d.get('tool_name', '')
 squeez = os.environ['SQUEEZ_BIN']
 
-if cmd.startswith(squeez):
-    sys.exit(0)
+# ── Bash tool: wrap command with squeez ────────────────────────────────
+if tool == 'Bash':
+    cmd = d.get('tool_input', {}).get('command')
+    if cmd is None:
+        sys.exit(0)
 
-if cmd.startswith('--no-squeez '):
-    d['tool_input']['command'] = cmd[len('--no-squeez '):]
+    if cmd.startswith(squeez):
+        sys.exit(0)
+
+    if cmd.startswith('--no-squeez '):
+        d['tool_input']['command'] = cmd[len('--no-squeez '):]
+        print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+        sys.exit(0)
+
+    d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
     print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
     sys.exit(0)
 
-d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
-print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+# ── Read/Grep/Glob: inject budget limits ──────────────────────────────
+if tool in ('Read', 'Grep', 'Glob'):
+    try:
+        result = subprocess.run(
+            [squeez, 'budget-params', tool],
+            capture_output=True, text=True, timeout=2,
+        )
+        out = result.stdout.strip()
+        if out:
+            patch = json.loads(out)
+            inp = d.get('tool_input', {})
+            changed = False
+            for k, v in patch.items():
+                if k not in inp:  # don't override explicit user values
+                    inp[k] = v
+                    changed = True
+            if changed:
+                d['tool_input'] = inp
+                print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+                sys.exit(0)
+    except Exception:
+        pass  # budget enforcement is best-effort
+    sys.exit(0)
+
+# ── All other tools: pass through ─────────────────────────────────────
+sys.exit(0)
 "

--- a/src/hosts/codex.rs
+++ b/src/hosts/codex.rs
@@ -9,7 +9,8 @@
 //!
 //! `PreToolUse` fires on Bash only (no Read/Grep/apply_patch hook surface),
 //! and `updatedInput` is parsed-but-unimplemented in Codex as of
-//! 2026-04-18 — tracked in openai/codex discussion #2150. Until upstream
+//! 2026-04-18 — tracked in openai/codex#18491 (plus background in discussion
+//! #2150). Until upstream
 //! expands the surface, Read/Grep enforcement ships as **soft** via a
 //! prose hint in the AGENTS.md block written by `inject_memory`.
 //!

--- a/src/hosts/gemini.rs
+++ b/src/hosts/gemini.rs
@@ -11,7 +11,7 @@
 //! stdout schema is not yet publicly documented, so this adapter treats
 //! Read/Grep/Glob budget enforcement as soft (hint in GEMINI.md) until we
 //! can empirically confirm the rewrite format. Upstream tracking:
-//!   https://github.com/google-gemini/gemini-cli/issues/14449
+//!   https://github.com/google-gemini/gemini-cli/issues/25629
 //!
 //! JSON patching of `settings.json` delegates to a python3 subprocess. The
 //! binary already requires python3 for Claude Code and Copilot CLI hook


### PR DESCRIPTION
## Linked issue

Closes #64

## Type of change

- [x] \`fix:\` / \`perf:\` — bug fix or perf improvement (→ patch bump)

## Area

- [x] Handler (\`src/commands/*\`)
- [x] CI / release / tooling
- [x] Docs

## Summary

Architect verification of the CLI host coverage program surfaced three items:

1. **\`CopilotCliAdapter.capabilities()\`** returned \`BUDGET_HARD\` but \`hooks/copilot-pretooluse.sh\` only wrapped Bash. This PR brings the hook to parity with \`hooks/pretooluse.sh\`: Bash → \`squeez wrap\`, Read/Grep/Glob → \`tool_input\` merged with \`squeez budget-params <Tool>\` output. The capability claim is now truthful
2. **Upstream issue references** in README + \`src/hosts/gemini.rs\` + \`src/hosts/codex.rs\` pointed at the older *discussion* threads rather than the dedicated feature-request issues filed during US-010. Updated every reference: google-gemini/gemini-cli#14449 → #25629, openai/codex#2150 → #18491 (Codex comment keeps a pointer to the original discussion for background)
3. **README line 9 ad-copy** now names all five hosts (Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI) instead of the legacy three

## Test plan

- [x] \`cargo test --release\` — **440 passed / 0 failed** (no regressions; hook-script change is exercised via the integration flow)
- [x] \`cargo build --release\` clean
- [x] The extended \`copilot-pretooluse.sh\` mirrors \`pretooluse.sh\` line-for-line in the non-bash branch, so Read/Grep/Glob budget injection is now consistent across Claude Code + Copilot CLI

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No \`Co-Authored-By:\` trailers in commit messages
- [x] Zero-dependency constraint respected (only a hook-script + docs change)