### PR TITLE
feat(hooks): SubagentStop hook feeds sub-agent output into SessionContext

### DIFF
--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -42,7 +42,7 @@ except Exception:
 # Feed to track-result so Read/Grep/Glob update SessionContext (files, errors).
 printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true
 
-# For Read/Grep/Glob: attempt output rewrite via updatedToolOutput.
+# For Read/Grep/Glob/Monitor: attempt output rewrite via updatedToolOutput.
 # compress-output prints hookSpecificOutput JSON if content is redundant or
 # oversized; prints nothing if the original should be kept as-is.
 if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ]; then

--- a/hooks/subagent-stop.sh
+++ b/hooks/subagent-stop.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# squeez SubagentStop hook — feeds sub-agent final output into SessionContext.
+#
+# SubagentStop fires when a sub-agent spawned via Agent/Task completes.
+# Payload includes last_assistant_message (top-level), agent_id, and
+# agent_transcript_path. We extract file paths and errors from the final
+# message so the parent agent can dedup against what the sub-agent already saw.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+input=$(cat)
+
+# Wrap last_assistant_message into a tool_result-compatible JSON so that
+# track-result's existing extract_content() logic picks it up correctly.
+wrapped=$(printf '%s' "$input" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    msg = d.get('last_assistant_message', '')
+    if not isinstance(msg, str):
+        msg = str(msg)
+    # Emit a synthetic tool_result payload for track-result
+    print(json.dumps({
+        'tool_name': 'SubagentStop',
+        'tool_result': {'content': msg},
+        'agent_id': d.get('agent_id', ''),
+    }))
+except Exception:
+    sys.exit(0)
+" 2>/dev/null || true)
+
+if [ -n "$wrapped" ]; then
+    printf '%s' "$wrapped" | "$SQUEEZ" track-result SubagentStop 2>/dev/null || true
+fi
+
+# Track sub-agent spawn cost (~200K tokens/spawn heuristic, size=0 for now)
+"$SQUEEZ" track SubagentStop 0 2>/dev/null || true

--- a/src/commands/track_result.rs
+++ b/src/commands/track_result.rs
@@ -30,7 +30,11 @@ pub fn run_with_dir(tool: &str, raw: &str, sessions_dir: &Path) -> i32 {
     let file_path = extract_string_field(raw, "file_path");
     let pattern = extract_string_field(raw, "pattern");
     let path_arg = extract_string_field(raw, "path");
-    let content = extract_content(raw);
+    // SubagentStop wraps last_assistant_message as tool_result.content in the
+    // hook script, so extract_content() already handles it. For direct calls
+    // (e.g. tests) also check last_assistant_message at the top level.
+    let content = extract_content(raw)
+        .or_else(|| extract_string_field(raw, "last_assistant_message").map(|s| unescape(&s)));
 
     let mut ctx = SessionContext::load(sessions_dir);
 

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -21,6 +21,7 @@ use super::{memory_size, HostAdapter, HostCaps};
 const PRETOOLUSE_SCRIPT: &str = include_str!("../../hooks/pretooluse.sh");
 const SESSION_START_SCRIPT: &str = include_str!("../../hooks/session-start.sh");
 const POSTTOOLUSE_SCRIPT: &str = include_str!("../../hooks/posttooluse.sh");
+const SUBAGENT_STOP_SCRIPT: &str = include_str!("../../hooks/subagent-stop.sh");
 const STATUSLINE_SCRIPT: &str = include_str!("../../hooks/statusline.sh");
 
 /// Patches ~/.claude/settings.json to register squeez hooks + statusline.
@@ -106,6 +107,12 @@ if not has_squeez(settings["PostToolUse"]):
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "posttooluse.sh")}],
     })
 
+ensure_list("SubagentStop")
+if not has_squeez(settings["SubagentStop"]):
+    settings["SubagentStop"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "subagent-stop.sh")}],
+    })
+
 existing_status = settings.get("statusLine")
 existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
 squeez_cmd = "bash " + statusline_bin
@@ -149,7 +156,7 @@ except Exception as e:
 if not isinstance(settings, dict):
     sys.exit(0)
 
-for event in ("PreToolUse", "SessionStart", "PostToolUse"):
+for event in ("PreToolUse", "SessionStart", "PostToolUse", "SubagentStop"):
     arr = settings.get(event)
     if isinstance(arr, list):
         settings[event] = [
@@ -255,6 +262,7 @@ impl HostAdapter for ClaudeCodeAdapter {
         write_hook(&hooks, "pretooluse.sh", PRETOOLUSE_SCRIPT)?;
         write_hook(&hooks, "session-start.sh", SESSION_START_SCRIPT)?;
         write_hook(&hooks, "posttooluse.sh", POSTTOOLUSE_SCRIPT)?;
+        write_hook(&hooks, "subagent-stop.sh", SUBAGENT_STOP_SCRIPT)?;
         write_hook(&bin, "statusline.sh", STATUSLINE_SCRIPT)?;
 
         run_python(


### PR DESCRIPTION
## Summary

- New `hooks/subagent-stop.sh` — wraps `last_assistant_message` into a `track-result`-compatible payload so the parent agent's SessionContext is updated with files and errors the sub-agent encountered
- Registers `SubagentStop` in `~/.claude/settings.json` via `install()` / `uninstall()`
- `track_result.rs` gains a fallback to `last_assistant_message` for direct (non-wrapped) calls
- Tracks sub-agent spawn cost via `squeez track SubagentStop`

## Test plan

- [ ] `cargo test` passes
- [ ] `squeez setup` adds `SubagentStop` entry to `~/.claude/settings.json`
- [ ] `squeez uninstall` removes it
- [ ] Sub-agent file paths visible in `squeez seen-files` after a sub-agent run

Closes #98