### PR TITLE
fix: G0 health check misses top-level event-key hooks

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -14,14 +14,24 @@ _settings="$HOME/.claude/settings.json"
 if [ -f "$_settings" ]; then
     _has_squeez=$(python3 -c "
 import json, sys
+HOOK_EVENTS = ('PreToolUse', 'PostToolUse', 'SessionStart', 'UserPromptSubmit', 'Stop')
 try:
     d = json.load(open(sys.argv[1]))
-    hooks = d.get('hooks', {}) if isinstance(d, dict) else {}
-    for entries in hooks.values():
-        for e in (entries if isinstance(entries, list) else []):
-            for h in (e.get('hooks', []) if isinstance(e, dict) else []):
-                if 'squeez' in str(h.get('command', '')):
-                    print('ok'); sys.exit(0)
+    if not isinstance(d, dict):
+        print('ok'); sys.exit(0)
+    # Squeez writes hooks at top-level event keys; some other tools nest under 'hooks.*'.
+    # Check both shapes plus the statusLine slot.
+    candidates = [d.get('hooks', {}) if isinstance(d.get('hooks'), dict) else {}]
+    candidates.append({k: d.get(k) for k in HOOK_EVENTS if k in d})
+    for bucket in candidates:
+        for entries in bucket.values():
+            for e in (entries if isinstance(entries, list) else []):
+                for h in (e.get('hooks', []) if isinstance(e, dict) else []):
+                    if 'squeez' in str(h.get('command', '')):
+                        print('ok'); sys.exit(0)
+    sl = d.get('statusLine', {})
+    if isinstance(sl, dict) and 'squeez' in str(sl.get('command', '')):
+        print('ok'); sys.exit(0)
     print('missing')
 except Exception:
     print('ok')


### PR DESCRIPTION
Closes #91

Follow-up to #90. End-to-end testing of the new SessionStart health check produced a false `missing` alarm against a real installation where squeez hooks were correctly present.

**Cause:** squeez writes hooks at `settings.PreToolUse` (top-level), but the check only inspected `settings.hooks.PreToolUse`.

**Fix:** scan both buckets + the `statusLine` slot.

## Test plan
- [x] Verified against a real settings.json with squeez at top-level → returns `ok`
- [x] Verified against synthetic OMC-style settings.json without squeez → returns `missing`