### PR TITLE
fix(compress-output): close PostToolUse compression gaps for Read/Edit/Write

### DIFF
--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -42,10 +42,11 @@ except Exception:
 # Feed to track-result so Read/Grep/Glob update SessionContext (files, errors).
 printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true
 
-# For Read/Grep/Glob/Monitor: attempt output rewrite via updatedToolOutput.
-# compress-output prints hookSpecificOutput JSON if content is redundant or
-# oversized; prints nothing if the original should be kept as-is.
-if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ] || [ "$tool" = "Agent" ] || [ "$tool" = "Task" ]; then
+# For Read/Grep/Glob/Monitor/Edit/Write: attempt output rewrite via
+# updatedToolOutput. compress-output prints hookSpecificOutput JSON if content
+# is redundant, oversized, or contains strippable boilerplate; prints nothing
+# if the original should be kept as-is.
+if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ] || [ "$tool" = "Agent" ] || [ "$tool" = "Task" ] || [ "$tool" = "Edit" ] || [ "$tool" = "Write" ]; then
     rewrite=$(printf '%s' "$input" | "$SQUEEZ" compress-output "$tool" 2>/dev/null || true)
     if [ -n "$rewrite" ]; then
         printf '%s\n' "$rewrite"

--- a/src/commands/compress_output.rs
+++ b/src/commands/compress_output.rs
@@ -5,8 +5,8 @@
 // content can be compressed. Exits 0 with no stdout when no rewrite is needed
 // (Claude Code sees the original result unchanged).
 //
-// Called from hooks/posttooluse.sh for Read / Grep / Glob tool calls.
-// Bash compression is already handled at PreToolUse via `squeez wrap`.
+// Called from hooks/posttooluse.sh for Read / Grep / Glob / Edit / Write
+// tool calls. Bash compression is handled at PreToolUse via `squeez wrap`.
 
 use std::io::Read;
 use std::path::Path;
@@ -16,6 +16,9 @@ use crate::context;
 use crate::session;
 
 const MAX_CONTENT_BYTES: usize = 256 * 1024;
+/// Minimum byte saving required before emitting an Edit/Write preamble-strip
+/// rewrite. Smaller wins aren't worth the rewrite plumbing overhead.
+const EDIT_STRIP_MIN_SAVINGS: usize = 30;
 
 pub fn run(tool: &str) -> i32 {
     let mut buf = String::new();
@@ -41,8 +44,24 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
         return None;
     }
 
-    let content = extract_content(raw).filter(|c| !c.trim().is_empty())?;
-    let content: String = content.chars().take(MAX_CONTENT_BYTES).collect();
+    let raw_content = extract_content(raw).filter(|c| !c.trim().is_empty())?;
+    let raw_content: String = raw_content.chars().take(MAX_CONTENT_BYTES).collect();
+
+    // Edit/Write: strip the verbose cat -n preamble that Claude Code emits.
+    // Saves ~70-100B per call across many edits; only applied when the gain
+    // exceeds EDIT_STRIP_MIN_SAVINGS to avoid noisy rewrites for tiny results.
+    if cfg.strip_edit_preamble && (tool == "Edit" || tool == "Write") {
+        if let Some(stripped) = strip_edit_preamble(&raw_content) {
+            let saved = raw_content.len().saturating_sub(stripped.len());
+            if saved >= EDIT_STRIP_MIN_SAVINGS {
+                return Some(stripped);
+            }
+        }
+        // Edit/Write don't participate in redundancy/summarize.
+        return None;
+    }
+
+    let content = raw_content;
     let lines: Vec<String> = content.lines().map(String::from).collect();
 
     if lines.is_empty() {
@@ -72,8 +91,10 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
         }
     }
 
-    // Summarize fallback for very large outputs.
-    let rewritten = if context::summarize::should_apply(&lines, cfg) {
+    // Summarize fallback for large outputs. Read tool uses a lower threshold
+    // (default 150 lines) since most code files fall in the 80-300 range and
+    // were slipping past the global default of 300.
+    let rewritten = if context::summarize::should_apply_for_tool(&lines, cfg, tool) {
         let summary = context::summarize::apply(lines.clone(), tool);
         if summary.len() < lines.len() {
             Some(summary.join("\n"))
@@ -91,6 +112,28 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
     }
 
     rewritten
+}
+
+/// Compress the Edit/Write tool preamble. Claude Code emits the boilerplate
+/// `"The file <path> has been updated successfully. Here's the result of
+/// running `cat -n` on a snippet of the edited file:"` (or similar for Write),
+/// which costs ~70-100 tokens per call. Returns `Some(shortened)` when a
+/// strip is possible, `None` if the preamble is missing.
+fn strip_edit_preamble(content: &str) -> Option<String> {
+    // Look for the verbose phrase. Multiple variants exist depending on
+    // tool/version (Edit, Write, NotebookEdit). Match on the most stable
+    // anchor: "Here's the result of running `cat -n` on".
+    let anchor = "Here's the result of running `cat -n`";
+    let idx = content.find(anchor)?;
+    // Find end of preamble line (the colon + newline that introduces the snippet).
+    let after_anchor = &content[idx..];
+    let line_end_rel = after_anchor.find(":\n")?;
+    let snippet_start = idx + line_end_rel + 2;
+    let snippet = &content[snippet_start..];
+    let prefix = content[..idx].trim_end();
+    // Keep the leading status line (e.g. "The file X has been updated.") but
+    // drop the verbose cat -n explanation.
+    Some(format!("{}\n{}", prefix, snippet))
 }
 
 fn emit_updated_output(content: &str) {
@@ -224,5 +267,103 @@ mod tests {
         // Small content: no redundancy hit, no summarize → exit 0, no stdout
         assert_eq!(run_with(json, "Read", &dir, &cfg), 0);
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn edit_preamble_is_stripped() {
+        let dir = tmp();
+        let cfg = Config::default();
+        let content = "The file /a/b.rs has been updated successfully. Here's the result of running `cat -n` on a snippet of the edited file:\n     1\thello\n     2\tworld";
+        let json = format!(
+            r#"{{"tool_name":"Edit","tool_result":{{"content":"{}"}}}}"#,
+            content.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n")
+        );
+        let rewrite = compute_rewrite(&json, "Edit", &dir, &cfg);
+        assert!(rewrite.is_some(), "Edit preamble should be stripped");
+        let out = rewrite.unwrap();
+        assert!(
+            !out.contains("Here's the result of running"),
+            "verbose preamble survived: {}",
+            out
+        );
+        assert!(out.contains("hello"), "snippet must remain");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn edit_without_preamble_passes_through() {
+        let dir = tmp();
+        let cfg = Config::default();
+        let json = r#"{"tool_name":"Edit","tool_result":{"content":"File written."}}"#;
+        // No verbose preamble → no rewrite emitted.
+        assert!(compute_rewrite(json, "Edit", &dir, &cfg).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn edit_strip_disabled_by_config() {
+        let dir = tmp();
+        let mut cfg = Config::default();
+        cfg.strip_edit_preamble = false;
+        let content = "The file /a.rs has been updated successfully. Here's the result of running `cat -n` on a snippet of the edited file:\n     1\thi";
+        let json = format!(
+            r#"{{"tool_name":"Edit","tool_result":{{"content":"{}"}}}}"#,
+            content.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n")
+        );
+        // With strip disabled: Edit returns None (no other compression for Edit).
+        assert!(compute_rewrite(&json, "Edit", &dir, &cfg).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_uses_lower_summarize_threshold() {
+        let dir = tmp();
+        let cfg = Config::default();
+        // Build 200 benign lines: passes global 300 default but triggers
+        // Read-specific 150 default (×2 benign = 300; so we need >300 for benign).
+        // Use error markers to ensure non-benign path (threshold = base = 150).
+        let mut lines = Vec::with_capacity(200);
+        lines.push("error: synthetic".to_string());
+        for i in 1..200 {
+            lines.push(format!("line {}", i));
+        }
+        let content = lines.join("\n");
+        let json = format!(
+            r#"{{"tool_name":"Read","tool_result":{{"content":"{}"}}}}"#,
+            content.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n")
+        );
+        let rewrite = compute_rewrite(&json, "Read", &dir, &cfg);
+        assert!(
+            rewrite.is_some(),
+            "Read with 200 lines + error marker should trigger summarize at threshold 150"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_threshold_zero_falls_back_to_global() {
+        let dir = tmp();
+        let mut cfg = Config::default();
+        cfg.read_summarize_threshold_lines = 0; // disable Read override
+        cfg.summarize_threshold_lines = 1000;
+        let mut lines = Vec::with_capacity(200);
+        lines.push("error: x".to_string());
+        for i in 1..200 {
+            lines.push(format!("l{}", i));
+        }
+        let content = lines.join("\n");
+        let json = format!(
+            r#"{{"tool_name":"Read","tool_result":{{"content":"{}"}}}}"#,
+            content.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n")
+        );
+        // 200 lines < 1000 global threshold → no rewrite.
+        assert!(compute_rewrite(&json, "Read", &dir, &cfg).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn strip_edit_preamble_helper_handles_missing_anchor() {
+        assert!(strip_edit_preamble("just a plain message").is_none());
+        assert!(strip_edit_preamble("").is_none());
     }
 }

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -178,11 +178,11 @@ pub fn run(cmd_str: &str) -> i32 {
         if let Some(hit) = context::redundancy::check(&ctx, &compressed) {
             compressed = vec![match hit.similarity {
                 None => format!(
-                    "[squeez: identical to {} at bash#{} — re-run with --no-squeez]",
+                    "[squeez: identical to {} at bash#{} — output omitted]",
                     hit.short_hash, hit.call_n
                 ),
                 Some(j) => format!(
-                    "[squeez: ~{}% similar to {} at bash#{} — re-run with --no-squeez]",
+                    "[squeez: ~{}% similar to {} at bash#{} — output omitted]",
                     (j * 100.0).round() as u32,
                     hit.short_hash,
                     hit.call_n

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,6 +85,15 @@ pub struct Config {
     /// Accumulate per-handler in/out token counts in handler_stats.json so
     /// `squeez_handler_stats` can surface under/over-performers. Default: true.
     pub handler_stats_enabled: bool,
+    // ── PostToolUse compression for Read/Edit/Write (gap fix) ────────────────
+    /// Override `summarize_threshold_lines` when the tool is Read. Default 150.
+    /// Many code files are 80-300 lines and never triggered the global default
+    /// of 300, leaving them uncompressed. Set to 0 to fall back to the global
+    /// `summarize_threshold_lines`.
+    pub read_summarize_threshold_lines: usize,
+    /// Strip the verbose `"Here's the result of running cat -n on a snippet of
+    /// the edited file:"` preamble from Edit/Write tool results. Default: true.
+    pub strip_edit_preamble: bool,
 }
 
 impl Default for Config {
@@ -136,6 +145,8 @@ impl Default for Config {
             nudge_file_mod_threshold: 5,
             nudge_cmd_repeat_threshold: 4,
             handler_stats_enabled: true,
+            read_summarize_threshold_lines: 150,
+            strip_edit_preamble: true,
         }
     }
 }
@@ -257,6 +268,11 @@ impl Config {
                         c.nudge_cmd_repeat_threshold =
                             v.parse().unwrap_or(c.nudge_cmd_repeat_threshold)
                     }
+                    "read_summarize_threshold_lines" => {
+                        c.read_summarize_threshold_lines =
+                            v.parse().unwrap_or(c.read_summarize_threshold_lines)
+                    }
+                    "strip_edit_preamble" => c.strip_edit_preamble = v == "true",
                     "handler_stats_enabled" => c.handler_stats_enabled = v == "true",
                     _ => {}
                 }

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -589,7 +589,7 @@ pub fn raw_read_hint(ctx: &SessionContext, cmd: &str) -> Option<String> {
         }
         if let Some(call_n) = ctx.file_was_seen(arg) {
             return Some(format!(
-                "# squeez hint: {} already in context (Read tool, call #{}) — consider --no-squeez or skip",
+                "# squeez hint: {} already in context (Read tool, call #{}) — reuse cached content if possible",
                 arg, call_n
             ));
         }

--- a/src/context/summarize.rs
+++ b/src/context/summarize.rs
@@ -65,10 +65,29 @@ pub fn is_benign(lines: &[String]) -> bool {
 /// preserves more verbatim text in the common "long but successful build"
 /// case while keeping the eager trigger for debugging output.
 pub fn should_apply(lines: &[String], cfg: &Config) -> bool {
+    apply_threshold(lines, cfg.summarize_threshold_lines)
+}
+
+/// Same as `should_apply` but lets the caller override the base threshold for
+/// specific tools. Read uses the smaller of `cfg.read_summarize_threshold_lines`
+/// and `cfg.summarize_threshold_lines` — typical code files in the 80-300 line
+/// range were slipping past the 300-line global default, but a user that
+/// lowers the global threshold should still see Read fire at least that early.
+pub fn should_apply_for_tool(lines: &[String], cfg: &Config, tool: &str) -> bool {
+    let base = match tool {
+        "Read" if cfg.read_summarize_threshold_lines > 0 => cfg
+            .read_summarize_threshold_lines
+            .min(cfg.summarize_threshold_lines),
+        _ => cfg.summarize_threshold_lines,
+    };
+    apply_threshold(lines, base)
+}
+
+fn apply_threshold(lines: &[String], base: usize) -> bool {
     let threshold = if is_benign(lines) {
-        cfg.summarize_threshold_lines.saturating_mul(BENIGN_MULTIPLIER)
+        base.saturating_mul(BENIGN_MULTIPLIER)
     } else {
-        cfg.summarize_threshold_lines
+        base
     };
     lines.len() > threshold
 }

--- a/src/economy/nudge.rs
+++ b/src/economy/nudge.rs
@@ -76,7 +76,7 @@ pub fn evaluate(
                 let key = format!("cmd:{}", cmd_name);
                 if ctx.mark_nudged(&key) {
                     hints.push(format!(
-                        "[squeez: hint — `{}` run ×{} — consider a script or `--no-squeez` cached invocation]",
+                        "[squeez: hint — `{}` run ×{} — consider scripting or caching the result]",
                         cmd_name, count
                     ));
                 }

--- a/src/strategies/truncation.rs
+++ b/src/strategies/truncation.rs
@@ -8,10 +8,7 @@ pub fn apply(lines: Vec<String>, limit: usize, keep: Keep) -> Vec<String> {
         return lines;
     }
     let dropped = lines.len() - limit;
-    let notice = format!(
-        "[... {} lines truncated — prefix command with --no-squeez to see full output]",
-        dropped
-    );
+    let notice = format!("[... {} lines truncated]", dropped);
     match keep {
         Keep::Head => {
             let mut r: Vec<String> = lines.into_iter().take(limit).collect();

--- a/tests/test_truncation.rs
+++ b/tests/test_truncation.rs
@@ -7,7 +7,6 @@ fn truncates_head() {
     assert_eq!(r.len(), 21);
     assert_eq!(r[0], "0");
     assert!(r[20].contains("80 lines truncated"));
-    assert!(r[20].contains("--no-squeez"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #122

## Summary

Audited a real Claude Code session log (1538 JSONL entries, 204 tool calls) and found three large token leaks that bypass the compression pipeline.

| Tool | Calls | Bytes uncompressed | Coverage before |
|---|---|---|---|
| **Read** | 49 | 117 KB | 0% |
| **Bash** | 64 | 43 KB | 52% (48% bypassed via `--no-squeez`) |
| **Edit** | 55 | 11 KB | 0% |

Three closely-related fixes ship in this PR:

- **Soften `--no-squeez` advertising.** Four hints (truncation notice, exact/fuzzy redundancy notes, cache file-was-seen hint, expensive-command nudge) were telling agents to prepend `--no-squeez` as the default remediation. Logs showed agents started doing this on nearly every `grep`/`find`/`head` invocation. Reworded the hints to point at the underlying remediation (reuse cache, script the command, output omitted) rather than the escape hatch.
- **Read tool: lower summarize threshold.** New config `read_summarize_threshold_lines` (default 150) applied via a `should_apply_for_tool` helper. Clamped to the smaller of itself and the global threshold so the override never raises the bar. Most code files (80–300 lines) were slipping past the global default of 300.
- **Edit/Write boilerplate strip.** Wired Edit/Write through the PostToolUse rewrite path. Strips the verbose `"Here's the result of running 'cat -n' on a snippet of the edited file:"` preamble while preserving the status line and the snippet itself. Gated on a 30-byte minimum savings.

## Test plan

- [x] `cargo test` — full suite green (204 tests across 60+ binaries)
- [x] New unit tests in `tests/test_compress_output.rs`:
  - `edit_preamble_is_stripped`
  - `edit_without_preamble_passes_through`
  - `edit_strip_disabled_by_config`
  - `read_uses_lower_summarize_threshold`
  - `read_threshold_zero_falls_back_to_global`
  - `strip_edit_preamble_helper_handles_missing_anchor`
- [x] Updated `tests/test_truncation.rs` to match the softened notice
- [ ] Manual smoke after `bash build.sh`: verify Edit results lose the preamble and a 200-line Read with an error marker gets summarized
