### PR TITLE
fix(claude-code): stop registering squeez statusLine + delegate install to adapter

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,77 +13,21 @@ cargo build --release
 BINARY="$REPO/target/release/squeez"
 
 INSTALL_DIR="$HOME/.claude/squeez"
-mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/hooks" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
+mkdir -p "$INSTALL_DIR/bin" "$INSTALL_DIR/sessions" "$INSTALL_DIR/memory"
 cp "$BINARY" "$INSTALL_DIR/bin/squeez" && chmod +x "$INSTALL_DIR/bin/squeez"
-cp "$REPO/hooks/"*.sh "$INSTALL_DIR/hooks/" && chmod +x "$INSTALL_DIR/hooks/"*.sh
-cp "$REPO/hooks/statusline.sh" "$INSTALL_DIR/bin/statusline.sh" && chmod +x "$INSTALL_DIR/bin/statusline.sh"
 
 # Commit binary to repo
 mkdir -p "$REPO/bin"
 cp "$BINARY" "$REPO/bin/squeez"
 
-# Register hooks + statusline
-python3 - <<'EOF'
-import json, os, shutil, sys
-
-path = os.path.expanduser("~/.claude/settings.json")
-settings = {}
-file_existed = os.path.exists(path)
-if file_existed:
-    try:
-        with open(path, "r", encoding="utf-8-sig") as f:
-            settings = json.load(f)
-    except Exception as e:
-        sys.stderr.write(
-            "squeez: refusing to overwrite " + path + ": could not parse existing JSON (" + str(e) + ").\n"
-            "squeez: fix or remove the file, then re-run the installer.\n"
-        )
-        sys.exit(2)
-if not isinstance(settings, dict):
-    sys.stderr.write("squeez: refusing to overwrite " + path + ": top-level value is not a JSON object.\n")
-    sys.exit(2)
-
-def ensure_list(key):
-    if not isinstance(settings.get(key), list):
-        settings[key] = []
-
-ensure_list("PreToolUse")
-pre = {"matcher": "Bash", "hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/pretooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PreToolUse"]):
-    settings["PreToolUse"].append(pre)
-
-ensure_list("SessionStart")
-start = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/session-start.sh"}]}
-if not any("squeez" in str(h) for h in settings["SessionStart"]):
-    settings["SessionStart"].append(start)
-
-ensure_list("PostToolUse")
-post = {"hooks": [{"type": "command", "command": "bash ~/.claude/squeez/hooks/posttooluse.sh"}]}
-if not any("squeez" in str(h) for h in settings["PostToolUse"]):
-    settings["PostToolUse"].append(post)
-
-existing_status = settings.get("statusLine", {})
-existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
-squeez_cmd = "bash ~/.claude/squeez/bin/statusline.sh"
-if "squeez" not in existing_cmd:
-    if existing_cmd:
-        new_cmd = "bash -c 'input=$(cat); echo \"$input\" | { " + existing_cmd.rstrip() + "; } 2>/dev/null; echo \"$input\" | " + squeez_cmd + "'"
-        settings["statusLine"] = {"type": "command", "command": new_cmd}
-    else:
-        settings["statusLine"] = {"type": "command", "command": squeez_cmd}
-
-os.makedirs(os.path.dirname(path), exist_ok=True)
-if file_existed:
-    try:
-        shutil.copy2(path, path + ".bak")
-    except Exception:
-        pass
-tmp = path + ".tmp"
-with open(tmp, "w", encoding="utf-8") as f:
-    json.dump(settings, f, indent=2)
-os.replace(tmp, path)
-print("hooks registered in ~/.claude/settings.json")
-EOF
+# Delegate hook installation + settings.json patching to the binary itself.
+# This routes through the same host adapter (`src/hosts/claude_code.rs`) that
+# `squeez setup` uses, so the inline build.sh registration cannot drift from
+# the Rust source of truth. The adapter writes hooks under
+# `settings.hooks.<event>` (the schema Claude Code v2.x reads from) — earlier
+# versions of this script wrote to top-level `settings.<event>`, which silently
+# disabled compression because the harness never read those entries.
+"$INSTALL_DIR/bin/squeez" setup
 
 # Auto-calibrate: run benchmark analysis to generate optimized config
 echo "  Running calibration..."

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -150,19 +150,22 @@ if not has_squeez(hooks_root["PostCompact"]):
         "hooks": [{"type": "command", "command": "bash " + os.path.join(hooks_dir, "postcompact.sh")}],
     })
 
+# Strip any prior squeez statusLine registration. The squeez status line
+# competes with third-party HUDs (e.g. claude-hud) and provides no critical
+# information that isn't already surfaced via memory/banner. Leave non-squeez
+# statusLine entries untouched. The `statusline_bin` arg is retained for
+# backward compatibility with older installers but is no longer consumed.
+_ = statusline_bin
+import re as _re
 existing_status = settings.get("statusLine")
-existing_cmd = existing_status.get("command", "") if isinstance(existing_status, dict) else ""
-squeez_cmd = "bash " + statusline_bin
-if "squeez" not in existing_cmd:
-    if existing_cmd:
-        new_cmd = (
-            "bash -c 'input=$(cat); echo \"$input\" | { "
-            + existing_cmd.rstrip() + "; } 2>/dev/null; echo \"$input\" | "
-            + squeez_cmd + "'"
-        )
-        settings["statusLine"] = {"type": "command", "command": new_cmd}
-    else:
-        settings["statusLine"] = {"type": "command", "command": squeez_cmd}
+if isinstance(existing_status, dict):
+    existing_cmd = str(existing_status.get("command", ""))
+    if "squeez" in existing_cmd:
+        m = _re.match(r"^bash -c 'input=\$\(cat\); echo \"\$input\" \| \{ (.+); \} 2>/dev/null; echo \"\$input\" \| bash .+/statusline\.sh'$", existing_cmd)
+        if m:
+            settings["statusLine"] = {"type": "command", "command": m.group(1)}
+        else:
+            del settings["statusLine"]
 
 os.makedirs(os.path.dirname(path), exist_ok=True)
 if file_existed:


### PR DESCRIPTION
Closes #123

## Summary
- Drop the squeez statusLine registration so claude-hud (and other third-party status lines) survive install.
- Strip any pre-existing squeez statusLine on re-install; unwrap third-party commands that were wrapped in a squeez composite.
- Replace the inline Python in `build.sh` with `squeez setup`, so the Rust adapter is the only place that patches `settings.json`. Fixes the case where `build.sh` was writing hooks at top-level keys that Claude Code v2.x silently ignores.

## Test plan
- [x] `cargo test` — 204 tests passing
- [x] Local install via `bash build.sh` — verified `~/.claude/settings.json` after install:
  - all 6 squeez hook entries land under `settings.hooks.<event>`
  - existing `claude-hud` statusLine is preserved untouched
  - no squeez entry in statusLine
- [x] Binary contains the softened hint strings shipped in #121
