### PR TITLE
fix(opencode): shell-quote bash command before prepending `squeez wrap`

### DIFF
--- a/opencode-plugin/squeez.js
+++ b/opencode-plugin/squeez.js
@@ -99,7 +99,14 @@ export default {
           if (command.startsWith(SQUEEZ_BIN)) return;
           if (command.includes("squeez wrap")) return;
           if (command.startsWith("--no-squeez")) return;
-          output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
+          // Shell-quote the command before prepending `squeez wrap`. Without
+          // this, multi-line `python3 -c "..."`, `bash -c '...'`, and quoted
+          // `git commit -m "msg with spaces"` are split into separate argv
+          // tokens by the host shell and end up with `-c` getting no argument,
+          // pathspec errors on commit messages, etc. Matches what the
+          // claude-code Python hook does with `shlex.quote(cmd)`.
+          const quoted = "'" + command.replace(/'/g, "'\\''") + "'";
+          output.args.command = `${SQUEEZ_BIN} wrap ${quoted}`;
           return;
         }
 

--- a/tests/test_hosts_opencode.rs
+++ b/tests/test_hosts_opencode.rs
@@ -69,6 +69,15 @@ fn opencode_install_drops_plugin_file() {
         assert!(body.contains("tool.execute.before"));
         assert!(body.contains("tool.execute.after"));
         assert!(body.contains("session.created"));
+        // The bash-rewrite path MUST single-quote the command before
+        // prepending `squeez wrap`, otherwise multi-line `python3 -c`,
+        // `bash -c`, and quoted `git commit -m "..."` are split into
+        // separate argv tokens by the host shell and break.
+        assert!(
+            body.contains("command.replace(/'/g"),
+            "plugin must shell-quote the command before wrapping; \
+             raw template-literal concat splits multi-line / quoted args"
+        );
     });
 }
 


### PR DESCRIPTION
## Summary

The OpenCode plugin builds the rewritten Bash command via raw template-literal concatenation:

```js
// opencode-plugin/squeez.js:102 (before)
output.args.command = `${SQUEEZ_BIN} wrap ${command}`;
```

When OpenCode then executes that string through its host shell, the original `command`'s embedded quotes and newlines aren't preserved. The shell tokenizes on whitespace, so:

- multi-line `python3 -c "<script>"` → `-c` gets *no* argument; the script body is interpreted line-by-line by `sh` (`sh: 2: import: not found`, syntax errors)
- `bash -c '<heredoc>'` → `bash: -c: option requires an argument`
- `git commit -m "extract: 30 questions"` → `git` receives `extract:`, `30`, `questions` as three separate pathspec tokens and produces an empty commit
- `find ".../State MSA Fraud and Other data" -type f` → `find: ‘.../State’: No such file or directory`

The agent then retries, burning tokens. This is the same problem `shlex.quote(cmd)` already solves on the claude-code Python side (`hooks/pretooluse.sh`) — only the OpenCode JS plugin diverged.

## Fix

Wrap `command` in single quotes and replace embedded `'` with the canonical `'\''` (close, escape, reopen) sequence before prefixing `squeez wrap`. This is the standard safe-shell-quote idiom and matches `shlex.quote` exactly.

```js
// after
const quoted = "'" + command.replace(/'/g, "'\\''") + "'";
output.args.command = `${SQUEEZ_BIN} wrap ${quoted}`;
```

## Reproducer

In an OpenCode session with squeez installed:

```
python3 -c "import os
print(os.getcwd())"
```

**Before:**
```
# squeez [python3] 52→52 tokens (-0%) 51ms [adaptive: Full]
Argument expected for the -c option
sh: 2: import: not found
```

**After:**
```
# squeez [python3] 52→17 tokens (-67%) 48ms [adaptive: Full]
/workspace
```

## Empirical impact

Measured on a real agent run (claude-sonnet-4-6, opencode harness, 30 data-science questions, KramaBench legal slice):

| | Before | After |
|---|---:|---:|
| Broken commands (4 quote-mangle categories combined) | **163** / 1,396 bash calls (11.7%) | **0** |
| Total run cost (sum of per-message OpenCode billing) | $98.77 | $71.22 (−27.9%) |
| Assistant message count | 2,199 | 1,374 (−37.5%) |

## Test

`tests/test_hosts_opencode.rs::opencode_install_drops_plugin_file` now asserts the rendered plugin body contains `command.replace(/'/g`, locking in the shell-quote step so a future regression would fail CI. Existing 7 opencode-adapter tests still pass.

## Test plan

- [x] `cargo test --test test_hosts_opencode` — 7/7 pass
- [x] `node --check opencode-plugin/squeez.js` — JS syntax OK
- [x] Manual repro of the four failure modes (`python3 -c`, `bash -c`, `git commit -m`, `find "path with space"`) — all return correct output post-patch