### PR TITLE
fix(opencode): align plugin with PluginModule SDK shape (default export + server map)

### DIFF
--- a/opencode-plugin/squeez.js
+++ b/opencode-plugin/squeez.js
@@ -1,13 +1,20 @@
 // squeez OpenCode plugin — full-parity integration.
 //
-// Capabilities:
-//   - session.created → finalize previous session and refresh AGENTS.md via
-//     `squeez init --host=opencode`.
+// Conforms to the @opencode-ai/plugin SDK `PluginModule` contract: a default
+// export object with `id` + async `server(input, options)` that returns a map
+// of hook-name → handler. The server return value MUST be an object — a bare
+// return (or `return undefined`) causes OpenCode to crash on internal
+// property access (see squeez issue #69, reproduced on opencode 1.4.11 +
+// @opencode-ai/plugin 1.4.10).
+//
+// Handlers:
+//   - event (session.created) → finalize previous session and refresh
+//     AGENTS.md via `squeez init --host=opencode`.
 //   - tool.execute.before (bash) → rewrite command to `squeez wrap <cmd>`.
 //   - tool.execute.before (read/grep) → inject budget limits so Read and
 //     Grep respect the squeez config.
-//   - tool.execute.after (any) → fire-and-forget `squeez track-result` for
-//     post-execution context tracking.
+//   - tool.execute.after (any known tool) → fire-and-forget
+//     `squeez track-result` for post-execution context tracking.
 //
 // Caveat (upstream sst/opencode#2319): MCP tool calls do NOT trigger these
 // hooks. That's a host limitation, not something this plugin can work around.
@@ -68,45 +75,51 @@ function trackResult(tool) {
   }
 }
 
-export const SqueezPlugin = async (ctx) => {
-  if (!squeezExists()) {
-    // squeez not installed locally — plugin becomes a no-op rather than
-    // throwing on every hook.
-    return;
-  }
+export default {
+  id: "squeez",
+  server: async (_input, _options) => {
+    // Returning `{}` (not `undefined`) keeps the plugin loader happy when
+    // squeez isn't on the machine. Hooks are simply absent so OpenCode runs
+    // as if the plugin were not installed.
+    if (!squeezExists()) return {};
 
-  ctx.hook?.("session.created", async () => {
-    runInit();
-  });
+    return {
+      event: async ({ event }) => {
+        if (event && event.type === "session.created") {
+          runInit();
+        }
+      },
 
-  ctx.hook?.("tool.execute.before", async (input, output) => {
-    if (!input || !output || !output.args) return;
+      "tool.execute.before": async (input, output) => {
+        if (!input || !output || !output.args) return;
 
-    if (input.tool === "bash") {
-      const command = output.args.command;
-      if (!command || typeof command !== "string") return;
-      if (command.startsWith(SQUEEZ_BIN)) return;
-      if (command.includes("squeez wrap")) return;
-      if (command.startsWith("--no-squeez")) return;
-      output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
-      return;
-    }
+        if (input.tool === "bash") {
+          const command = output.args.command;
+          if (!command || typeof command !== "string") return;
+          if (command.startsWith(SQUEEZ_BIN)) return;
+          if (command.includes("squeez wrap")) return;
+          if (command.startsWith("--no-squeez")) return;
+          output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+          return;
+        }
 
-    const patch = budgetPatch(input.tool);
-    if (!patch) return;
-    for (const [k, v] of Object.entries(patch)) {
-      // Do not override fields the user (or agent) already set explicitly.
-      if (output.args[k] === undefined) {
-        output.args[k] = v;
-      }
-    }
-  });
+        const patch = budgetPatch(input.tool);
+        if (!patch) return;
+        for (const [k, v] of Object.entries(patch)) {
+          // Do not override fields the user (or agent) already set explicitly.
+          if (output.args[k] === undefined) {
+            output.args[k] = v;
+          }
+        }
+      },
 
-  ctx.hook?.("tool.execute.after", async (input) => {
-    if (!input || !input.tool) return;
-    // Only track tools we know about — keeps the noise down.
-    if (["bash", "read", "grep", "glob"].includes(input.tool)) {
-      trackResult(input.tool);
-    }
-  });
+      "tool.execute.after": async (input) => {
+        if (!input || !input.tool) return;
+        // Only track tools we know about — keeps the noise down.
+        if (["bash", "read", "grep", "glob"].includes(input.tool)) {
+          trackResult(input.tool);
+        }
+      },
+    };
+  },
 };

--- a/tests/test_hosts_opencode.rs
+++ b/tests/test_hosts_opencode.rs
@@ -61,8 +61,13 @@ fn opencode_install_drops_plugin_file() {
         let plugin = home.join("opencode/plugins/squeez.js");
         assert!(plugin.exists(), "plugin file missing at {:?}", plugin);
         let body = std::fs::read_to_string(&plugin).unwrap();
-        assert!(body.contains("SqueezPlugin"));
+        // The plugin must use the PluginModule shape (default export w/ `id`
+        // + async `server` returning a handler map). See issue #69.
+        assert!(body.contains("export default"));
+        assert!(body.contains("id: \"squeez\""));
+        assert!(body.contains("server: async"));
         assert!(body.contains("tool.execute.before"));
+        assert!(body.contains("tool.execute.after"));
         assert!(body.contains("session.created"));
     });
 }


### PR DESCRIPTION
Closes #69

## Summary

The plugin dropped at `~/.config/opencode/plugins/squeez.js` used a named export `SqueezPlugin = async (ctx) => { ctx.hook?.(...); }` that returned `undefined`. OpenCode 1.4.11 + `@opencode-ai/plugin` 1.4.10 expect a default export with `id` + async `server(input, options)` that returns a hook-name→handler map. Accessing fields on the undefined return triggered:

```
TypeError: undefined is not an object (evaluating '_.auth')
    at <anonymous> (/$bunfs/root/chunk-s856ypm6.js:684:63495)
```

…and crashed OpenCode on startup for anyone who ran `squeez setup --host=opencode` on a recent OpenCode.

## Fix

Rewrite to the `PluginModule` contract:

```js
export default {
  id: "squeez",
  server: async (_input, _options) => {
    if (!squeezExists()) return {};
    return { event, "tool.execute.before", "tool.execute.after" };
  },
};
```

- `session.created` moves from its own hook name into the generic `event` handler (`if (event.type === "session.created") runInit()`), matching the current SDK
- When squeez is absent on the machine, `server` returns `{}` (not `undefined`) so the plugin becomes a true no-op instead of crashing on property access
- All existing bash-wrap / budget-param / track-result behavior preserved

## Test plan

- [x] `cargo test --release --test test_hosts_opencode` → 7/7 pass
- [x] `cargo test --release` full suite → 0 failed
- [x] `cargo build --release` → clean
- [x] `tests/test_hosts_opencode.rs` assertions updated to verify the new shape (`export default`, `id: "squeez"`, `server: async`)

## Files changed

- `opencode-plugin/squeez.js` — full rewrite (60 insertions, 42 deletions)
- `tests/test_hosts_opencode.rs` — assertion update (6 lines)