### PR TITLE
fix(claude-code): register hooks under settings.hooks.<event>, not at top level

### DIFF
--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -54,9 +54,32 @@ if not isinstance(settings, dict):
     )
     sys.exit(2)
 
+# Claude Code expects hooks at settings["hooks"][event], not top-level.
+if not isinstance(settings.get("hooks"), dict):
+    settings["hooks"] = {}
+hooks_root = settings["hooks"]
+
 def ensure_list(key):
-    if not isinstance(settings.get(key), list):
-        settings[key] = []
+    if not isinstance(hooks_root.get(key), list):
+        hooks_root[key] = []
+
+# Migrate legacy top-level entries written by earlier squeez versions.
+for _legacy_evt in ("PreToolUse", "SessionStart", "PostToolUse", "SubagentStop", "PreCompact", "PostCompact"):
+    _legacy = settings.pop(_legacy_evt, None)
+    if isinstance(_legacy, list):
+        ensure_list(_legacy_evt)
+        _existing_cmds = {
+            str(h.get("command", ""))
+            for m in hooks_root[_legacy_evt] if isinstance(m, dict)
+            for h in (m.get("hooks") or [])
+        }
+        for _m in _legacy:
+            if not isinstance(_m, dict):
+                continue
+            _cmds = [str(h.get("command", "")) for h in (_m.get("hooks") or [])]
+            if any(c in _existing_cmds for c in _cmds):
+                continue
+            hooks_root[_legacy_evt].append(_m)
 
 PRETOOLUSE_MATCHER = "Bash|Read|Grep|Glob|Agent|Task"
 PRETOOLUSE_CMD = "bash " + os.path.join(hooks_dir, "pretooluse.sh")
@@ -83,14 +106,14 @@ def find_squeez_pretooluse(arr):
     return -1
 
 ensure_list("PreToolUse")
-idx = find_squeez_pretooluse(settings["PreToolUse"])
+idx = find_squeez_pretooluse(hooks_root["PreToolUse"])
 if idx == -1:
-    settings["PreToolUse"].append({
+    hooks_root["PreToolUse"].append({
         "matcher": PRETOOLUSE_MATCHER,
         "hooks": [{"type": "command", "command": PRETOOLUSE_CMD}],
     })
 else:
-    entry = settings["PreToolUse"][idx]
+    entry = hooks_root["PreToolUse"][idx]
     if entry.get("matcher") != PRETOOLUSE_MATCHER:
         entry["matcher"] = PRETOOLUSE_MATCHER
     cmd_list = entry.get("hooks", [])
@@ -98,32 +121,32 @@ else:
         cmd_list[0]["command"] = PRETOOLUSE_CMD
 
 ensure_list("SessionStart")
-if not has_squeez(settings["SessionStart"]):
-    settings["SessionStart"].append({
+if not has_squeez(hooks_root["SessionStart"]):
+    hooks_root["SessionStart"].append({
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "session-start.sh")}],
     })
 
 ensure_list("PostToolUse")
-if not has_squeez(settings["PostToolUse"]):
-    settings["PostToolUse"].append({
+if not has_squeez(hooks_root["PostToolUse"]):
+    hooks_root["PostToolUse"].append({
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "posttooluse.sh")}],
     })
 
 ensure_list("SubagentStop")
-if not has_squeez(settings["SubagentStop"]):
-    settings["SubagentStop"].append({
+if not has_squeez(hooks_root["SubagentStop"]):
+    hooks_root["SubagentStop"].append({
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "subagent-stop.sh")}],
     })
 
 ensure_list("PreCompact")
-if not has_squeez(settings["PreCompact"]):
-    settings["PreCompact"].append({
+if not has_squeez(hooks_root["PreCompact"]):
+    hooks_root["PreCompact"].append({
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "precompact.sh")}],
     })
 
 ensure_list("PostCompact")
-if not has_squeez(settings["PostCompact"]):
-    settings["PostCompact"].append({
+if not has_squeez(hooks_root["PostCompact"]):
+    hooks_root["PostCompact"].append({
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "postcompact.sh")}],
     })
 
@@ -170,15 +193,30 @@ except Exception as e:
 if not isinstance(settings, dict):
     sys.exit(0)
 
+def _strip_squeez(arr):
+    return [
+        m for m in arr
+        if isinstance(m, dict)
+        and not any("squeez" in str(h.get("command", "")) for h in (m.get("hooks") or []))
+    ]
+
+hooks_root = settings.get("hooks") if isinstance(settings.get("hooks"), dict) else None
 for event in ("PreToolUse", "SessionStart", "PostToolUse", "SubagentStop", "PreCompact", "PostCompact"):
+    # Current shape: settings["hooks"][event]
+    if hooks_root is not None:
+        arr = hooks_root.get(event)
+        if isinstance(arr, list):
+            hooks_root[event] = _strip_squeez(arr)
+            if not hooks_root[event]:
+                del hooks_root[event]
+    # Legacy shape: settings[event] (pre-fix installs)
     arr = settings.get(event)
     if isinstance(arr, list):
-        settings[event] = [
-            m for m in arr
-            if not any("squeez" in str(h.get("command", "")) for h in m.get("hooks", []))
-        ]
+        settings[event] = _strip_squeez(arr)
         if not settings[event]:
             del settings[event]
+if hooks_root is not None and not hooks_root:
+    del settings["hooks"]
 
 status = settings.get("statusLine")
 if isinstance(status, dict) and "squeez" in str(status.get("command", "")):

--- a/tests/test_hosts_claude_code.rs
+++ b/tests/test_hosts_claude_code.rs
@@ -207,6 +207,126 @@ fn claude_code_uninstall_removes_subagent_stop_precompact_postcompact() {
     });
 }
 
+// Returns (top_level_squeez_count, nested_squeez_count) by parsing settings.json
+// via python3 — keeps this crate zero-dep (no serde_json). Python indentation
+// is significant, so the script is concat!'d with explicit "\n" — Rust's
+// `\<newline>` continuation would strip the leading whitespace and break it.
+fn count_squeez(settings_path: &std::path::Path) -> (usize, usize) {
+    let script = concat!(
+        "import json, sys\n",
+        "EV=('PreToolUse','SessionStart','PostToolUse','SubagentStop','PreCompact','PostCompact')\n",
+        "s=json.load(open(sys.argv[1]))\n",
+        "def n(arr):\n",
+        "    return sum(1 for m in (arr or []) if isinstance(m, dict) and any('squeez' in str(h.get('command','')) for h in (m.get('hooks') or [])))\n",
+        "top=sum(n(s.get(e)) for e in EV if isinstance(s.get(e), list))\n",
+        "nst=sum(n((s.get('hooks') or {}).get(e)) for e in EV if isinstance((s.get('hooks') or {}).get(e), list))\n",
+        "print(f'{top}\\t{nst}')\n",
+    );
+    let out = std::process::Command::new("python3")
+        .arg("-c")
+        .arg(script)
+        .arg(settings_path)
+        .output()
+        .expect("python3 probe failed");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let mut parts = stdout.trim().split('\t');
+    let top: usize = parts
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("probe stdout='{stdout}' stderr='{stderr}'"));
+    let nested: usize = parts
+        .next()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("probe stdout='{stdout}' stderr='{stderr}'"));
+    (top, nested)
+}
+
+#[test]
+fn claude_code_install_writes_hooks_into_hooks_object_not_top_level() {
+    // Regression: earlier installs wrote hook entries at settings["PreToolUse"]
+    // etc. Claude Code only reads from settings["hooks"][event], so the hooks
+    // were silently inert. Lock down the correct shape.
+    if !python3_available() {
+        eprintln!("python3 unavailable — skipping");
+        return;
+    }
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".claude")).unwrap();
+        let a = ClaudeCodeAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+
+        let (top, nested) = count_squeez(&home.join(".claude/settings.json"));
+        assert_eq!(top, 0, "squeez entries must not live at top-level (Claude Code ignores them there)");
+        assert_eq!(nested, 6, "expected 6 squeez entries under settings.hooks.* — got {nested}");
+    });
+}
+
+#[test]
+fn claude_code_install_migrates_legacy_top_level_hooks() {
+    // Older squeez wrote hooks at the top level. A re-install must migrate
+    // them into settings.hooks.* without duplication.
+    if !python3_available() {
+        eprintln!("python3 unavailable — skipping");
+        return;
+    }
+    with_home(|home| {
+        let claude_dir = home.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let hooks_dir = claude_dir.join("squeez/hooks");
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        let legacy_cmd = format!("bash {}/pretooluse.sh", hooks_dir.display());
+        let seed = format!(
+            r#"{{"PreToolUse":[{{"matcher":"Bash|Read|Grep|Glob|Agent|Task","hooks":[{{"type":"command","command":"{legacy_cmd}"}}]}}]}}"#
+        );
+        let settings_path = claude_dir.join("settings.json");
+        std::fs::write(&settings_path, &seed).unwrap();
+
+        let a = ClaudeCodeAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+
+        let (top, nested) = count_squeez(&settings_path);
+        assert_eq!(top, 0, "legacy top-level entries should be gone after migration");
+        assert_eq!(nested, 6, "expected 6 nested squeez entries after migration");
+        let body = std::fs::read_to_string(&settings_path).unwrap();
+        assert_eq!(
+            body.matches("pretooluse.sh").count(), 1,
+            "pretooluse.sh duplicated after migration:\n{body}"
+        );
+    });
+}
+
+#[test]
+fn claude_code_uninstall_removes_legacy_top_level_hooks() {
+    // Users upgrading from broken installs may have squeez entries at the
+    // top level. uninstall() must clean both shapes.
+    if !python3_available() {
+        eprintln!("python3 unavailable — skipping");
+        return;
+    }
+    with_home(|home| {
+        let claude_dir = home.join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        let hooks_dir = claude_dir.join("squeez/hooks");
+        std::fs::create_dir_all(&hooks_dir).unwrap();
+        let cmd = format!("bash {}/pretooluse.sh", hooks_dir.display());
+        let seed = format!(
+            r#"{{"PreToolUse":[{{"matcher":"Bash","hooks":[{{"type":"command","command":"{cmd}"}}]}}]}}"#
+        );
+        std::fs::write(claude_dir.join("settings.json"), &seed).unwrap();
+
+        let a = ClaudeCodeAdapter;
+        a.uninstall().expect("uninstall should succeed");
+
+        if let Ok(body) = std::fs::read_to_string(claude_dir.join("settings.json")) {
+            assert!(
+                !body.contains("pretooluse.sh"),
+                "legacy top-level squeez entry left after uninstall:\n{body}"
+            );
+        }
+    });
+}
+
 #[test]
 fn claude_code_install_is_idempotent_for_new_hooks() {
     if !python3_available() {


### PR DESCRIPTION
Closes #120

## Summary

- Hook entries were written to `settings[event]` (top level), but Claude Code only reads `settings["hooks"][event]`. Result: every fresh install registered six hooks (PreToolUse, SessionStart, PostToolUse, SubagentStop, PreCompact, PostCompact) that the host silently ignored — the binary, statusline, and CLAUDE.md banner worked, but the compression pipeline never fired through hooks.
- Patches both install and uninstall, and migrates legacy top-level entries into the nested location on re-install (dedup on command string).
- Adds three regression tests covering correct shape, legacy migration, and legacy uninstall cleanup.

## How users on broken installs recover

Re-running `squeez setup` migrates the existing top-level entries into `settings.hooks.*` and dedups against anything already present. Uninstall scripts strip squeez from both shapes, so a clean `squeez uninstall` followed by `squeez setup` also works.

## Test plan

- [x] `cargo test --release` — 186 unit + integration tests pass, 0 failures
- [x] `cargo test --test test_hosts_claude_code` — 10/10 (existing 7 + new 3)
- [x] Manual end-to-end: rebuilt binary against a real Claude Code install — `squeez setup` is idempotent against a correctly-shaped `settings.json` (empty diff), and migration is verified by `claude_code_install_migrates_legacy_top_level_hooks`
- [x] Confirmed hooks actually fire in a live Claude Code session after the fix (every Bash command shows `[squeez] cmd N→M tokens (-X%)` header)
