### PR TITLE
fix(ci): push release docs directly to main (loop-safe)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,7 +184,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # RELEASE_PAT (admin fine-grained) so the docs commit can be
+          # pushed straight to main without going through a PR round-trip.
+          # Loop-safe: auto-release.yml classifies `docs:` commits as
+          # TYPE=none and short-circuits before bumping a new version.
+          token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
@@ -211,15 +215,16 @@ jobs:
       - name: Copy CHANGELOG to npm directory
         run: cp CHANGELOG.md npm/CHANGELOG.md
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update-docs-${{ github.ref_name }}
-          title: "docs: update changelog and benchmarks for ${{ github.ref_name }}"
-          commit-message: "docs: update changelog and benchmarks for ${{ github.ref_name }} [skip release]"
-          body: "Auto-generated: CHANGELOG.md + README benchmark table updated for ${{ github.ref_name }}."
-          add-paths: |
-            CHANGELOG.md
-            npm/CHANGELOG.md
-            README.md
+      - name: Commit + push directly to main
+        run: |
+          if git diff --quiet -- CHANGELOG.md npm/CHANGELOG.md README.md; then
+            echo "No doc changes for ${{ github.ref_name }} — skipping commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md npm/CHANGELOG.md README.md
+          git commit -m "docs: update changelog and benchmarks for ${{ github.ref_name }}"
+          # Direct push to main. Admin-owned RELEASE_PAT bypasses required-
+          # review on main; auto-release.yml sees a `docs:` commit and skips.
+          git push origin main


### PR DESCRIPTION
## Linked issue

Closes #67

## Type of change

- [x] \`fix:\` / \`perf:\` — bug fix or perf improvement (→ patch bump)

## Area

- [x] CI / release / tooling

## Summary

After each release, the \`update-docs\` job in \`release.yml\` was opening a stand-alone PR with the generated CHANGELOG + benchmark updates. Six of those accumulated (v1.1.0 through v1.5.1) because:

- Merging them sequentially would cause conflicts (each PR touches the same files)
- None of them carry anything a human needed to review — it's pure bot-generated markdown

This PR swaps the \`peter-evans/create-pull-request\` step for a direct \`git commit + push\` to \`main\` using \`RELEASE_PAT\`.

## Loop safety

Auto-release.yml classifies commits by **subject prefix** (post-#44/#46 hardening):

\`\`\`
tag vX.Y.Z → release.yml fires → update-docs commits "docs: update changelog..." on main
  → auto-release.yml fires (on every push to main)
  → subject prefix docs: → TYPE=none → skip, no new tag
\`\`\`

One-shot per release. No cascade.

## Other guarantees

- \`git diff --quiet\` guard skips the commit entirely if no docs changed (edge case: a release that didn't move any benchmarks)
- Admin-owned \`RELEASE_PAT\` bypasses main's required-review rule (enforce_admins=false) so the bot can land the commit without human intervention
- Uses \`RELEASE_PAT\` not \`GITHUB_TOKEN\` because we WANT auto-release.yml to inspect the docs commit and confirm "no bump" — GITHUB_TOKEN-pushed commits skip downstream workflows

## Test plan

- [x] YAML validates
- [ ] First real trigger happens on the next release — confirms end-to-end

## Checklist

- [x] Issue is linked above
- [ ] CI is green (pending run)
- [x] No \`Co-Authored-By:\` trailers in commit messages
- [x] Zero-dependency constraint respected (workflow-only change)