### PR TITLE
feat(hooks): PreCompact + PostCompact lifecycle hooks

### DIFF
--- a/hooks/postcompact.sh
+++ b/hooks/postcompact.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# squeez PostCompact hook — re-arms squeez after context compaction.
+#
+# PostCompact fires after Claude Code compacts the context window. The model's
+# context is now shorter; session memory injected at SessionStart may have
+# been trimmed. We log the event and emit a brief re-arm reminder so the
+# model knows compression is still active for the remainder of the session.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+"$SQUEEZ" track PostCompact 0 2>/dev/null || true
+
+# Emit a terse re-arm note. Claude Code may surface this to the model
+# as a system-level context injection depending on hook output handling.
+printf '[squeez] context compacted — compression still active\n'

--- a/hooks/precompact.sh
+++ b/hooks/precompact.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# squeez PreCompact hook — logs compaction events for session efficiency metrics.
+#
+# PreCompact fires before Claude Code compacts the context window.
+# A hook can block compaction by exiting 2 or returning {"decision":"block"}.
+# squeez does not block — compaction is healthy. We only record the event
+# so session stats can show how often compaction occurred and at what call depth.
+set -euo pipefail
+
+SQUEEZ="$HOME/.claude/squeez/bin/squeez"
+if [ ! -x "$SQUEEZ" ]; then
+    _sq=$(command -v squeez 2>/dev/null || true)
+    [ -n "$_sq" ] && SQUEEZ="$_sq"
+fi
+[ ! -x "$SQUEEZ" ] && exit 0
+
+"$SQUEEZ" track PreCompact 0 2>/dev/null || true

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -22,6 +22,8 @@ const PRETOOLUSE_SCRIPT: &str = include_str!("../../hooks/pretooluse.sh");
 const SESSION_START_SCRIPT: &str = include_str!("../../hooks/session-start.sh");
 const POSTTOOLUSE_SCRIPT: &str = include_str!("../../hooks/posttooluse.sh");
 const SUBAGENT_STOP_SCRIPT: &str = include_str!("../../hooks/subagent-stop.sh");
+const PRECOMPACT_SCRIPT: &str = include_str!("../../hooks/precompact.sh");
+const POSTCOMPACT_SCRIPT: &str = include_str!("../../hooks/postcompact.sh");
 const STATUSLINE_SCRIPT: &str = include_str!("../../hooks/statusline.sh");
 
 /// Patches ~/.claude/settings.json to register squeez hooks + statusline.
@@ -113,6 +115,18 @@ if not has_squeez(settings["SubagentStop"]):
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "subagent-stop.sh")}],
     })
 
+ensure_list("PreCompact")
+if not has_squeez(settings["PreCompact"]):
+    settings["PreCompact"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "precompact.sh")}],
+    })
+
+ensure_list("PostCompact")
+if not has_squeez(settings["PostCompact"]):
+    settings["PostCompact"].append({
+        "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "postcompact.sh")}],
+    })
+
 existing_status = settings.get("statusLine")
 existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
 squeez_cmd = "bash " + statusline_bin
@@ -156,7 +170,7 @@ except Exception as e:
 if not isinstance(settings, dict):
     sys.exit(0)
 
-for event in ("PreToolUse", "SessionStart", "PostToolUse", "SubagentStop"):
+for event in ("PreToolUse", "SessionStart", "PostToolUse", "SubagentStop", "PreCompact", "PostCompact"):
     arr = settings.get(event)
     if isinstance(arr, list):
         settings[event] = [
@@ -263,6 +277,8 @@ impl HostAdapter for ClaudeCodeAdapter {
         write_hook(&hooks, "session-start.sh", SESSION_START_SCRIPT)?;
         write_hook(&hooks, "posttooluse.sh", POSTTOOLUSE_SCRIPT)?;
         write_hook(&hooks, "subagent-stop.sh", SUBAGENT_STOP_SCRIPT)?;
+        write_hook(&hooks, "precompact.sh", PRECOMPACT_SCRIPT)?;
+        write_hook(&hooks, "postcompact.sh", POSTCOMPACT_SCRIPT)?;
         write_hook(&bin, "statusline.sh", STATUSLINE_SCRIPT)?;
 
         run_python(


### PR DESCRIPTION
## Summary

- `hooks/precompact.sh` — fires before compaction, logs the event via `squeez track PreCompact`, exits 0 (allows compaction)
- `hooks/postcompact.sh` — fires after compaction, logs the event and emits a brief `[squeez] context compacted — compression still active` re-arm reminder
- Both registered in `~/.claude/settings.json` via `install()` and cleaned up by `uninstall()`
- Added to `PRECOMPACT_SCRIPT`/`POSTCOMPACT_SCRIPT` includes and `write_hook()` calls in `claude_code.rs`

## Test plan

- [ ] `cargo test` passes
- [ ] `squeez setup` adds `PreCompact` and `PostCompact` entries to `~/.claude/settings.json`
- [ ] `squeez uninstall` removes both entries
- [ ] Hook scripts present at `~/.claude/squeez/hooks/precompact.sh` and `postcompact.sh` after install

Closes #97