### PR TITLE
feat(hosts): add Pi adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Builds from [crates.io](https://crates.io/crates/squeez). Requires Rust stable. 
 | **OpenCode** | `~/.config/opencode/AGENTS.md` | ✅ native | ✅ native | ✅ native | Plugin at `~/.config/opencode/plugins/squeez.js`; MCP tool calls skip hooks (upstream sst/opencode#2319) |
 | **Gemini CLI** | `~/.gemini/GEMINI.md` | ✅ native | ✅ native | 🟡 soft via `GEMINI.md` | `BeforeTool` rewrite schema pending upstream docs ([google-gemini/gemini-cli#25629](https://github.com/google-gemini/gemini-cli/issues/25629)) |
 | **Codex CLI** | `~/.codex/AGENTS.md` | ✅ native | ✅ native | 🟡 soft via `AGENTS.md` | `apply_patch` hooks landed in 0.123.0 ([#18391](https://github.com/openai/codex/pull/18391)); `updatedInput` + `read_file`/`grep` hook surface still pending ([openai/codex#18491](https://github.com/openai/codex/issues/18491)) |
+| **Pi** | `~/.pi/agent/skills/squeez/SKILL.md` | ✅ native | ✅ via skill | ✅ native | TypeScript extension at `~/.pi/agent/extensions/squeez/index.ts`; restart Pi after setup |
 
 ### Manage
 
@@ -70,7 +71,7 @@ squeez uninstall              # remove squeez entries from every detected host
 squeez uninstall --host=<slug>
 ```
 
-Slugs: `claude-code` / `copilot` / `opencode` / `gemini` / `codex`.
+Slugs: `claude-code` / `copilot` / `opencode` / `gemini` / `codex` / `pi`.
 
 After install, restart the CLI you use to pick up the new hooks.
 
@@ -491,6 +492,10 @@ Refresh memory manually:
 SQUEEZ_DIR=~/.copilot/squeez ~/.claude/squeez/bin/squeez init --copilot
 ```
 
+### Pi
+
+TypeScript extension installed at `~/.pi/agent/extensions/squeez/index.ts`. Pi auto-discovers extensions from that directory — no settings patching needed. Session memory is injected via a skill at `~/.pi/agent/skills/squeez/SKILL.md`; Pi includes the skill description in every system prompt and loads full instructions on demand. Unlike other hosts, Pi achieves `BUDGET_HARD` output compression via the `tool_result` event (return-patch API), not just soft hints.
+
 ---
 
 ## Local development
@@ -527,6 +532,12 @@ gh pr create --base main --title "Short title" --body "Description"
 CI runs `cargo test`, `bench/run.sh`, `bench/run_context.sh`, and `squeez benchmark` on every push and pull request.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for coding standards.
+
+---
+
+## Similar projects
+
+There is an unrelated project with the same name at [KRLabsOrg/squeez](https://github.com/KRLabsOrg/squeez). This project (claudioemmanuel/squeez) is a hook-based token compressor for AI coding CLIs.
 
 ---
 

--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -1,0 +1,81 @@
+// squeez extension for Pi coding agent (https://pi.dev)
+// Capabilities: BASH_WRAP + SESSION_MEM + BUDGET_HARD
+//
+// Events wired:
+//   session_start          → squeez init --host=pi
+//   tool_call              → mutates bash command → squeez wrap <cmd>
+//   tool_result            → pipes text through squeez filter, returns compressed
+//   session_before_compact → squeez track PreCompact <size>
+import { spawnSync } from "child_process";
+import { accessSync, constants } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+const SQUEEZ_DIR = join(homedir(), ".pi", "agent", "squeez");
+
+function squeezBin(): string {
+  const home = homedir();
+  for (const candidate of [
+    join(home, ".claude", "squeez", "bin", "squeez"),
+    join(home, ".pi", "agent", "squeez", "bin", "squeez"),
+  ]) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  return "squeez";
+}
+
+function shellQuote(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+export default function (pi: any) {
+  pi.on("session_start", async (_event: any, _ctx: any) => {
+    const sq = squeezBin();
+    spawnSync(sq, ["init", "--host=pi"], {
+      env: { ...process.env, SQUEEZ_DIR },
+      timeout: 5000,
+    });
+  });
+
+  pi.on("tool_call", async (event: any, _ctx: any) => {
+    const tool: string = event.toolName ?? "";
+    if (!["bash", "Bash", "run_shell_command", "shell"].includes(tool)) return;
+    const cmd: unknown = event.input?.command;
+    if (!cmd || typeof cmd !== "string") return;
+    const sq = squeezBin();
+    if (cmd.includes("squeez wrap") || cmd.startsWith("--no-squeez")) return;
+    event.input.command = `${sq} wrap ${shellQuote(cmd)}`;
+  });
+
+  pi.on("tool_result", async (event: any, _ctx: any) => {
+    const content: unknown = event.content;
+    if (!Array.isArray(content) || content.length === 0) return;
+    const text = (content as any[])
+      .filter((b) => b?.type === "text")
+      .map((b) => (b.text as string) ?? "")
+      .join("\n");
+    if (!text.trim()) return;
+    const sq = squeezBin();
+    const tool: string = event.toolName ?? "unknown";
+    const result = spawnSync(sq, ["filter", tool], {
+      input: text,
+      encoding: "utf8",
+      env: { ...process.env, SQUEEZ_DIR },
+      timeout: 3000,
+    });
+    if (result.status === 0 && result.stdout) {
+      return { content: [{ type: "text", text: result.stdout as string }] };
+    }
+  });
+
+  pi.on("session_before_compact", async (_event: any, _ctx: any) => {
+    const sq = squeezBin();
+    spawnSync(sq, ["track", "PreCompact", "0"], {
+      env: { ...process.env, SQUEEZ_DIR },
+      timeout: 3000,
+    });
+  });
+}

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -16,11 +16,13 @@ pub mod copilot;
 pub mod gemini;
 pub mod memory_size;
 pub mod opencode;
+pub mod pi;
 pub use claude_code::ClaudeCodeAdapter;
 pub use codex::CodexCliAdapter;
 pub use copilot::CopilotCliAdapter;
 pub use gemini::GeminiCliAdapter;
 pub use opencode::OpenCodeAdapter;
+pub use pi::PiAdapter;
 
 use std::path::{Path, PathBuf};
 
@@ -95,6 +97,7 @@ pub fn all_hosts() -> Vec<Box<dyn HostAdapter>> {
         Box::new(OpenCodeAdapter),
         Box::new(GeminiCliAdapter),
         Box::new(CodexCliAdapter),
+        Box::new(PiAdapter),
     ]
 }
 

--- a/src/hosts/pi.rs
+++ b/src/hosts/pi.rs
@@ -1,0 +1,200 @@
+//! Pi coding agent adapter (https://pi.dev)
+//!
+//! Pi auto-discovers TypeScript extensions from `~/.pi/agent/extensions/`.
+//! No JSON patching is needed — squeez writes its extension directly to
+//! `~/.pi/agent/extensions/squeez/index.ts` and Pi loads it on next start.
+//!
+//! Memory injection writes `~/.pi/agent/skills/squeez/SKILL.md`. Pi's skill
+//! system includes skill descriptions in every system prompt (progressive
+//! disclosure: full instructions load on-demand when the model invokes them).
+//!
+//! Capabilities: `BASH_WRAP | SESSION_MEM | BUDGET_HARD`.
+//! `BUDGET_HARD` is achieved via the `tool_result` event — the extension
+//! pipes tool output through `squeez filter <tool>` before it reaches the LLM.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::persona;
+use crate::config::Config;
+use crate::memory::Summary;
+use crate::session::home_dir;
+
+use super::{memory_size, HostAdapter, HostCaps};
+
+const EXTENSION_SCRIPT: &str = include_str!("../../hooks/pi-extension.ts");
+
+const SKILL_FRONTMATTER: &str =
+    "---\nname: squeez\ndescription: Always-on token compressor. Apply terse persona, keep tool output within budget, track cross-session context.\n---\n";
+
+pub struct PiAdapter;
+
+impl PiAdapter {
+    fn pi_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.pi/agent", home_dir()))
+    }
+    fn extension_dir() -> PathBuf {
+        Self::pi_dir().join("extensions").join("squeez")
+    }
+    fn skill_dir() -> PathBuf {
+        Self::pi_dir().join("skills").join("squeez")
+    }
+    fn extension_path() -> PathBuf {
+        Self::extension_dir().join("index.ts")
+    }
+    fn skill_md_path() -> PathBuf {
+        Self::skill_dir().join("SKILL.md")
+    }
+}
+
+impl HostAdapter for PiAdapter {
+    fn name(&self) -> &'static str {
+        "pi"
+    }
+
+    fn is_installed(&self) -> bool {
+        Self::pi_dir().exists()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        Self::pi_dir().join("squeez")
+    }
+
+    fn capabilities(&self) -> HostCaps {
+        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM | HostCaps::BUDGET_HARD
+    }
+
+    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
+        let ext_dir = Self::extension_dir();
+        std::fs::create_dir_all(&ext_dir)?;
+        std::fs::write(Self::extension_path(), EXTENSION_SCRIPT)?;
+
+        let skill_dir = Self::skill_dir();
+        std::fs::create_dir_all(&skill_dir)?;
+        let skill_path = Self::skill_md_path();
+        if !skill_path.exists() {
+            std::fs::write(&skill_path, SKILL_FRONTMATTER)?;
+        }
+        Ok(())
+    }
+
+    fn uninstall(&self) -> std::io::Result<()> {
+        let ext_dir = Self::extension_dir();
+        if ext_dir.exists() {
+            std::fs::remove_dir_all(&ext_dir)?;
+        }
+        let skill_dir = Self::skill_dir();
+        if skill_dir.exists() {
+            std::fs::remove_dir_all(&skill_dir)?;
+        }
+        Ok(())
+    }
+
+    fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
+        let path = Self::skill_md_path();
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let existing = std::fs::read_to_string(&path).unwrap_or_default();
+        let (frontmatter, body) = split_frontmatter(&existing);
+
+        let mut block = String::from("<!-- squeez:start -->\n");
+        if let Some(banner) =
+            memory_size::size_warning(&existing, "SKILL.md", cfg.memory_file_warn_tokens)
+        {
+            block.push_str(&banner);
+        }
+        block.push_str("## squeez — session context\n");
+        let budget_k = cfg.compact_threshold_tokens * 5 / 4 / 1000;
+        block.push_str(&format!(
+            "Context budget: ~{}K tokens | Compression: ON | Memory: ON | Persona: {}\n",
+            budget_k,
+            persona::as_str(cfg.persona)
+        ));
+        for s in summaries {
+            block.push_str(&format!("- {}\n", s.display_line()));
+        }
+        if summaries.is_empty() {
+            block.push_str("- No prior sessions recorded yet.\n");
+        }
+        let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
+        if !persona_text.is_empty() {
+            block.push('\n');
+            block.push_str(persona_text);
+        }
+        block.push_str("<!-- squeez:end -->\n");
+
+        let cleaned_body = strip_squeez_block(body);
+        let new_body = format!("{}\n{}", block, cleaned_body.trim_start());
+        let fm = if frontmatter.is_empty() {
+            SKILL_FRONTMATTER.to_string()
+        } else {
+            frontmatter.to_string()
+        };
+        std::fs::write(&path, format!("{}{}", fm, new_body))
+    }
+}
+
+/// Split a markdown file into `(frontmatter, body)`.
+/// `frontmatter` includes both `---` delimiters and their newlines.
+/// Returns `("", s)` when no valid frontmatter is found.
+fn split_frontmatter(s: &str) -> (&str, &str) {
+    if !s.starts_with("---\n") {
+        return ("", s);
+    }
+    if let Some(end_offset) = s[4..].find("\n---\n") {
+        let split = 4 + end_offset + 5;
+        (&s[..split], &s[split..])
+    } else {
+        ("", s)
+    }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_squeez_block_inside_existing_skill_md() {
+        let s = "# context\n<!-- squeez:start -->\nfoo\n<!-- squeez:end -->\n## after\n";
+        let out = strip_squeez_block(s);
+        assert!(!out.contains("<!-- squeez:start -->"));
+        assert!(out.contains("# context"));
+        assert!(out.contains("## after"));
+    }
+
+    #[test]
+    fn split_frontmatter_extracts_yaml_block() {
+        let s = "---\nname: squeez\n---\nbody here\n";
+        let (fm, body) = split_frontmatter(s);
+        assert!(fm.contains("name: squeez"));
+        assert_eq!(body.trim(), "body here");
+    }
+
+    #[test]
+    fn split_frontmatter_no_frontmatter() {
+        let s = "no frontmatter here\n";
+        let (fm, body) = split_frontmatter(s);
+        assert!(fm.is_empty());
+        assert_eq!(body, "no frontmatter here\n");
+    }
+
+    #[test]
+    fn split_frontmatter_only_opening_delimiter() {
+        let s = "---\nincomplete";
+        let (fm, body) = split_frontmatter(s);
+        assert!(fm.is_empty());
+        assert_eq!(body, s);
+    }
+}

--- a/tests/test_hosts_pi.rs
+++ b/tests/test_hosts_pi.rs
@@ -1,0 +1,167 @@
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use squeez::config::Config;
+use squeez::hosts::{find, PiAdapter, HostAdapter, HostCaps};
+
+static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+fn tmp_home() -> PathBuf {
+    let uniq = format!(
+        "{}-{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        std::process::id()
+    );
+    let path = std::env::temp_dir().join(format!("squeez-pi-test-{uniq}"));
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+fn with_home<F: FnOnce(&PathBuf) -> R, R>(f: F) -> R {
+    let guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let home = tmp_home();
+    let prev_home = std::env::var("HOME").ok();
+    let prev_userprofile = std::env::var("USERPROFILE").ok();
+    std::env::set_var("HOME", &home);
+    std::env::remove_var("USERPROFILE");
+    let r = f(&home);
+    if let Some(h) = prev_home {
+        std::env::set_var("HOME", h);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    if let Some(u) = prev_userprofile {
+        std::env::set_var("USERPROFILE", u);
+    }
+    drop(guard);
+    r
+}
+
+#[test]
+fn pi_capabilities_bash_wrap_session_mem_budget_hard() {
+    let a = find("pi").expect("pi adapter");
+    let caps = a.capabilities();
+    assert!(caps.contains(HostCaps::BASH_WRAP));
+    assert!(caps.contains(HostCaps::SESSION_MEM));
+    assert!(caps.contains(HostCaps::BUDGET_HARD));
+    assert!(!caps.contains(HostCaps::BUDGET_SOFT));
+}
+
+#[test]
+fn pi_data_dir_under_home_pi_agent_squeez() {
+    with_home(|home| {
+        let a = PiAdapter;
+        assert_eq!(a.data_dir(), home.join(".pi/agent/squeez"));
+    });
+}
+
+#[test]
+fn pi_is_installed_when_pi_agent_dir_exists() {
+    with_home(|home| {
+        let a = PiAdapter;
+        assert!(!a.is_installed(), "should not detect Pi before dir exists");
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        assert!(a.is_installed(), "should detect Pi after dir created");
+    });
+}
+
+#[test]
+fn pi_install_writes_extension_and_skill() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let a = PiAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez"))
+            .expect("install");
+        let ext = home.join(".pi/agent/extensions/squeez/index.ts");
+        assert!(ext.exists(), "extension not written");
+        let body = std::fs::read_to_string(&ext).unwrap();
+        assert!(body.contains("squeez wrap"), "extension missing wrap logic");
+        assert!(body.contains("tool_result"), "extension missing tool_result handler");
+        let skill = home.join(".pi/agent/skills/squeez/SKILL.md");
+        assert!(skill.exists(), "SKILL.md not written");
+        let skill_body = std::fs::read_to_string(&skill).unwrap();
+        assert!(skill_body.contains("name: squeez"));
+    });
+}
+
+#[test]
+fn pi_install_is_idempotent() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let a = PiAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        let ext = home.join(".pi/agent/extensions/squeez/index.ts");
+        assert!(ext.exists());
+    });
+}
+
+#[test]
+fn pi_uninstall_removes_extension_and_skill() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let a = PiAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        a.uninstall().unwrap();
+        assert!(!home.join(".pi/agent/extensions/squeez").exists());
+        assert!(!home.join(".pi/agent/skills/squeez").exists());
+    });
+}
+
+#[test]
+fn pi_inject_memory_writes_marker_block() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let a = PiAdapter;
+        a.inject_memory(&Config::default(), &[]).expect("inject");
+        let skill = home.join(".pi/agent/skills/squeez/SKILL.md");
+        assert!(skill.exists(), "SKILL.md not created");
+        let body = std::fs::read_to_string(&skill).unwrap();
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("<!-- squeez:end -->"));
+        assert!(body.contains("name: squeez"), "frontmatter missing");
+    });
+}
+
+#[test]
+fn pi_inject_memory_is_idempotent() {
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".pi/agent")).unwrap();
+        let a = PiAdapter;
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let body = std::fs::read_to_string(
+            home.join(".pi/agent/skills/squeez/SKILL.md"),
+        )
+        .unwrap();
+        assert_eq!(
+            body.matches("<!-- squeez:start -->").count(),
+            1,
+            "duplicate squeez block after re-run"
+        );
+    });
+}
+
+#[test]
+fn pi_inject_memory_preserves_frontmatter() {
+    with_home(|home| {
+        let skill_dir = home.join(".pi/agent/skills/squeez");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: squeez\ndescription: custom\n---\nuser content\n",
+        )
+        .unwrap();
+        let a = PiAdapter;
+        a.inject_memory(&Config::default(), &[]).unwrap();
+        let body = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(body.contains("name: squeez"), "frontmatter not preserved");
+        assert!(body.contains("description: custom"), "frontmatter not preserved");
+        assert!(body.contains("<!-- squeez:start -->"));
+        assert!(body.contains("user content"), "user content dropped");
+    });
+}

--- a/tests/test_hosts_registry.rs
+++ b/tests/test_hosts_registry.rs
@@ -1,9 +1,9 @@
 use squeez::hosts::{all_hosts, find, HostCaps};
 
 #[test]
-fn registry_contains_five_adapters() {
+fn registry_contains_six_adapters() {
     let hosts = all_hosts();
-    assert_eq!(hosts.len(), 5, "expected 5 host adapters");
+    assert_eq!(hosts.len(), 6, "expected 6 host adapters");
 }
 
 #[test]
@@ -25,8 +25,8 @@ fn all_hosts_expose_bash_wrap_and_session_mem() {
 }
 
 #[test]
-fn claude_copilot_opencode_expose_budget_hard() {
-    for name in &["claude-code", "copilot", "opencode"] {
+fn claude_copilot_opencode_pi_expose_budget_hard() {
+    for name in &["claude-code", "copilot", "opencode", "pi"] {
         let a = find(name).expect(name);
         assert!(
             a.capabilities().contains(HostCaps::BUDGET_HARD),
@@ -50,7 +50,7 @@ fn gemini_and_codex_expose_budget_soft() {
 
 #[test]
 fn find_known_slugs() {
-    for slug in &["claude-code", "copilot", "opencode", "gemini", "codex"] {
+    for slug in &["claude-code", "copilot", "opencode", "gemini", "codex", "pi"] {
         assert!(find(slug).is_some(), "find({}) returned None", slug);
     }
 }


### PR DESCRIPTION
## Summary

- Adds Pi coding agent as the 6th supported host
- Pi has a TypeScript extension API with lifecycle hooks: `session_start`, `tool_call`, `tool_result`, `session_before_compact`
- `tool_result` accepts a return patch, so the Pi adapter achieves **`BUDGET_HARD`** via `squeez filter` — better than the soft-budget fallback used for Gemini/Codex
- Pi auto-discovers extensions from `~/.pi/agent/extensions/`, so no JSON patching is needed (unlike every other adapter)
- Memory is injected via a skill at `~/.pi/agent/skills/squeez/SKILL.md` — Pi includes skill descriptions in every system prompt
- Adds a "Similar projects" note in the README disambiguating from an unrelated repo of the same name

## Files

- `hooks/pi-extension.ts` — TS extension wiring all four lifecycle events
- `src/hosts/pi.rs` — Rust adapter (no JSON patching needed)
- `tests/test_hosts_pi.rs` — 8 tests: install/inject/uninstall/idempotency/frontmatter preservation
- `src/hosts/mod.rs` — register `PiAdapter` in the registry
- `tests/test_hosts_registry.rs` — bump count 5→6, add `pi` to slug + BUDGET_HARD assertions
- `README.md` — Pi row in hosts table, platform note, slug update, "Similar projects" section

## Test plan

- [x] `cargo test` — all 170+ tests pass including 8 new Pi tests
- [x] `cargo build` — clean
- [ ] Install on a machine with Pi present, restart Pi, verify `tool_result` compression works end-to-end
- [ ] Verify `squeez setup` auto-detects Pi when `~/.pi/agent/` exists

## Closes

- Closes #112 (name clash)
- Closes #113 (Pi support)