### PR TITLE
feat(monitor): add Monitor tool to PostToolUse compress-output dispatch

### DIFF
--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -45,7 +45,7 @@ printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true
 # For Read/Grep/Glob: attempt output rewrite via updatedToolOutput.
 # compress-output prints hookSpecificOutput JSON if content is redundant or
 # oversized; prints nothing if the original should be kept as-is.
-if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ]; then
+if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ]; then
     rewrite=$(printf '%s' "$input" | "$SQUEEZ" compress-output "$tool" 2>/dev/null || true)
     if [ -n "$rewrite" ]; then
         printf '%s\n' "$rewrite"

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -65,6 +65,7 @@ fn detect(cmd: &str) -> Box<dyn Handler> {
         | "cat" | "head" | "tail" | "less" | "more" | "bat"
         | "bfs" => Box::new(FsHandler),
         "ugrep" => Box::new(TextProcHandler),
+        "monitor" => Box::new(GenericHandler),
         // JSON/YAML/IaC tools
         "jq" | "yq" | "terraform" | "tofu" | "helm" | "pulumi" => Box::new(DataToolHandler),
         // Text-processing tools: grep match output


### PR DESCRIPTION
## Summary

- Adds `Monitor` to the `posttooluse.sh` tool dispatch so its output runs through `squeez compress-output` (redundancy dedup + summarize fallback via `updatedToolOutput`)
- Routes `"monitor"` → `GenericHandler` in `filter.rs` for any Bash-path compression

Monitor (Claude Code v2.1.98) produces streaming event output that can be repetitive across calls. The existing compress-output pipeline applies without any changes to the Rust code.

## Test plan

- [ ] `cargo test` passes
- [ ] `grep Monitor hooks/posttooluse.sh` shows the tool in the dispatch list
- [ ] `grep monitor src/filter.rs` shows the GenericHandler mapping

Closes #99