### PR TITLE
feat(economy): auto-curation nudges + cross-session handler stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,15 @@ burn_rate_warn_calls      = 20    # warn when < 20 calls remaining
 agent_spawn_cost          = 200000 # estimated tokens per Agent/Task spawn
 read_max_lines            = 0     # max lines injected into Read tool_input (0 = off)
 grep_max_results          = 0     # max results injected into Grep tool_input (0 = off)
+
+# ── Auto-curation nudges ──────────────────────────────────────
+nudge_enabled              = true   # emit [squeez: hint ...] markers on recurring patterns
+nudge_error_threshold      = 3      # fingerprint repeats before a nudge fires
+nudge_file_mod_threshold   = 5      # writes/creates to same path before nudge fires
+nudge_cmd_repeat_threshold = 4      # expensive-command repeats before nudge fires
+
+# ── Continuous handler calibration ────────────────────────────
+handler_stats_enabled      = true   # accumulate per-handler savings across sessions
 ```
 
 ### Adaptive intensity — Full / Ultra split

--- a/src/commands/mcp_server.rs
+++ b/src/commands/mcp_server.rs
@@ -187,6 +187,11 @@ const TOOLS: &[(&str, &str, &str)] = &[
         "Current context pressure: budget used %, calls remaining, tokens_saved this session, and an actionable recommendation (ok / compact_soon / use_state_first). Call this to decide whether to /compact or save state and /clear.",
         "{\"type\":\"object\",\"properties\":{}}",
     ),
+    (
+        "squeez_handler_stats",
+        "Per-handler cumulative compression stats across sessions: calls, in/out tokens, savings %. Flags under-performers (savings <10%) and over-performers (≥90%) when a handler has ≥5 calls. Use to spot handlers that warrant tuning or broader matching.",
+        "{\"type\":\"object\",\"properties\":{}}",
+    ),
 ];
 
 fn tools_list_response(id: &str) -> String {
@@ -238,6 +243,7 @@ fn tools_call_response(id: &str, line: &str) -> String {
         "squeez_agent_costs" => tool_agent_costs(),
         "squeez_session_efficiency" => tool_session_efficiency(),
         "squeez_context_pressure" => tool_context_pressure(),
+        "squeez_handler_stats" => tool_handler_stats(),
         other => return error_response(id, -32602, &format!("unknown tool: {}", other)),
     };
     text_result_response(id, &text)
@@ -757,6 +763,12 @@ fn tool_session_efficiency() -> String {
     crate::economy::efficiency::format_efficiency(&score)
 }
 
+/// Item 2: cumulative cross-session per-handler compression table.
+fn tool_handler_stats() -> String {
+    let stats = crate::economy::handler_stats::HandlerStats::load(&session::sessions_dir());
+    crate::economy::handler_stats::format_table(&stats)
+}
+
 /// Context pressure advisor: pressure %, calls remaining, tokens_saved, recommendation.
 fn tool_context_pressure() -> String {
     let ctx = load_ctx();
@@ -869,7 +881,7 @@ mod tests {
     fn handle_tools_list_returns_all_tools() {
         let req = "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}";
         let resp = handle_request(req).expect("must respond");
-        // All fourteen tool names appear in the response.
+        // All fifteen tool names appear in the response.
         for name in [
             "squeez_recent_calls",
             "squeez_seen_files",
@@ -885,6 +897,7 @@ mod tests {
             "squeez_agent_costs",
             "squeez_session_efficiency",
             "squeez_context_pressure",
+            "squeez_handler_stats",
         ] {
             assert!(resp.contains(name), "missing tool {}", name);
         }

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -265,7 +265,23 @@ pub fn run(cmd_str: &str) -> i32 {
         ctx.note_tool_tokens("Bash", input_tokens as u64);
         // Token economy: record burn rate
         ctx.note_burn(output_tokens as u64);
+
+        // ── Auto-curation nudges (item 1) ──────────────────────────────
+        let nudges = crate::economy::nudge::evaluate(
+            &mut ctx, cmd_str, &files, access, &errors, &config,
+        );
+        for n in &nudges {
+            println!("{}", n);
+        }
+
         ctx.save(&sessions_dir_pp);
+    }
+
+    // ── Continuous handler calibration (item 2) ────────────────────────
+    if config.handler_stats_enabled {
+        let mut stats = crate::economy::handler_stats::HandlerStats::load(&sessions_dir_pp);
+        stats.record(cmd_name, input_tokens as u64, output_tokens as u64);
+        stats.save(&sessions_dir_pp);
     }
 
     exit_code

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,6 +68,23 @@ pub struct Config {
     /// Pass through all output uncompressed when SQUEEZ_PLAN_MODE=1 env var is set.
     /// Default: true. Set to false to compress even in plan mode.
     pub plan_mode_passthrough: bool,
+    // ── Auto-curation nudges (item 1) ────────────────────────────────────────
+    /// Emit `[squeez: hint ...]` markers when recurring patterns are detected.
+    /// Default: true.
+    pub nudge_enabled: bool,
+    /// Recurrence count at which a repeated error fingerprint triggers a nudge.
+    /// Default: 3.
+    pub nudge_error_threshold: u32,
+    /// Modification count at which a repeatedly-edited file triggers a nudge.
+    /// Default: 5.
+    pub nudge_file_mod_threshold: u32,
+    /// Repeat count at which an expensive command triggers a nudge.
+    /// Default: 4.
+    pub nudge_cmd_repeat_threshold: u32,
+    // ── Continuous handler calibration (item 2) ──────────────────────────────
+    /// Accumulate per-handler in/out token counts in handler_stats.json so
+    /// `squeez_handler_stats` can surface under/over-performers. Default: true.
+    pub handler_stats_enabled: bool,
 }
 
 impl Default for Config {
@@ -114,6 +131,11 @@ impl Default for Config {
             summary_format: "auto".to_string(),
             agent_prompt_max_tokens: 2000,
             plan_mode_passthrough: true,
+            nudge_enabled: true,
+            nudge_error_threshold: 3,
+            nudge_file_mod_threshold: 5,
+            nudge_cmd_repeat_threshold: 4,
+            handler_stats_enabled: true,
         }
     }
 }
@@ -222,6 +244,20 @@ impl Config {
                             v.parse().unwrap_or(c.agent_prompt_max_tokens)
                     }
                     "plan_mode_passthrough" => c.plan_mode_passthrough = v == "true",
+                    "nudge_enabled" => c.nudge_enabled = v == "true",
+                    "nudge_error_threshold" => {
+                        c.nudge_error_threshold =
+                            v.parse().unwrap_or(c.nudge_error_threshold)
+                    }
+                    "nudge_file_mod_threshold" => {
+                        c.nudge_file_mod_threshold =
+                            v.parse().unwrap_or(c.nudge_file_mod_threshold)
+                    }
+                    "nudge_cmd_repeat_threshold" => {
+                        c.nudge_cmd_repeat_threshold =
+                            v.parse().unwrap_or(c.nudge_cmd_repeat_threshold)
+                    }
+                    "handler_stats_enabled" => c.handler_stats_enabled = v == "true",
                     _ => {}
                 }
             }

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -142,6 +142,21 @@ pub struct SessionContext {
     pub agent_estimated_tokens: u64,
     pub agent_spawn_log: Vec<AgentSpawnEntry>,
     pub burn_window: Vec<BurnEntry>,
+    // ── Nudges (auto-curation, item 1) ─────────────────────────────────
+    /// Per-session recurrence counters keyed by error fingerprint.
+    /// Parallel to `error_count_n`; persisted across sub-process invocations
+    /// within the same session via context.json.
+    pub error_count_fp: Vec<u64>,
+    pub error_count_n: Vec<u32>,
+    /// Per-session write/create counts for file paths (parallel arrays).
+    pub file_mod_path: Vec<String>,
+    pub file_mod_n: Vec<u32>,
+    /// Per-session repeat counts for expensive shell command names (parallel arrays).
+    pub cmd_repeat_name: Vec<String>,
+    pub cmd_repeat_n: Vec<u32>,
+    /// Nudge keys already emitted this session — prevents duplicate hints.
+    /// Format: `err:<hex>`, `file:<path>`, `cmd:<name>`.
+    pub nudged_keys: Vec<String>,
     // ── Tunables (phase 5) — set from Config at session start, not persisted ─
     pub max_call_log: usize,
     pub recent_window: usize,
@@ -172,6 +187,13 @@ impl Default for SessionContext {
             agent_estimated_tokens: 0,
             agent_spawn_log: Vec::new(),
             burn_window: Vec::new(),
+            error_count_fp: Vec::new(),
+            error_count_n: Vec::new(),
+            file_mod_path: Vec::new(),
+            file_mod_n: Vec::new(),
+            cmd_repeat_name: Vec::new(),
+            cmd_repeat_n: Vec::new(),
+            nudged_keys: Vec::new(),
             max_call_log: DEFAULT_MAX_CALL_LOG,
             recent_window: DEFAULT_RECENT_WINDOW,
             similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
@@ -481,6 +503,57 @@ impl SessionContext {
         }
     }
 
+    // ── Nudge counter helpers (item 1) ───────────────────────────────────
+
+    /// Bump the recurrence count for an error fingerprint. Returns the new count.
+    pub fn bump_error_count(&mut self, fp: u64) -> u32 {
+        if let Some(idx) = self.error_count_fp.iter().position(|f| *f == fp) {
+            let n = self.error_count_n[idx].saturating_add(1);
+            self.error_count_n[idx] = n;
+            n
+        } else {
+            self.error_count_fp.push(fp);
+            self.error_count_n.push(1);
+            1
+        }
+    }
+
+    /// Bump the modification count for a file path. Returns the new count.
+    pub fn bump_file_mod(&mut self, path: &str) -> u32 {
+        if let Some(idx) = self.file_mod_path.iter().position(|p| p == path) {
+            let n = self.file_mod_n[idx].saturating_add(1);
+            self.file_mod_n[idx] = n;
+            n
+        } else {
+            self.file_mod_path.push(path.to_string());
+            self.file_mod_n.push(1);
+            1
+        }
+    }
+
+    /// Bump the repeat count for a shell command name. Returns the new count.
+    pub fn bump_cmd_repeat(&mut self, cmd_name: &str) -> u32 {
+        if let Some(idx) = self.cmd_repeat_name.iter().position(|c| c == cmd_name) {
+            let n = self.cmd_repeat_n[idx].saturating_add(1);
+            self.cmd_repeat_n[idx] = n;
+            n
+        } else {
+            self.cmd_repeat_name.push(cmd_name.to_string());
+            self.cmd_repeat_n.push(1);
+            1
+        }
+    }
+
+    /// Mark a nudge key as already emitted. Returns true if newly inserted
+    /// (i.e. the caller should print the nudge), false if it was already there.
+    pub fn mark_nudged(&mut self, key: &str) -> bool {
+        if self.nudged_keys.iter().any(|k| k == key) {
+            return false;
+        }
+        self.nudged_keys.push(key.to_string());
+        true
+    }
+
     /// Record token usage by tool category.
     pub fn note_tool_tokens(&mut self, tool: &str, tokens: u64) {
         match tool.to_lowercase().as_str() {
@@ -636,6 +709,12 @@ impl SessionContext {
         let bw_tokens: Vec<u64> = self.burn_window.iter().map(|e| e.tokens).collect();
         let bw_ts: Vec<u64> = self.burn_window.iter().map(|e| e.ts).collect();
 
+        // Nudge counters as parallel arrays. u32 promoted to u64 for the
+        // existing array helper (lossless within u32 range).
+        let ec_n_u64: Vec<u64> = self.error_count_n.iter().map(|&n| n as u64).collect();
+        let fm_n_u64: Vec<u64> = self.file_mod_n.iter().map(|&n| n as u64).collect();
+        let cr_n_u64: Vec<u64> = self.cmd_repeat_n.iter().map(|&n| n as u64).collect();
+
         format!(
             "{{\"session_file\":\"{}\",\"call_counter\":{},\
 \"call_log_n\":{},\"call_log_cmd\":{},\"call_log_hash\":{},\"call_log_len\":{},\"call_log_short\":{},\
@@ -647,7 +726,11 @@ impl SessionContext {
 \"exact_dedup_hits\":{},\"fuzzy_dedup_hits\":{},\"summarize_triggers\":{},\"intensity_ultra_calls\":{},\
 \"agent_spawns\":{},\"agent_estimated_tokens\":{},\
 \"agent_spawn_log_call_n\":{},\"agent_spawn_log_tool\":{},\"agent_spawn_log_tokens\":{},\"agent_spawn_log_ts\":{},\
-\"burn_window_call_n\":{},\"burn_window_tokens\":{},\"burn_window_ts\":{}}}",
+\"burn_window_call_n\":{},\"burn_window_tokens\":{},\"burn_window_ts\":{},\
+\"error_count_fp\":{},\"error_count_n\":{},\
+\"file_mod_path\":{},\"file_mod_n\":{},\
+\"cmd_repeat_name\":{},\"cmd_repeat_n\":{},\
+\"nudged_keys\":{}}}",
             json_util::escape_str(&self.session_file),
             self.call_counter,
             json_util::u64_array(&cl_n),
@@ -682,6 +765,13 @@ impl SessionContext {
             json_util::u64_array(&bw_call_n),
             json_util::u64_array(&bw_tokens),
             json_util::u64_array(&bw_ts),
+            json_util::u64_array(&self.error_count_fp),
+            json_util::u64_array(&ec_n_u64),
+            json_util::str_array(&self.file_mod_path),
+            json_util::u64_array(&fm_n_u64),
+            json_util::str_array(&self.cmd_repeat_name),
+            json_util::u64_array(&cr_n_u64),
+            json_util::str_array(&self.nudged_keys),
         )
     }
 
@@ -805,6 +895,27 @@ impl SessionContext {
                 ts: bw_ts[i],
             });
         }
+
+        // Nudge counters — optional for backward compat with older context.json.
+        let ec_fp = json_util::map_u64_array(&map, "error_count_fp");
+        let ec_n = json_util::map_u64_array(&map, "error_count_n");
+        let ec_len = ec_fp.len().min(ec_n.len());
+        c.error_count_fp = ec_fp.iter().take(ec_len).copied().collect();
+        c.error_count_n = ec_n.iter().take(ec_len).map(|&n| n as u32).collect();
+
+        let fm_path = json_util::map_str_array(&map, "file_mod_path");
+        let fm_n = json_util::map_u64_array(&map, "file_mod_n");
+        let fm_len = fm_path.len().min(fm_n.len());
+        c.file_mod_path = fm_path.iter().take(fm_len).cloned().collect();
+        c.file_mod_n = fm_n.iter().take(fm_len).map(|&n| n as u32).collect();
+
+        let cr_name = json_util::map_str_array(&map, "cmd_repeat_name");
+        let cr_n = json_util::map_u64_array(&map, "cmd_repeat_n");
+        let cr_len = cr_name.len().min(cr_n.len());
+        c.cmd_repeat_name = cr_name.iter().take(cr_len).cloned().collect();
+        c.cmd_repeat_n = cr_n.iter().take(cr_len).map(|&n| n as u32).collect();
+
+        c.nudged_keys = json_util::map_str_array(&map, "nudged_keys");
 
         c
     }

--- a/src/economy/handler_stats.rs
+++ b/src/economy/handler_stats.rs
@@ -1,0 +1,309 @@
+// Continuous handler calibration (item 2 from Hermes-inspired roadmap).
+//
+// Aggregates per-handler {calls, in_tokens, out_tokens} across sessions in
+// `~/.claude/squeez/sessions/handler_stats.json` so `squeez_handler_stats`
+// can surface under-performers (savings <10%) and over-performers (>90%).
+//
+// Pure JSON over parallel arrays — no extra runtime deps, matches the rest
+// of squeez's persistence style.
+
+use std::path::Path;
+
+use crate::json_util;
+
+const MAX_HANDLERS: usize = 64;
+
+#[derive(Debug, Clone, Default)]
+pub struct HandlerStats {
+    pub names: Vec<String>,
+    pub calls: Vec<u64>,
+    pub in_tokens: Vec<u64>,
+    pub out_tokens: Vec<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct HandlerRow {
+    pub name: String,
+    pub calls: u64,
+    pub in_tokens: u64,
+    pub out_tokens: u64,
+    /// Compression ratio in basis points (0-10000 = 0-100%). 0 when in_tokens == 0.
+    pub savings_bp: u32,
+}
+
+impl HandlerStats {
+    pub fn load(sessions_dir: &Path) -> Self {
+        let path = sessions_dir.join("handler_stats.json");
+        let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        if size == 0 || size > crate::memory::MAX_FILE_BYTES {
+            return Self::default();
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(_) => return Self::default(),
+        };
+        let map = json_util::extract_all(&content);
+        let names = json_util::map_str_array(&map, "names");
+        let calls = json_util::map_u64_array(&map, "calls");
+        let in_tk = json_util::map_u64_array(&map, "in_tokens");
+        let out_tk = json_util::map_u64_array(&map, "out_tokens");
+        let n = names.len().min(calls.len()).min(in_tk.len()).min(out_tk.len());
+        Self {
+            names: names.into_iter().take(n).collect(),
+            calls: calls.into_iter().take(n).collect(),
+            in_tokens: in_tk.into_iter().take(n).collect(),
+            out_tokens: out_tk.into_iter().take(n).collect(),
+        }
+    }
+
+    pub fn save(&self, sessions_dir: &Path) {
+        let _ = std::fs::create_dir_all(sessions_dir);
+        let path = sessions_dir.join("handler_stats.json");
+        let tmp = path.with_extension("json.tmp");
+        let json = format!(
+            "{{\"names\":{},\"calls\":{},\"in_tokens\":{},\"out_tokens\":{}}}",
+            json_util::str_array(&self.names),
+            json_util::u64_array(&self.calls),
+            json_util::u64_array(&self.in_tokens),
+            json_util::u64_array(&self.out_tokens),
+        );
+        #[cfg(unix)]
+        {
+            use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(&tmp)
+            {
+                let _ = f.write_all(json.as_bytes());
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = std::fs::write(&tmp, &json);
+        }
+        let _ = std::fs::rename(&tmp, &path);
+    }
+
+    /// Record one bash invocation's accounting under the given handler name.
+    /// Idempotent on the array shape: appends a new slot the first time `name`
+    /// is seen, otherwise increments in place. Caps the table at MAX_HANDLERS.
+    pub fn record(&mut self, name: &str, in_tk: u64, out_tk: u64) {
+        if name.is_empty() {
+            return;
+        }
+        if let Some(idx) = self.names.iter().position(|n| n == name) {
+            self.calls[idx] = self.calls[idx].saturating_add(1);
+            self.in_tokens[idx] = self.in_tokens[idx].saturating_add(in_tk);
+            self.out_tokens[idx] = self.out_tokens[idx].saturating_add(out_tk);
+            return;
+        }
+        if self.names.len() >= MAX_HANDLERS {
+            return; // skip; rare in practice
+        }
+        self.names.push(name.to_string());
+        self.calls.push(1);
+        self.in_tokens.push(in_tk);
+        self.out_tokens.push(out_tk);
+    }
+
+    /// Sorted view: most-called first. Caller may further filter by savings.
+    pub fn rows(&self) -> Vec<HandlerRow> {
+        let mut rows: Vec<HandlerRow> = (0..self.names.len())
+            .map(|i| {
+                let in_tk = self.in_tokens[i];
+                let out_tk = self.out_tokens[i];
+                let savings_bp = if in_tk > 0 {
+                    let saved = in_tk.saturating_sub(out_tk);
+                    ((saved.saturating_mul(10_000)) / in_tk).min(10_000) as u32
+                } else {
+                    0
+                };
+                HandlerRow {
+                    name: self.names[i].clone(),
+                    calls: self.calls[i],
+                    in_tokens: in_tk,
+                    out_tokens: out_tk,
+                    savings_bp,
+                }
+            })
+            .collect();
+        rows.sort_by(|a, b| b.calls.cmp(&a.calls));
+        rows
+    }
+}
+
+/// Format the handler stats as a human-readable table. Used by both the MCP
+/// tool and the SessionStart banner (so output stays consistent).
+pub fn format_table(stats: &HandlerStats) -> String {
+    let rows = stats.rows();
+    if rows.is_empty() {
+        return "(no handler stats recorded yet — run a few commands first)".to_string();
+    }
+    let mut out = String::from("squeez handler stats (cumulative, cross-session)\n");
+    out.push_str("name             calls    in_tok    out_tok   saved\n");
+    for r in &rows {
+        out.push_str(&format!(
+            "{:<16} {:>5}  {:>8}  {:>8}   {:>4}%\n",
+            truncate(&r.name, 16),
+            r.calls,
+            r.in_tokens,
+            r.out_tokens,
+            r.savings_bp / 100,
+        ));
+    }
+    // Highlight under/over-performers (calls ≥ 5 to avoid noise).
+    let under: Vec<&HandlerRow> = rows.iter().filter(|r| r.calls >= 5 && r.savings_bp < 1_000).collect();
+    let over: Vec<&HandlerRow> = rows.iter().filter(|r| r.calls >= 5 && r.savings_bp >= 9_000).collect();
+    if !under.is_empty() {
+        out.push_str("\nunder-performers (savings <10%, ≥5 calls): ");
+        out.push_str(&under.iter().map(|r| r.name.as_str()).collect::<Vec<_>>().join(", "));
+        out.push('\n');
+    }
+    if !over.is_empty() {
+        out.push_str("over-performers (savings ≥90%, ≥5 calls): ");
+        out.push_str(&over.iter().map(|r| r.name.as_str()).collect::<Vec<_>>().join(", "));
+        out.push('\n');
+    }
+    out
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> std::path::PathBuf {
+        std::env::temp_dir().join(format!(
+            "squeez_hs_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .subsec_nanos()
+        ))
+    }
+
+    #[test]
+    fn record_inserts_new_handler() {
+        let mut s = HandlerStats::default();
+        s.record("git", 1000, 100);
+        assert_eq!(s.names, vec!["git"]);
+        assert_eq!(s.calls, vec![1]);
+        assert_eq!(s.in_tokens, vec![1000]);
+        assert_eq!(s.out_tokens, vec![100]);
+    }
+
+    #[test]
+    fn record_accumulates_existing_handler() {
+        let mut s = HandlerStats::default();
+        s.record("cargo", 500, 50);
+        s.record("cargo", 700, 70);
+        assert_eq!(s.calls, vec![2]);
+        assert_eq!(s.in_tokens, vec![1200]);
+        assert_eq!(s.out_tokens, vec![120]);
+    }
+
+    #[test]
+    fn rows_sorted_by_calls_desc() {
+        let mut s = HandlerStats::default();
+        s.record("a", 1, 1);
+        s.record("b", 1, 1);
+        s.record("b", 1, 1);
+        s.record("c", 1, 1);
+        s.record("c", 1, 1);
+        s.record("c", 1, 1);
+        let rows = s.rows();
+        assert_eq!(rows[0].name, "c");
+        assert_eq!(rows[1].name, "b");
+        assert_eq!(rows[2].name, "a");
+    }
+
+    #[test]
+    fn savings_bp_computed_correctly() {
+        let mut s = HandlerStats::default();
+        s.record("nine", 1000, 100); // 90% saved → 9000 bp
+        s.record("zero", 1000, 1000); // 0% saved → 0 bp
+        s.record("full", 100, 0); // 100% saved → 10_000 bp
+        let rows = s.rows();
+        let by_name = |n: &str| rows.iter().find(|r| r.name == n).unwrap().savings_bp;
+        assert_eq!(by_name("nine"), 9_000);
+        assert_eq!(by_name("zero"), 0);
+        assert_eq!(by_name("full"), 10_000);
+    }
+
+    #[test]
+    fn round_trip_persistence() {
+        let dir = tmp();
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut s = HandlerStats::default();
+        s.record("git", 1000, 200);
+        s.record("git", 500, 100);
+        s.record("cargo", 5000, 800);
+        s.save(&dir);
+
+        let loaded = HandlerStats::load(&dir);
+        assert_eq!(loaded.names, s.names);
+        assert_eq!(loaded.calls, s.calls);
+        assert_eq!(loaded.in_tokens, s.in_tokens);
+        assert_eq!(loaded.out_tokens, s.out_tokens);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tmp();
+        std::fs::create_dir_all(&dir).unwrap();
+        let loaded = HandlerStats::load(&dir);
+        assert!(loaded.names.is_empty());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cap_at_max_handlers() {
+        let mut s = HandlerStats::default();
+        for i in 0..(MAX_HANDLERS + 10) {
+            s.record(&format!("h{}", i), 100, 10);
+        }
+        assert_eq!(s.names.len(), MAX_HANDLERS);
+    }
+
+    #[test]
+    fn format_table_calls_out_under_and_over_performers() {
+        let mut s = HandlerStats::default();
+        // 5 calls of `bad` at 0% savings.
+        for _ in 0..5 {
+            s.record("bad", 100, 100);
+        }
+        // 5 calls of `good` at 95% savings.
+        for _ in 0..5 {
+            s.record("good", 1000, 50);
+        }
+        // Below-threshold (4 calls) should not be flagged.
+        for _ in 0..4 {
+            s.record("rare", 1000, 50);
+        }
+        let table = format_table(&s);
+        assert!(table.contains("under-performers"));
+        assert!(table.contains("bad"));
+        assert!(table.contains("over-performers"));
+        assert!(table.contains("good"));
+        // `rare` has 4 calls (<5) so it's not flagged.
+        assert!(!table.contains("under-performers") || !table.split('\n').any(|l| l.starts_with("under-performers") && l.contains("rare")));
+    }
+
+    #[test]
+    fn empty_stats_format_message() {
+        let s = HandlerStats::default();
+        assert!(format_table(&s).contains("no handler stats"));
+    }
+}

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -3,3 +3,5 @@ pub mod budget;
 pub mod burn_rate;
 pub mod calibrate;
 pub mod efficiency;
+pub mod handler_stats;
+pub mod nudge;

--- a/src/economy/nudge.rs
+++ b/src/economy/nudge.rs
@@ -1,0 +1,260 @@
+// Auto-curation nudges (item 1 from Hermes-inspired roadmap).
+//
+// When recurring patterns are detected within a session, emit a single
+// `[squeez: hint ...]` marker so the LLM is prompted to persist a learning,
+// commit, or batch work. Each pattern key fires at most once per session.
+//
+// Counters live on `SessionContext` (persisted in context.json) so they
+// survive across the per-call sub-process boundary.
+
+use crate::config::Config;
+use crate::context::cache::{FileAccess, SessionContext};
+use crate::context::hash::fnv1a_64;
+
+/// Evaluate the current call against the session's recurrence counters and
+/// return zero-or-more nudge hint lines. Mutates `ctx` to bump counters and
+/// record which keys have already been emitted (so the same hint never repeats).
+pub fn evaluate(
+    ctx: &mut SessionContext,
+    cmd: &str,
+    files: &[String],
+    file_access: FileAccess,
+    errors: &[String],
+    cfg: &Config,
+) -> Vec<String> {
+    if !cfg.nudge_enabled {
+        return Vec::new();
+    }
+
+    let mut hints: Vec<String> = Vec::new();
+
+    // Recurring errors: bump every observation, nudge at threshold.
+    for e in errors {
+        let normalized = crate::context::cache::normalize_error(e);
+        let fp = fnv1a_64(normalized.as_bytes());
+        let count = ctx.bump_error_count(fp);
+        if count >= cfg.nudge_error_threshold {
+            let key = format!("err:{:016x}", fp);
+            if ctx.mark_nudged(&key) {
+                let snippet: String = e.trim().chars().take(80).collect();
+                hints.push(format!(
+                    "[squeez: hint — error seen ×{}: \"{}\" — consider documenting the fix in CLAUDE.md/AGENTS.md]",
+                    count, snippet
+                ));
+            }
+        }
+    }
+
+    // Repeatedly-modified files. Only bump on writes/creates/deletes — reading
+    // a file 5 times isn't a curation signal, but editing it 5x without
+    // committing is.
+    let counts_write = matches!(
+        file_access,
+        FileAccess::Write | FileAccess::Created | FileAccess::Deleted
+    );
+    if counts_write {
+        for p in files {
+            let count = ctx.bump_file_mod(p);
+            if count >= cfg.nudge_file_mod_threshold {
+                let key = format!("file:{}", p);
+                if ctx.mark_nudged(&key) {
+                    hints.push(format!(
+                        "[squeez: hint — {} modified ×{} without commit — consider `git add` + `git commit`]",
+                        p, count
+                    ));
+                }
+            }
+        }
+    }
+
+    // Repeated expensive commands. We treat the first whitespace token as the
+    // command name (matches the convention used in wrap.rs for the bash header).
+    if let Some(cmd_name) = first_token(cmd) {
+        if is_expensive(cmd_name) {
+            let count = ctx.bump_cmd_repeat(cmd_name);
+            if count >= cfg.nudge_cmd_repeat_threshold {
+                let key = format!("cmd:{}", cmd_name);
+                if ctx.mark_nudged(&key) {
+                    hints.push(format!(
+                        "[squeez: hint — `{}` run ×{} — consider a script or `--no-squeez` cached invocation]",
+                        cmd_name, count
+                    ));
+                }
+            }
+        }
+    }
+
+    hints
+}
+
+/// Strip path prefix and return the first whitespace-separated token of `cmd`.
+/// `/usr/local/bin/cargo test` → `cargo`. Returns None for empty input.
+fn first_token(cmd: &str) -> Option<&str> {
+    let first = cmd.split_whitespace().next()?;
+    Some(first.rsplit('/').next().unwrap_or(first))
+}
+
+/// Commands whose repeated invocation suggests automation or a cached build.
+/// Conservative list: long-running builds, full test suites, and full repo
+/// scans. Quick read-only commands (`ls`, `cat`, `git status`) are excluded.
+fn is_expensive(name: &str) -> bool {
+    matches!(
+        name,
+        "cargo"
+            | "make"
+            | "cmake"
+            | "gradle"
+            | "mvn"
+            | "xcodebuild"
+            | "npm"
+            | "pnpm"
+            | "yarn"
+            | "bun"
+            | "jest"
+            | "vitest"
+            | "pytest"
+            | "playwright"
+            | "tsc"
+            | "eslint"
+            | "biome"
+            | "next"
+            | "terraform"
+            | "tofu"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> SessionContext {
+        SessionContext::default()
+    }
+
+    fn cfg() -> Config {
+        Config::default()
+    }
+
+    #[test]
+    fn no_nudge_below_threshold() {
+        let mut c = ctx();
+        let cfg = cfg();
+        // 2 occurrences of same error: below default threshold (3) → no hint.
+        let hints1 = evaluate(&mut c, "cargo build", &[], FileAccess::Read, &["error: foo".into()], &cfg);
+        let hints2 = evaluate(&mut c, "cargo build", &[], FileAccess::Read, &["error: foo".into()], &cfg);
+        assert!(hints1.is_empty());
+        assert!(hints2.is_empty());
+    }
+
+    #[test]
+    fn error_threshold_emits_once() {
+        let mut c = ctx();
+        let cfg = cfg();
+        let err = vec!["error: connection refused on tcp://10.0.0.1:5432".to_string()];
+        // Default threshold = 3. Calls 1, 2: no hint. Call 3: hint. Call 4+: no repeat.
+        evaluate(&mut c, "cmd", &[], FileAccess::Read, &err, &cfg);
+        evaluate(&mut c, "cmd", &[], FileAccess::Read, &err, &cfg);
+        let h3 = evaluate(&mut c, "cmd", &[], FileAccess::Read, &err, &cfg);
+        let h4 = evaluate(&mut c, "cmd", &[], FileAccess::Read, &err, &cfg);
+        assert_eq!(h3.len(), 1);
+        assert!(h3[0].contains("seen ×3"));
+        assert!(h4.is_empty());
+    }
+
+    #[test]
+    fn file_mod_threshold_counts_writes_only() {
+        let mut c = ctx();
+        let cfg = cfg();
+        let files = vec!["/foo.rs".to_string()];
+        // 5 read accesses → no nudge (reads don't count).
+        for _ in 0..5 {
+            let h = evaluate(&mut c, "cmd", &files, FileAccess::Read, &[], &cfg);
+            assert!(h.is_empty());
+        }
+        // 5 writes → nudge on the 5th.
+        for i in 1..=5 {
+            let h = evaluate(&mut c, "cmd", &files, FileAccess::Write, &[], &cfg);
+            if i < 5 {
+                assert!(h.is_empty(), "early nudge at i={}", i);
+            } else {
+                assert_eq!(h.len(), 1);
+                assert!(h[0].contains("/foo.rs"));
+                assert!(h[0].contains("×5"));
+            }
+        }
+    }
+
+    #[test]
+    fn cmd_repeat_threshold_only_for_expensive_commands() {
+        let mut c = ctx();
+        let cfg = cfg();
+        // 10 invocations of `ls` (cheap) → never nudges.
+        for _ in 0..10 {
+            let h = evaluate(&mut c, "ls -la", &[], FileAccess::Read, &[], &cfg);
+            assert!(h.is_empty());
+        }
+        // 4 invocations of `cargo` (expensive, threshold 4) → nudge on 4th.
+        for i in 1..=4 {
+            let h = evaluate(&mut c, "cargo test", &[], FileAccess::Read, &[], &cfg);
+            if i < 4 {
+                assert!(h.is_empty());
+            } else {
+                assert_eq!(h.len(), 1);
+                assert!(h[0].contains("cargo"));
+            }
+        }
+    }
+
+    #[test]
+    fn nudge_disabled_short_circuits() {
+        let mut c = ctx();
+        let mut cfg = cfg();
+        cfg.nudge_enabled = false;
+        for _ in 0..10 {
+            let h = evaluate(
+                &mut c,
+                "cargo build",
+                &["/x.rs".into()],
+                FileAccess::Write,
+                &["error: boom".into()],
+                &cfg,
+            );
+            assert!(h.is_empty());
+        }
+    }
+
+    #[test]
+    fn path_prefix_stripped_in_cmd_name() {
+        // `/usr/local/bin/cargo test` → counts under `cargo`, not full path.
+        assert_eq!(first_token("/usr/local/bin/cargo test"), Some("cargo"));
+        assert_eq!(first_token("cargo"), Some("cargo"));
+        assert_eq!(first_token(""), None);
+    }
+
+    #[test]
+    fn error_fingerprint_collapses_paths_and_digits() {
+        // Two errors that differ only in path and digits should bump the same
+        // counter — caller observes ×2, not two ×1 entries.
+        let mut c = ctx();
+        let cfg = cfg();
+        evaluate(
+            &mut c,
+            "cmd",
+            &[],
+            FileAccess::Read,
+            &["error: file /tmp/a.txt line 42 failed".into()],
+            &cfg,
+        );
+        evaluate(
+            &mut c,
+            "cmd",
+            &[],
+            FileAccess::Read,
+            &["error: file /var/log/b.txt line 99 failed".into()],
+            &cfg,
+        );
+        // Both bumped the same fingerprint → one entry, count = 2.
+        assert_eq!(c.error_count_fp.len(), 1);
+        assert_eq!(c.error_count_n[0], 2);
+    }
+}

--- a/tests/test_handler_stats.rs
+++ b/tests/test_handler_stats.rs
@@ -1,0 +1,136 @@
+// Integration tests for the continuous handler calibration aggregator.
+//
+// Unit tests for record/accumulate/sort live in src/economy/handler_stats.rs.
+// This file exercises the disk persistence layer end-to-end: cross-session
+// accumulation, format_table flagging, and graceful handling of a missing file.
+
+use squeez::economy::handler_stats::{format_table, HandlerStats};
+
+fn tmp_dir(label: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "squeez_hs_it_{}_{}",
+        label,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+#[test]
+fn accumulates_across_simulated_sessions() {
+    // Two separate "sessions" record into the same handler_stats.json:
+    // the second session reads what the first wrote and increments.
+    let dir = tmp_dir("crosssess");
+
+    {
+        let mut s = HandlerStats::load(&dir);
+        s.record("git", 800, 100);
+        s.record("cargo", 4000, 500);
+        s.save(&dir);
+    }
+
+    {
+        let mut s = HandlerStats::load(&dir);
+        s.record("git", 600, 50);
+        s.record("npm", 200, 180);
+        s.save(&dir);
+    }
+
+    let final_stats = HandlerStats::load(&dir);
+    let rows = final_stats.rows();
+
+    let by_name = |n: &str| rows.iter().find(|r| r.name == n).cloned();
+    let git = by_name("git").unwrap();
+    assert_eq!(git.calls, 2);
+    assert_eq!(git.in_tokens, 1400);
+    assert_eq!(git.out_tokens, 150);
+
+    let cargo = by_name("cargo").unwrap();
+    assert_eq!(cargo.calls, 1);
+
+    let npm = by_name("npm").unwrap();
+    assert_eq!(npm.calls, 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn format_table_lists_under_and_over_performers() {
+    let mut s = HandlerStats::default();
+    // `bad` — 8 calls, only 5% savings (under-performer).
+    for _ in 0..8 {
+        s.record("bad", 1000, 950);
+    }
+    // `good` — 6 calls, 95% savings (over-performer).
+    for _ in 0..6 {
+        s.record("good", 1000, 50);
+    }
+    // `mid` — 6 calls, 50% savings (neither).
+    for _ in 0..6 {
+        s.record("mid", 1000, 500);
+    }
+
+    let table = format_table(&s);
+    // The high-level table renders all three.
+    assert!(table.contains("bad"));
+    assert!(table.contains("good"));
+    assert!(table.contains("mid"));
+    // And it calls out the extremes by name.
+    assert!(table.contains("under-performers"));
+    assert!(table.contains("over-performers"));
+    let under_line = table
+        .lines()
+        .find(|l| l.starts_with("under-performers"))
+        .expect("missing under-performers line");
+    assert!(under_line.contains("bad"));
+    assert!(!under_line.contains("good"));
+    let over_line = table
+        .lines()
+        .find(|l| l.starts_with("over-performers"))
+        .expect("missing over-performers line");
+    assert!(over_line.contains("good"));
+    assert!(!over_line.contains("bad"));
+}
+
+#[test]
+fn missing_file_loads_as_empty_stats() {
+    let dir = tmp_dir("missing");
+    // No prior file written.
+    let s = HandlerStats::load(&dir);
+    assert!(s.names.is_empty());
+    assert!(s.calls.is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn rows_sorted_by_call_count_desc() {
+    let mut s = HandlerStats::default();
+    s.record("rare", 10, 1);
+    for _ in 0..3 {
+        s.record("often", 10, 1);
+    }
+    s.record("once", 10, 1);
+
+    let rows = s.rows();
+    assert_eq!(rows[0].name, "often");
+    assert!(rows[0].calls >= rows[1].calls);
+    assert!(rows[1].calls >= rows[2].calls);
+}
+
+#[test]
+fn savings_pct_renders_in_table() {
+    let mut s = HandlerStats::default();
+    // 10 calls of 80% savings — pct cell should read "80%".
+    for _ in 0..10 {
+        s.record("eighty", 1000, 200);
+    }
+    let table = format_table(&s);
+    let row_line = table
+        .lines()
+        .find(|l| l.starts_with("eighty"))
+        .expect("expected eighty row");
+    assert!(row_line.contains("80%"), "row: {:?}", row_line);
+}

--- a/tests/test_nudge.rs
+++ b/tests/test_nudge.rs
@@ -1,0 +1,157 @@
+// Integration tests for the auto-curation nudge engine.
+//
+// Unit tests for the in-memory state machine live alongside the module in
+// src/economy/nudge.rs. This file covers the end-to-end persistence path:
+// counters survive a save → reload cycle on context.json, and the same
+// nudge does not re-fire after a reload.
+
+use squeez::config::Config;
+use squeez::context::cache::{FileAccess, SessionContext};
+use squeez::economy::nudge;
+
+#[test]
+fn nudge_counters_round_trip_via_json() {
+    let mut ctx = SessionContext::default();
+    let cfg = Config::default();
+    let err = vec!["error: boom".to_string()];
+
+    // Bump error counter twice (below threshold). Then write/read context.json.
+    nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+    nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+
+    let json = ctx.to_json();
+    let restored = SessionContext::from_json(&json);
+
+    assert_eq!(restored.error_count_fp.len(), 1);
+    assert_eq!(restored.error_count_n[0], 2);
+}
+
+#[test]
+fn nudge_fires_after_reload_when_threshold_crossed() {
+    // Simulate the per-call sub-process boundary: bump twice, persist, reload,
+    // bump once more — the nudge must fire on this third call.
+    let cfg = Config::default();
+    let err = vec!["error: oops".to_string()];
+
+    let mut ctx = SessionContext::default();
+    nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+    nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+
+    let json = ctx.to_json();
+    let mut restored = SessionContext::from_json(&json);
+
+    let hints = nudge::evaluate(&mut restored, "cmd", &[], FileAccess::Read, &err, &cfg);
+    assert_eq!(hints.len(), 1);
+    assert!(hints[0].contains("seen ×3"));
+}
+
+#[test]
+fn nudge_does_not_repeat_after_reload() {
+    // Once a nudge has been emitted, it must stay quiet on subsequent calls
+    // — even after the context is round-tripped through disk.
+    let cfg = Config::default();
+    let err = vec!["error: x".to_string()];
+
+    let mut ctx = SessionContext::default();
+    for _ in 0..3 {
+        nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+    }
+    assert!(!ctx.nudged_keys.is_empty(), "first burst should mark the key");
+
+    let json = ctx.to_json();
+    let mut restored = SessionContext::from_json(&json);
+
+    // Two more bumps after reload — no fresh hint expected.
+    let h1 = nudge::evaluate(&mut restored, "cmd", &[], FileAccess::Read, &err, &cfg);
+    let h2 = nudge::evaluate(&mut restored, "cmd", &[], FileAccess::Read, &err, &cfg);
+    assert!(h1.is_empty());
+    assert!(h2.is_empty());
+}
+
+#[test]
+fn legacy_context_without_nudge_fields_still_loads() {
+    // Pre-existing context.json files written by older squeez versions don't
+    // have the nudge fields. Loading them must not blow up — and the nudge
+    // counters must initialize to empty.
+    let legacy = r#"{"session_file":"old.jsonl","call_counter":3,
+"call_log_n":[],"call_log_cmd":[],"call_log_hash":[],"call_log_len":[],"call_log_short":[],
+"call_log_shingles":[],
+"seen_files_path":[],"seen_files_size":[],"seen_files_last":[],"seen_files_access":[],
+"seen_errors":[],"error_snippet_fp":[],"error_snippet_text":[],
+"seen_git_refs":[],
+"tokens_bash":0,"tokens_read":0,"tokens_grep":0,"tokens_other":0,"reread_count":0,
+"exact_dedup_hits":0,"fuzzy_dedup_hits":0,"summarize_triggers":0,"intensity_ultra_calls":0,
+"agent_spawns":0,"agent_estimated_tokens":0,
+"agent_spawn_log_call_n":[],"agent_spawn_log_tool":[],"agent_spawn_log_tokens":[],"agent_spawn_log_ts":[],
+"burn_window_call_n":[],"burn_window_tokens":[],"burn_window_ts":[]}"#;
+
+    let c = SessionContext::from_json(legacy);
+    assert_eq!(c.call_counter, 3);
+    assert!(c.error_count_fp.is_empty());
+    assert!(c.error_count_n.is_empty());
+    assert!(c.file_mod_path.is_empty());
+    assert!(c.cmd_repeat_name.is_empty());
+    assert!(c.nudged_keys.is_empty());
+}
+
+#[test]
+fn file_mod_nudge_triggers_only_on_writes() {
+    let cfg = Config::default();
+    let files = vec!["/src/foo.rs".to_string()];
+
+    let mut ctx = SessionContext::default();
+    // Five reads → no nudge, no counter increment.
+    for _ in 0..5 {
+        nudge::evaluate(&mut ctx, "less /src/foo.rs", &files, FileAccess::Read, &[], &cfg);
+    }
+    assert!(ctx.file_mod_path.is_empty());
+
+    // Five writes → exactly one nudge on the fifth.
+    let mut any = false;
+    for i in 1..=5 {
+        let h = nudge::evaluate(&mut ctx, "sed -i ...", &files, FileAccess::Write, &[], &cfg);
+        if i == 5 {
+            assert_eq!(h.len(), 1, "should nudge exactly on 5th write");
+            assert!(h[0].contains("/src/foo.rs"));
+            any = true;
+        }
+    }
+    assert!(any);
+}
+
+#[test]
+fn cmd_repeat_nudge_triggers_for_expensive_cmds_only() {
+    let cfg = Config::default();
+    let mut ctx = SessionContext::default();
+
+    // `ls` is cheap → never nudges.
+    for _ in 0..20 {
+        let h = nudge::evaluate(&mut ctx, "ls -la", &[], FileAccess::Read, &[], &cfg);
+        assert!(h.is_empty());
+    }
+    assert!(ctx.cmd_repeat_name.is_empty());
+
+    // `cargo` is expensive. Default threshold = 4.
+    for i in 1..=4 {
+        let h = nudge::evaluate(&mut ctx, "cargo test", &[], FileAccess::Read, &[], &cfg);
+        if i == 4 {
+            assert_eq!(h.len(), 1);
+            assert!(h[0].contains("cargo"));
+        } else {
+            assert!(h.is_empty());
+        }
+    }
+}
+
+#[test]
+fn nudge_thresholds_respect_config_overrides() {
+    let mut cfg = Config::default();
+    cfg.nudge_error_threshold = 2;
+    let err = vec!["error: zap".to_string()];
+
+    let mut ctx = SessionContext::default();
+    let h1 = nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+    let h2 = nudge::evaluate(&mut ctx, "cmd", &[], FileAccess::Read, &err, &cfg);
+    assert!(h1.is_empty());
+    assert_eq!(h2.len(), 1, "with threshold=2 the second occurrence fires");
+}


### PR DESCRIPTION
Closes #117

## Summary

Two Hermes-inspired features built on existing squeez infrastructure:

- **Auto-curation nudges** (`src/economy/nudge.rs`): emit one-shot `[squeez: hint ...]` markers when recurring patterns are detected (repeated error fingerprints, repeated file writes, repeated expensive commands). Each nudge key fires at most once per session.
- **Continuous handler calibration** (`src/economy/handler_stats.rs`): accumulate per-handler `{calls, in_tokens, out_tokens}` across sessions in `handler_stats.json`. New MCP tool `squeez_handler_stats` flags under-performers (<10% savings) and over-performers (≥90%).

Both features are gated by config flags (default on), persist as plain JSON to keep the `libc`-only constraint intact, and add five tunables: `nudge_enabled`, `nudge_error_threshold`, `nudge_file_mod_threshold`, `nudge_cmd_repeat_threshold`, `handler_stats_enabled`.

## Files

- `src/context/cache.rs` — six new fields on `SessionContext` (3 parallel-array counter pairs + nudged-keys set), bump helpers, backward-compatible JSON (de)serialization.
- `src/config.rs` — 5 new fields + parser arms.
- `src/economy/nudge.rs` — evaluator + 7 unit tests.
- `src/economy/handler_stats.rs` — accumulator + 9 unit tests.
- `src/commands/wrap.rs` — wires both into the post-pass after artifact extraction.
- `src/commands/mcp_server.rs` — registers `squeez_handler_stats` tool.
- `tests/test_nudge.rs` — 7 integration tests (round-trip via JSON, post-reload behavior, legacy compat).
- `tests/test_handler_stats.rs` — 5 integration tests (cross-session accumulation, format flagging, missing-file handling).
- `README.md` — config docs.

## Test plan

- [x] `cargo test` — 621/621 pass (28 new)
- [x] `bash bench/run.sh` — 18/18 pass
- [x] `bash bench/run_context.sh` — 3/3 pass
- [x] `squeez benchmark` — 90.7% reduction, 28/28 quality
- [x] Smoke test: `squeez wrap 'echo hello'` populates `handler_stats.json` correctly
- [x] Backward compat: pre-existing `context.json` without the new fields loads cleanly with empty nudge state