### PR TITLE
feat(compress): plug Agent/Task output, HTML bash, and PreCompact telemetry gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ No Makefile — all build tooling is Cargo-native.
 
 ## Architecture
 
-**squeez** is hook-based bash output compressor for five CLI agent hosts: Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI. It intercepts every tool invocation via host-specific hooks and runs output through a 4-stage compression pipeline before the model sees it. Claude Code hooks: PreToolUse → wrap/budget/prompt-compress, SessionStart → init, PostToolUse → track-result + updatedToolOutput rewrite (Read/Grep/Glob/Monitor), SubagentStop → feed sub-agent output into SessionContext, PreCompact → log event, PostCompact → re-arm reminder.
+**squeez** is hook-based bash output compressor for five CLI agent hosts: Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI. It intercepts every tool invocation via host-specific hooks and runs output through 4-stage compression pipeline before model sees it. Claude Code hooks: PreToolUse → wrap/budget/prompt-compress, SessionStart → init, PostToolUse → track-result + updatedToolOutput rewrite (Read/Grep/Glob/Monitor), SubagentStop → feed sub-agent output into SessionContext, PreCompact → log event, PostCompact → re-arm reminder.
 
 ### Host adapters (`src/hosts/`)
 

--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -45,7 +45,7 @@ printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true
 # For Read/Grep/Glob/Monitor: attempt output rewrite via updatedToolOutput.
 # compress-output prints hookSpecificOutput JSON if content is redundant or
 # oversized; prints nothing if the original should be kept as-is.
-if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ]; then
+if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ] || [ "$tool" = "Agent" ] || [ "$tool" = "Task" ]; then
     rewrite=$(printf '%s' "$input" | "$SQUEEZ" compress-output "$tool" 2>/dev/null || true)
     if [ -n "$rewrite" ]; then
         printf '%s\n' "$rewrite"

--- a/hooks/precompact.sh
+++ b/hooks/precompact.sh
@@ -14,4 +14,6 @@ if [ ! -x "$SQUEEZ" ]; then
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
-"$SQUEEZ" track PreCompact 0 2>/dev/null || true
+input=$(cat)
+ctx_bytes=${#input}
+"$SQUEEZ" track PreCompact "$ctx_bytes" 2>/dev/null || true

--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -937,6 +937,77 @@ fn make_large_claude_md() -> String {
     out
 }
 
+/// Minified SSR HTML page simulating `curl http://localhost:3000 | head -50`.
+/// Tests HTML-aware tag-stripping in NetworkHandler — 50 dense lines of HTML
+/// should compress to ≤30 lines of extracted text.
+fn make_curl_html_response() -> String {
+    let mut out = String::new();
+    out.push_str("<!DOCTYPE html><html lang=\"en\"><head><meta charSet=\"utf-8\"/>");
+    out.push_str("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"/>");
+    out.push_str("<title>Band World Cup</title>");
+    for i in 0..8 {
+        out.push_str(&format!(
+            "<link rel=\"stylesheet\" href=\"/_next/static/css/chunk-{}.css\"/>",
+            i
+        ));
+    }
+    out.push_str("</head><body><div id=\"__next\"><main class=\"min-h-screen\">");
+    for i in 0..30 {
+        out.push_str(&format!(
+            "<div class=\"section-{} container mx-auto px-4 py-8\"><h2 class=\"text-2xl font-bold\">Section {}</h2><p class=\"text-gray-600\">Content for section {} with nested markup and many attributes.</p><button class=\"btn btn-primary\" data-id=\"{}\">Action {}</button></div>",
+            i, i, i, i, i
+        ));
+    }
+    out.push_str("</main></div>");
+    for i in 0..5 {
+        out.push_str(&format!(
+            "<script src=\"/_next/static/chunks/chunk-{}.js\" defer></script>",
+            i
+        ));
+    }
+    out.push_str("</body></html>\n");
+    out
+}
+
+/// Explore-agent style markdown directory listing — simulates the 14.6 KB
+/// uncompressed agent output found in the session analysis.
+fn make_agent_directory_output() -> String {
+    let mut out = String::with_capacity(16_000);
+    out.push_str("Perfect! Now I have a comprehensive view. Let me create a well-organized summary.\n\n");
+    out.push_str("## Full Directory Structure Map\n\n");
+    let dirs = [
+        "app", "components", "lib", "hooks", "types", "utils",
+        "public", "styles", "config", "tests", "prisma", "scripts",
+    ];
+    for dir in &dirs {
+        out.push_str(&format!("### {}/\n\n", dir));
+        for j in 0..15 {
+            let ext = ["ts", "tsx", "json", "css", "md"][j % 5];
+            out.push_str(&format!(
+                "- `{}/module_{}.{}` — handles {} logic for the {} subsystem\n",
+                dir, j, ext, j, dir
+            ));
+        }
+        out.push('\n');
+    }
+    out.push_str("## Infrastructure Files\n\n");
+    for f in &[
+        "next.config.ts", "tsconfig.json", "package.json",
+        "tailwind.config.ts", "prisma/schema.prisma",
+        "docker-compose.yml", ".env.example", "Dockerfile",
+    ] {
+        out.push_str(&format!("- `{}` — project configuration\n", f));
+    }
+    out.push_str("\n## Key Dependencies\n\n");
+    for dep in &["next@16", "react@19", "prisma@6", "tailwindcss@4", "zod@3"] {
+        out.push_str(&format!("- `{}` — core runtime dependency\n", dep));
+    }
+    out.push_str("\n## Summary\n\n");
+    out.push_str("The project is a Next.js 16 application with 12 top-level directories, ");
+    out.push_str("180+ source files, and a Prisma-backed PostgreSQL database.\n");
+    out
+}
+
 // ─── Scenario construction ────────────────────────────────────────────────────
 
 fn build_scenarios(fixtures: &PathBuf) -> Vec<Scenario> {
@@ -1052,6 +1123,26 @@ fn build_scenarios(fixtures: &PathBuf) -> Vec<Scenario> {
         content: make_jest_failures(),
         required_keywords: vec!["FAIL".to_string(), "failed".to_string()],
         quality_mode: QualityMode::Signal,
+    });
+    // curl HTML response: minified SSR page — validates NetworkHandler HTML stripping.
+    // Quality: Keywords only (tags are stripped; no surviving HTML terms expected).
+    s.push(Scenario {
+        name: "curl_html_response".to_string(),
+        category: "bash_output".to_string(),
+        kind: ScenarioKind::Filter { hint: "curl http://localhost:3000".to_string() },
+        content: make_curl_html_response(),
+        required_keywords: vec!["Section".to_string()],
+        quality_mode: QualityMode::Keywords,
+    });
+    // agent_directory_output: Explore-agent markdown summary — validates that
+    // large agent tool results get compressed by the generic summarize pipeline.
+    s.push(Scenario {
+        name: "agent_directory_output".to_string(),
+        category: "bash_output".to_string(),
+        kind: ScenarioKind::Filter { hint: "bash".to_string() },
+        content: make_agent_directory_output(),
+        required_keywords: vec!["app".to_string()],
+        quality_mode: QualityMode::Keywords,
     });
 
     // ── Markdown / context scenarios ──────────────────────────────────────────

--- a/src/commands/network.rs
+++ b/src/commands/network.rs
@@ -15,6 +15,12 @@ impl Handler for NetworkHandler {
             return extract_graphql_error(&lines);
         }
 
+        // HTML response: strip tags so 50 lines of minified HTML don't flood context.
+        if is_html_response(&lines) {
+            let text_lines = strip_html_tags(lines);
+            return truncation::apply(text_lines, 30, truncation::Keep::Head);
+        }
+
         let filtered: Vec<String> = lines
             .into_iter()
             .filter(|l| l.starts_with("< HTTP") || l.starts_with("HTTP/") || !l.starts_with("< "))
@@ -22,6 +28,58 @@ impl Handler for NetworkHandler {
 
         truncation::apply(filtered, 60, truncation::Keep::Head)
     }
+}
+
+fn is_html_response(lines: &[String]) -> bool {
+    lines.first().map(|l| {
+        let t = l.trim().to_lowercase();
+        t.starts_with("<!doctype") || t.starts_with("<html")
+    }).unwrap_or(false)
+}
+
+fn strip_html_tags(lines: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in lines {
+        let text = strip_tags_from_line(&line);
+        let text = text.trim().to_string();
+        if !text.is_empty() {
+            out.push(text);
+        }
+    }
+    out
+}
+
+/// Remove all `<…>` spans, replace each closing `>` with a space, then
+/// collapse runs of whitespace so the extracted text stays readable.
+pub fn strip_tags_from_line(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut in_tag = false;
+    for c in s.chars() {
+        match c {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                out.push(' ');
+            }
+            _ if !in_tag => out.push(c),
+            _ => {}
+        }
+    }
+    // Collapse consecutive spaces into one.
+    let mut result = String::with_capacity(out.len());
+    let mut prev_space = false;
+    for c in out.chars() {
+        if c == ' ' || c == '\t' {
+            if !prev_space {
+                result.push(' ');
+            }
+            prev_space = true;
+        } else {
+            result.push(c);
+            prev_space = false;
+        }
+    }
+    result
 }
 
 fn extract_graphql_error(lines: &[String]) -> Vec<String> {

--- a/tests/test_agent_compress_output.rs
+++ b/tests/test_agent_compress_output.rs
@@ -1,0 +1,124 @@
+use squeez::commands::compress_output;
+use squeez::config::Config;
+
+fn tmp() -> std::path::PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let d = std::env::temp_dir().join(format!(
+        "squeez_agent_co_{}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        n
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[test]
+fn agent_small_output_not_rewritten() {
+    let dir = tmp();
+    let cfg = Config::default();
+    let json = r#"{"tool_name":"Agent","tool_result":{"content":"Done. Project explored."}}"#;
+    assert_eq!(compress_output::run_with(json, "Agent", &dir, &cfg), 0);
+    // Small output: no rewrite should occur (exits cleanly)
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn agent_large_output_summarized() {
+    let dir = tmp();
+    let mut cfg = Config::default();
+    cfg.redundancy_cache_enabled = false;
+
+    // 600+ lines — above summarize_threshold_lines (default 300)
+    let mut content = String::from("## Full Directory Structure\\n\\n");
+    for i in 0..120 {
+        content.push_str(&format!(
+            "- `src/module_{}/index.ts` — module {} implementation\\n",
+            i, i
+        ));
+        content.push_str(&format!(
+            "- `src/module_{}/types.ts` — module {} types\\n",
+            i, i
+        ));
+        content.push_str(&format!(
+            "- `src/module_{}/utils.ts` — module {} utilities\\n",
+            i, i
+        ));
+        content.push_str(&format!(
+            "- `src/module_{}/tests.ts` — module {} tests\\n",
+            i, i
+        ));
+        content.push_str(&format!(
+            "- `src/module_{}/README.md` — module {} docs\\n\\n",
+            i, i
+        ));
+    }
+    let json = format!(
+        r#"{{"tool_name":"Agent","tool_result":{{"content":"{}"}}}}"#,
+        content
+    );
+    let rewrite = compress_output::compute_rewrite(&json, "Agent", &dir, &cfg);
+    assert!(
+        rewrite.is_some(),
+        "expected summarize to fire for 600-line agent output"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn agent_identical_output_deduplicated() {
+    let dir = tmp();
+    let cfg = Config::default();
+
+    let lines: String = (0..60)
+        .map(|i| format!("line {}: agent output content for item {}", i, i))
+        .collect::<Vec<_>>()
+        .join("\\n");
+    let json = format!(
+        r#"{{"tool_name":"Agent","tool_result":{{"content":"{}"}}}}"#,
+        lines
+    );
+
+    // First call records the content
+    compress_output::run_with(&json, "Agent", &dir, &cfg);
+    // Second identical call should be deduplicated
+    let rewrite = compress_output::compute_rewrite(&json, "Agent", &dir, &cfg);
+    assert!(
+        rewrite.is_some(),
+        "second identical agent output should be deduplicated"
+    );
+    let note = rewrite.unwrap();
+    assert!(
+        note.contains("identical") || note.contains("similar"),
+        "expected dedup note, got: {}",
+        note
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn task_tool_same_pipeline_as_agent() {
+    let dir = tmp();
+    let cfg = Config::default();
+
+    let content: String = (0..60)
+        .map(|i| format!("task result line {}", i))
+        .collect::<Vec<_>>()
+        .join("\\n");
+    let json = format!(
+        r#"{{"tool_name":"Task","tool_result":{{"content":"{}"}}}}"#,
+        content
+    );
+
+    compress_output::run_with(&json, "Task", &dir, &cfg);
+    let rewrite = compress_output::compute_rewrite(&json, "Task", &dir, &cfg);
+    assert!(
+        rewrite.is_some(),
+        "Task tool should deduplicate identical output same as Agent"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_network.rs
+++ b/tests/test_network.rs
@@ -1,4 +1,5 @@
-use squeez::commands::{network::NetworkHandler, Handler};
+use squeez::commands::network::{strip_tags_from_line, NetworkHandler};
+use squeez::commands::Handler;
 use squeez::config::Config;
 
 #[test]
@@ -24,4 +25,70 @@ fn graphql_error_extracts_message() {
         NetworkHandler.compress("curl http://localhost/graphql", lines, &Config::default());
     assert!(result.iter().any(|l| l.contains("Service not found")));
     assert!(result.iter().any(|l| l.contains("INTERNAL_SERVER_ERROR")));
+}
+
+#[test]
+fn html_response_strips_tags_preserves_text() {
+    let lines = vec![
+        "<!DOCTYPE html><html lang=\"en\"><head><title>My App</title></head><body>".to_string(),
+        "<div class=\"container\"><h1>Hello World</h1><p>Some content here.</p></div>".to_string(),
+        "<div class=\"footer\"><p>Footer text</p></div>".to_string(),
+        "</body></html>".to_string(),
+    ];
+    let result = NetworkHandler.compress("curl http://localhost:3000", lines, &Config::default());
+    // No angle brackets should remain
+    assert!(
+        !result.iter().any(|l| l.contains('<') || l.contains('>')),
+        "HTML tags should be stripped: {:?}",
+        result
+    );
+    // Meaningful text preserved
+    assert!(result.iter().any(|l| l.contains("Hello World")));
+    assert!(result.iter().any(|l| l.contains("Footer text")));
+}
+
+#[test]
+fn html_response_truncated_to_30_text_lines() {
+    let mut lines = vec!["<!DOCTYPE html><html>".to_string()];
+    for i in 0..100 {
+        lines.push(format!(
+            "<div class=\"s-{}\"><p>Section {} content</p></div>",
+            i, i
+        ));
+    }
+    lines.push("</html>".to_string());
+    let result = NetworkHandler.compress("curl http://localhost:3000", lines, &Config::default());
+    // 30 text lines + 1 truncation notice
+    assert!(result.len() <= 32, "expected ≤32 lines, got {}", result.len());
+}
+
+#[test]
+fn html_doctype_lowercase_detected() {
+    let lines = vec![
+        "<!doctype html><html><body><p>lowercase doctype</p></body></html>".to_string(),
+    ];
+    let result = NetworkHandler.compress("curl http://example.com", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("lowercase doctype")));
+    assert!(!result.iter().any(|l| l.contains('<')));
+}
+
+#[test]
+fn non_html_json_response_unchanged() {
+    let lines = vec![
+        "< HTTP/1.1 200 OK".to_string(),
+        "{\"status\": \"ok\", \"data\": 42}".to_string(),
+    ];
+    let result = NetworkHandler.compress("curl https://api.example.com", lines, &Config::default());
+    assert!(result.iter().any(|l| l.contains("200 OK") || l.contains("status")));
+    // JSON braces must survive (no HTML stripping applied)
+    assert!(result.iter().any(|l| l.contains('{')));
+}
+
+#[test]
+fn strip_tags_from_line_removes_attributes() {
+    let input = "<div class=\"foo\" data-id=\"42\"><span>text content</span></div>";
+    let result = strip_tags_from_line(input);
+    assert!(!result.contains('<'));
+    assert!(!result.contains('>'));
+    assert!(result.contains("text content"));
 }


### PR DESCRIPTION
## Summary

- **PostToolUse:Agent/Task**: add `Agent` and `Task` to `compress-output` dispatch — 14.6 KB Explore agent output now flows through redundancy check + summarize pipeline
- **HTML bash output**: `NetworkHandler` detects `<!DOCTYPE`/`<html`, strips tags, truncates to 30 text lines (curl SSR pages: 71.3% reduction)
- **PreCompact telemetry**: `precompact.sh` reads stdin byte count instead of passing hardcoded `0` to `squeez track`
- **Benchmarks + tests**: 2 new scenarios (`curl_html_response` 71.3%, `agent_directory_output` 95.0%), 9 new tests

## Benchmark results

```
curl_html_response      2181tk → 626tk   71.3%  ✅
agent_directory_output  3348tk → 167tk   95.0%  ✅
```

## Test plan

- [x] `cargo test` — all tests green (no regressions)
- [x] `cargo test --test test_network` — 7 tests pass (5 new HTML tests)
- [x] `cargo test --test test_agent_compress_output` — 4 tests pass (all new)
- [x] `./target/release/squeez benchmark --scenario curl_html_response` — 71.3% ✅
- [x] `./target/release/squeez benchmark --scenario agent_directory_output` — 95.0% ✅

Closes #109