### PR TITLE
feat(economy): compress Agent/Task prompt at PreToolUse time

### DIFF
--- a/hooks/pretooluse.sh
+++ b/hooks/pretooluse.sh
@@ -65,6 +65,25 @@ if tool in ('Read', 'Grep', 'Glob'):
         pass  # budget enforcement is best-effort
     sys.exit(0)
 
+# ── Agent/Task: compress prompt ───────────────────────────────────────
+if tool in ('Agent', 'Task'):
+    prompt = d.get('tool_input', {}).get('prompt')
+    if isinstance(prompt, str) and prompt:
+        try:
+            result = subprocess.run(
+                [squeez, 'compress-prompt'],
+                input=prompt, capture_output=True, text=True, timeout=5,
+            )
+            compressed = result.stdout
+            # Only replace when compression actually shrinks the prompt.
+            if compressed and len(compressed) < len(prompt):
+                d['tool_input']['prompt'] = compressed
+                print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
+                sys.exit(0)
+        except Exception:
+            pass
+    sys.exit(0)
+
 # ── All other tools: pass through ─────────────────────────────────────
 sys.exit(0)
 "

--- a/src/commands/compress_prompt.rs
+++ b/src/commands/compress_prompt.rs
@@ -1,0 +1,153 @@
+//! `squeez compress-prompt` — compress an agent/task prompt from stdin to stdout.
+//!
+//! Reads stdin to a String. If the token estimate (chars / 4) is within
+//! `agent_prompt_max_tokens`, echoes unchanged. Otherwise runs the input
+//! through markdown compression. If still over budget after compression,
+//! head-truncates to fit and appends a notice.
+
+use crate::commands::compress_md::{compress_text_with_locale, Mode};
+use crate::config::Config;
+
+pub fn run() -> i32 {
+    let cfg = Config::load();
+
+    // 0 = disabled: echo stdin unchanged
+    if cfg.agent_prompt_max_tokens == 0 {
+        let mut input = String::new();
+        loop {
+            let mut buf = String::new();
+            match std::io::stdin().read_line(&mut buf) {
+                Ok(0) => break,
+                Ok(_) => input.push_str(&buf),
+                Err(_) => break,
+            }
+        }
+        print!("{}", input);
+        return 0;
+    }
+
+    let input = read_stdin();
+    let orig_tokens = input.chars().count() / 4;
+
+    if orig_tokens <= cfg.agent_prompt_max_tokens {
+        print!("{}", input);
+        return 0;
+    }
+
+    // Run markdown compression
+    let locale = crate::commands::compress_md::Locale::from_code(&cfg.lang);
+    let result = compress_text_with_locale(&input, Mode::Ultra, locale);
+    let compressed = if result.safe {
+        result.output
+    } else {
+        input.clone()
+    };
+
+    let compressed_tokens = compressed.chars().count() / 4;
+    if compressed_tokens <= cfg.agent_prompt_max_tokens {
+        print!("{}", compressed);
+        return 0;
+    }
+
+    // Head-truncate to budget
+    let max_chars = cfg.agent_prompt_max_tokens * 4;
+    let notice = format!(
+        "\n[squeez: agent prompt truncated from {} to {} tokens — pass --no-squeez in the prompt to disable]",
+        orig_tokens,
+        cfg.agent_prompt_max_tokens,
+    );
+    let available_chars = max_chars.saturating_sub(notice.len());
+    let truncated = char_truncate(&compressed, available_chars);
+    print!("{}{}", truncated, notice);
+    0
+}
+
+fn read_stdin() -> String {
+    use std::io::Read;
+    let mut buf = String::new();
+    let _ = std::io::stdin().read_to_string(&mut buf);
+    buf
+}
+
+fn char_truncate(s: &str, max_chars: usize) -> &str {
+    if s.chars().count() <= max_chars {
+        return s;
+    }
+    let mut idx = 0;
+    let mut count = 0;
+    for (byte_idx, _) in s.char_indices() {
+        if count == max_chars {
+            idx = byte_idx;
+            break;
+        }
+        count += 1;
+    }
+    &s[..idx]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token_est(s: &str) -> usize {
+        s.chars().count() / 4
+    }
+
+    #[test]
+    fn short_prompt_passes_through_unchanged() {
+        // Build a prompt well under 2000 tokens (< 8000 chars)
+        let input = "# Plan\n\nDo something simple.\n";
+        let tokens = token_est(input);
+        assert!(tokens < 2000, "test input should be short");
+
+        // Use a high budget so compress logic is skipped
+        let cfg = Config {
+            agent_prompt_max_tokens: 2000,
+            ..Config::default()
+        };
+
+        // Simulate the logic inline (cfg.agent_prompt_max_tokens check)
+        let orig_tokens = input.chars().count() / 4;
+        assert!(orig_tokens <= cfg.agent_prompt_max_tokens);
+        // Should pass through unchanged
+        let output = input;
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn markdown_heavy_prompt_shrinks() {
+        // Build a prompt that has lots of filler prose
+        let filler = "This is just really basically a simple test item that I would like to ensure you understand completely.\n";
+        let mut input = String::from("# Plan\n\n");
+        for _ in 0..50 {
+            input.push_str(filler);
+        }
+
+        let locale = crate::commands::compress_md::Locale::from_code("en");
+        let result = compress_text_with_locale(&input, Mode::Ultra, locale);
+        if result.safe {
+            assert!(
+                result.output.len() < input.len(),
+                "compressed should be smaller than original"
+            );
+        }
+    }
+
+    #[test]
+    fn truncation_appends_notice() {
+        // Construct input that exceeds 10 tokens (40 chars) to test truncation path
+        let input = "abcdefghij".repeat(20); // 200 chars = 50 tokens
+        let max_tokens = 10usize;
+        let max_chars = max_tokens * 4;
+        let notice = format!(
+            "\n[squeez: agent prompt truncated from {} to {} tokens — pass --no-squeez in the prompt to disable]",
+            input.chars().count() / 4,
+            max_tokens,
+        );
+        let available = max_chars.saturating_sub(notice.len());
+        let truncated = char_truncate(&input, available);
+        let output = format!("{}{}", truncated, notice);
+        assert!(output.contains("[squeez: agent prompt truncated"));
+        assert!(output.len() < input.len() + notice.len() + 10);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub trait Handler {
 pub mod build;
 pub mod cloud;
 pub mod compress_md;
+pub mod compress_prompt;
 pub mod data_tool;
 pub mod database;
 pub mod docker;

--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -35,6 +35,7 @@ summarize_threshold_lines = 300\n\
 dedup_min = 2\n\
 read_max_lines = 300\n\
 grep_max_results = 100\n\
+agent_prompt_max_tokens = 2000\n\
 \n\
 # Memory\n\
 memory_retention_days = 30\n\

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,10 @@ pub struct Config {
     /// Summary output shape: "prose" | "structured" | "auto".
     /// "auto" selects Structured when Intensity == Ultra, Prose otherwise.
     pub summary_format: String,
+    // ── Agent prompt compression ─────────────────────────────────────────────
+    /// Max token estimate for Agent/Task prompt before compression kicks in.
+    /// 0 = disabled. Default: 2000.
+    pub agent_prompt_max_tokens: usize,
 }
 
 impl Default for Config {
@@ -105,6 +109,7 @@ impl Default for Config {
             sig_mode_threshold_lines: 400,
             memory_file_warn_tokens: 1000,
             summary_format: "auto".to_string(),
+            agent_prompt_max_tokens: 2000,
         }
     }
 }
@@ -207,6 +212,10 @@ impl Config {
                             "prose" | "structured" | "auto" => v.to_string(),
                             _ => "auto".to_string(),
                         };
+                    }
+                    "agent_prompt_max_tokens" => {
+                        c.agent_prompt_max_tokens =
+                            v.parse().unwrap_or(c.agent_prompt_max_tokens)
                     }
                     _ => {}
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ fn main() {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::commands::compress_md::run(&rest));
         }
+        Some("compress-prompt") => {
+            std::process::exit(squeez::commands::compress_prompt::run());
+        }
         Some("setup") => {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::commands::setup::run_with_help(&rest));

--- a/tests/test_compress_prompt.rs
+++ b/tests/test_compress_prompt.rs
@@ -1,0 +1,72 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn squeez_bin() -> String {
+    format!(
+        "{}/target/debug/squeez",
+        env!("CARGO_MANIFEST_DIR")
+    )
+}
+
+/// Pipe `input` into `squeez compress-prompt` and return stdout.
+fn compress_prompt(input: &str) -> String {
+    let mut child = Command::new(squeez_bin())
+        .arg("compress-prompt")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("failed to spawn squeez compress-prompt");
+
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(input.as_bytes())
+        .unwrap();
+
+    let output = child.wait_with_output().expect("failed to wait");
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+/// Build a large markdown string (~10 000 chars, well over 2000 tokens).
+fn large_markdown() -> String {
+    let filler = "This is just really basically a simple description of the feature that the agent should implement completely.\n";
+    let mut s = String::from("# Implementation Plan\n\n## Overview\n\n");
+    while s.len() < 12_000 {
+        s.push_str("### Section\n\n");
+        s.push_str(filler);
+    }
+    s
+}
+
+#[test]
+fn short_prompt_passes_through_unchanged() {
+    let input = "# Short plan\n\nDo one thing.\n";
+    let out = compress_prompt(input);
+    // Under the default 2000-token budget — output must equal input exactly.
+    assert_eq!(out, input, "short prompt should be echoed verbatim");
+}
+
+#[test]
+fn large_prompt_is_shorter_than_input() {
+    let input = large_markdown();
+    let out = compress_prompt(&input);
+    assert!(
+        out.len() < input.len(),
+        "compressed output ({} bytes) should be shorter than input ({} bytes)",
+        out.len(),
+        input.len()
+    );
+}
+
+#[test]
+fn large_prompt_retains_key_headings() {
+    let input = large_markdown();
+    let out = compress_prompt(&input);
+    // The top-level heading must survive (headings are protected verbatim).
+    assert!(
+        out.contains("# Implementation Plan"),
+        "key heading must be present in compressed output"
+    );
+}


### PR DESCRIPTION
## Summary

- New `squeez compress-prompt` subcommand reads stdin, runs markdown compression via the existing `compress_md` pipeline (Ultra mode), and head-truncates with a notice if still over budget; echos unchanged when under the token budget
- New `agent_prompt_max_tokens` config field (default `2000`, `0` = disabled) with parser arm in `Config::from_str` and entry in the default `config.ini` written by `squeez setup`
- `hooks/pretooluse.sh`: new Agent/Task branch pipes `tool_input.prompt` through `squeez compress-prompt` and replaces it only when the output is strictly shorter than the input
- `src/hosts/claude_code.rs`: PreToolUse matcher extended from `"Bash"` to `"Bash|Read|Grep|Glob|Agent|Task"` so the new branch fires
- `tests/test_compress_prompt.rs`: integration test spawns the debug binary; asserts short prompt echoes verbatim, large markdown prompt is shorter than input, and key headings survive

## Motivation

In observed production sessions a single plan.md (1,754 lines, ~7,000+ tokens) was injected verbatim into every Agent/Task spawn. With multiple agent invocations per session this compounds quickly. squeez already compresses Bash output and Read/Grep/Glob inputs; this PR closes the gap for the prompt field, which is the single largest uncompressed input vector for multi-agent workflows.

## Test plan

- [ ] `cargo test` — all tests pass (162 unit + 3 new integration in `test_compress_prompt.rs`)
- [ ] `cargo build --release` — binary builds clean, zero-dep constraint preserved
- [ ] Manual: `echo "# Plan\n\nshort" | squeez compress-prompt` — echoes unchanged
- [ ] Manual: pipe a 1500-line markdown file — output is shorter, heading structure preserved
- [ ] After `squeez setup`: verify `~/.claude/settings.json` PreToolUse matcher includes `Agent|Task`
- [ ] Verify `~/.claude/squeez/config.ini` contains `agent_prompt_max_tokens = 2000`