### PR TITLE
fix(hooks): add hookEventName to PreToolUse hookSpecificOutput

### DIFF
--- a/hooks/copilot-pretooluse.sh
+++ b/hooks/copilot-pretooluse.sh
@@ -41,11 +41,11 @@ if tool == 'Bash':
 
     if cmd.startswith('--no-squeez '):
         d['tool_input']['command'] = cmd[len('--no-squeez '):]
-        print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+        print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
         sys.exit(0)
 
     d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
-    print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
     sys.exit(0)
 
 # ── Read/Grep/Glob: inject budget limits ──────────────────────────────
@@ -66,7 +66,7 @@ if tool in ('Read', 'Grep', 'Glob'):
                     changed = True
             if changed:
                 d['tool_input'] = inp
-                print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+                print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
                 sys.exit(0)
     except Exception:
         pass  # budget enforcement is best-effort

--- a/hooks/pretooluse.sh
+++ b/hooks/pretooluse.sh
@@ -34,11 +34,11 @@ if tool == 'Bash':
 
     if cmd.startswith('--no-squeez '):
         d['tool_input']['command'] = cmd[len('--no-squeez '):]
-        print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+        print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
         sys.exit(0)
 
     d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
-    print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+    print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
     sys.exit(0)
 
 # ── Read/Grep/Glob: inject budget limits ──────────────────────────────
@@ -59,7 +59,7 @@ if tool in ('Read', 'Grep', 'Glob'):
                     changed = True
             if changed:
                 d['tool_input'] = inp
-                print(json.dumps({'hookSpecificOutput': {'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+                print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
                 sys.exit(0)
     except Exception:
         pass  # budget enforcement is best-effort


### PR DESCRIPTION
## Summary
- Adds `hookEventName: "PreToolUse"` to every `hookSpecificOutput` payload emitted by `hooks/pretooluse.sh` and `hooks/copilot-pretooluse.sh`.
- Fixes Claude Code v2.1+ validation error "Hook JSON output validation failed — hookSpecificOutput is missing required field \"hookEventName\"" that surfaces on every Bash tool call.

## Why
Claude Code v2.1.114 tightened hook schema validation. The PreToolUse hook still *functions* (squeez wrap runs, budget params still inject), but the missing field emits a validation error into every turn transcript, polluting logs and eventually risking outright rejection if upstream enforces strict mode.

## Changes
- `hooks/pretooluse.sh` — 3 sites (--no-squeez unwrap, Bash wrap, Read/Grep/Glob budget)
- `hooks/copilot-pretooluse.sh` — same 3 sites (parity with Claude Code hook)

Scripts are `include_str!`'d into `src/hosts/claude_code.rs` and `src/hosts/copilot.rs`, so rebuilding the binary automatically ships the fix.

## Test plan
- [x] `echo '{"tool_name":"Bash","tool_input":{"command":"ls"}}' | bash hooks/pretooluse.sh` emits `hookEventName: "PreToolUse"`
- [x] Same check for `hooks/copilot-pretooluse.sh`
- [ ] After release, confirm Claude Code v2.1+ no longer logs the validation error

Closes #77