### PR TITLE
feat(benchmark): output-token inflation guard via info-preservation metric

### DIFF
--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -15,6 +15,7 @@ use std::time::Instant;
 use crate::commands::compress_md::{compress_text, Mode as MdMode};
 use crate::config::Config;
 use crate::context::summarize::{apply_with_format, SummaryFormat};
+use crate::economy::preservation;
 use crate::filter;
 use crate::json_util;
 
@@ -40,6 +41,13 @@ pub struct ScenarioResult {
     pub latency_us: u64,
     pub quality_score: f64,
     pub quality_pass: bool,
+    /// Information-preservation score in [0.0, 1.0] — fraction of structural
+    /// anchors (file paths, line refs, error codes, test verdicts) from
+    /// baseline that survive compression. See `economy::preservation`.
+    pub info_preservation: f64,
+    /// True when reduction_pct >= 90% AND info_preservation < 0.70 — the
+    /// regime where rtk-ai/rtk#582 reported a net +18% cost regression.
+    pub compression_risk: bool,
     /// Extra context saved via cross-call dedup (Wrap scenarios only).
     pub context_saved_tokens: usize,
     pub iterations: usize,
@@ -66,6 +74,8 @@ pub struct BenchmarkReport {
     pub quality_pass_count: usize,
     pub quality_fail_count: usize,
     pub quality_skip_count: usize,
+    /// Number of scenarios flagged with compression risk (see `economy::preservation`).
+    pub compression_risk_count: usize,
 }
 
 // ─── Internal types ───────────────────────────────────────────────────────────
@@ -1376,6 +1386,7 @@ fn run_filter(scenario: &Scenario, hint: &str, iterations: usize) -> ScenarioRes
     let compressed_tokens = last_compressed.len() / 4;
     let reduction = reduction_pct(baseline_tokens, compressed_tokens);
     let qscore = quality_score(&scenario.content, &last_compressed, &scenario.required_keywords, &scenario.quality_mode);
+    let preservation_score = preservation::info_preservation(&scenario.content, &last_compressed);
 
     ScenarioResult {
         name: scenario.name.clone(),
@@ -1386,6 +1397,8 @@ fn run_filter(scenario: &Scenario, hint: &str, iterations: usize) -> ScenarioRes
         latency_us: median_us,
         quality_score: qscore,
         quality_pass: qscore >= QUALITY_PASS_THRESHOLD,
+        info_preservation: preservation_score,
+        compression_risk: preservation::is_compression_risk(reduction, preservation_score),
         context_saved_tokens: 0,
         iterations,
     }
@@ -1409,6 +1422,7 @@ fn run_markdown(scenario: &Scenario, iterations: usize) -> ScenarioResult {
     let compressed_tokens = last_output.len() / 4;
     let reduction = reduction_pct(baseline_tokens, compressed_tokens);
     let qscore = quality_score(&scenario.content, &last_output, &scenario.required_keywords, &scenario.quality_mode);
+    let preservation_score = preservation::info_preservation(&scenario.content, &last_output);
 
     ScenarioResult {
         name: scenario.name.clone(),
@@ -1419,6 +1433,8 @@ fn run_markdown(scenario: &Scenario, iterations: usize) -> ScenarioResult {
         latency_us: median_us,
         quality_score: qscore,
         quality_pass: qscore >= QUALITY_PASS_THRESHOLD,
+        info_preservation: preservation_score,
+        compression_risk: preservation::is_compression_risk(reduction, preservation_score),
         context_saved_tokens: 0,
         iterations,
     }
@@ -1437,6 +1453,8 @@ fn run_wrap(scenario: &Scenario, calls: usize, iterations: usize) -> ScenarioRes
                 latency_us: 0,
                 quality_score: 0.0,
                 quality_pass: false,
+                info_preservation: 0.0,
+                compression_risk: false,
                 context_saved_tokens: 0,
                 iterations: 0,
             };
@@ -1465,6 +1483,8 @@ fn run_wrap(scenario: &Scenario, calls: usize, iterations: usize) -> ScenarioRes
             latency_us: 0,
             quality_score: 1.0,
             quality_pass: true,
+            info_preservation: 1.0,
+            compression_risk: false,
             context_saved_tokens: 0,
             iterations: 0,
         };
@@ -1543,6 +1563,8 @@ fn run_wrap(scenario: &Scenario, calls: usize, iterations: usize) -> ScenarioRes
         &scenario.required_keywords,
         &scenario.quality_mode,
     );
+    let preservation_score =
+        preservation::info_preservation(&scenario.content, &last_output_all_calls);
 
     ScenarioResult {
         name: scenario.name.clone(),
@@ -1553,6 +1575,8 @@ fn run_wrap(scenario: &Scenario, calls: usize, iterations: usize) -> ScenarioRes
         latency_us: median_us,
         quality_score: qscore,
         quality_pass: qscore >= QUALITY_PASS_THRESHOLD,
+        info_preservation: preservation_score,
+        compression_risk: preservation::is_compression_risk(reduction, preservation_score),
         context_saved_tokens: if baseline_total > avg_compressed {
             baseline_total - avg_compressed
         } else {
@@ -1621,6 +1645,10 @@ fn build_report(results: Vec<ScenarioResult>) -> BenchmarkReport {
     let quality_pass = results.iter().filter(|r| r.quality_pass).count();
     let quality_fail = results.iter().filter(|r| !r.quality_pass && r.iterations > 0).count();
     let quality_skip = results.iter().filter(|r| r.iterations == 0).count();
+    let compression_risk_count = results
+        .iter()
+        .filter(|r| r.compression_risk && r.iterations > 0)
+        .count();
 
     BenchmarkReport {
         results,
@@ -1636,6 +1664,7 @@ fn build_report(results: Vec<ScenarioResult>) -> BenchmarkReport {
         quality_pass_count: quality_pass,
         quality_fail_count: quality_fail,
         quality_skip_count: quality_skip,
+        compression_risk_count,
     }
 }
 
@@ -1649,8 +1678,11 @@ pub fn print_human(report: &BenchmarkReport) {
     println!();
 
     // ── Per-scenario table ──────────────────────────────────────────────────
-    println!("{:<32} {:>8} {:>8} {:>10} {:>8} {:>7}  {}", "SCENARIO", "BEFORE", "AFTER", "REDUCTION", "LATENCY", "QUALITY", "STATUS");
-    println!("{}", "─".repeat(84));
+    println!(
+        "{:<32} {:>8} {:>8} {:>10} {:>8} {:>7} {:>7}  {}",
+        "SCENARIO", "BEFORE", "AFTER", "REDUCTION", "LATENCY", "QUALITY", "PRESERV", "STATUS"
+    );
+    println!("{}", "─".repeat(92));
 
     let mut last_cat = String::new();
     for r in &report.results {
@@ -1663,16 +1695,23 @@ pub fn print_human(report: &BenchmarkReport) {
             println!("  ▸ {}", r.category.replace('_', " ").to_uppercase());
             last_cat = r.category.clone();
         }
-        let status = if r.quality_pass { "✅" } else { "❌ quality" };
+        let status = if r.compression_risk {
+            "⚠️  risk"
+        } else if !r.quality_pass {
+            "❌ quality"
+        } else {
+            "✅"
+        };
         let latency_str = format_latency(r.latency_us);
         println!(
-            "  {:<30} {:>6}tk {:>6}tk {:>8.1}%  {:>8}  {:>5.0}%   {}",
+            "  {:<30} {:>6}tk {:>6}tk {:>8.1}%  {:>8}  {:>5.0}%  {:>5.0}%   {}",
             r.name,
             r.baseline_tokens,
             r.compressed_tokens,
             r.reduction_pct,
             latency_str,
             r.quality_score * 100.0,
+            r.info_preservation * 100.0,
             status
         );
     }
@@ -1740,6 +1779,34 @@ pub fn print_human(report: &BenchmarkReport) {
 
     println!();
 
+    // ── Compression risk ─────────────────────────────────────────────────────
+    println!(
+        "COMPRESSION RISK  (reduction ≥{:.0}% AND preservation <{:.0}%)",
+        preservation::RISK_REDUCTION_THRESHOLD,
+        preservation::RISK_PRESERVATION_FLOOR * 100.0,
+    );
+    let total_scored = report.quality_pass_count + report.quality_fail_count;
+    println!(
+        "  flagged  {}/{}  (rtk-ai/rtk#582 regime — Claude may inflate output tokens)",
+        report.compression_risk_count, total_scored,
+    );
+    if report.compression_risk_count > 0 {
+        for r in report
+            .results
+            .iter()
+            .filter(|r| r.compression_risk && r.iterations > 0)
+        {
+            println!(
+                "    ⚠  {}  reduction={:.0}%  preservation={:.0}%",
+                r.name,
+                r.reduction_pct,
+                r.info_preservation * 100.0,
+            );
+        }
+    }
+
+    println!();
+
     // ── Interpretation ────────────────────────────────────────────────────────
     println!("INTERPRETATION");
     println!("  Best gains:   high-volume/noisy outputs (ps aux, logs, repetitive lines)");
@@ -1793,6 +1860,7 @@ pub fn to_json(report: &BenchmarkReport) -> String {
     out.push_str(&format!("  \"quality_pass_count\": {},\n", report.quality_pass_count));
     out.push_str(&format!("  \"quality_fail_count\": {},\n", report.quality_fail_count));
     out.push_str(&format!("  \"quality_skip_count\": {},\n", report.quality_skip_count));
+    out.push_str(&format!("  \"compression_risk_count\": {},\n", report.compression_risk_count));
     out.push_str("  \"scenarios\": [\n");
     for (i, r) in report.results.iter().enumerate() {
         let comma = if i + 1 < report.results.len() { "," } else { "" };
@@ -1805,6 +1873,8 @@ pub fn to_json(report: &BenchmarkReport) -> String {
         out.push_str(&format!("      \"latency_us\": {},\n", r.latency_us));
         out.push_str(&format!("      \"quality_score\": {:.4},\n", r.quality_score));
         out.push_str(&format!("      \"quality_pass\": {},\n", r.quality_pass));
+        out.push_str(&format!("      \"info_preservation\": {:.4},\n", r.info_preservation));
+        out.push_str(&format!("      \"compression_risk\": {},\n", r.compression_risk));
         out.push_str(&format!("      \"context_saved_tokens\": {},\n", r.context_saved_tokens));
         out.push_str(&format!("      \"iterations\": {}\n", r.iterations));
         out.push_str(&format!("    }}{}\n", comma));

--- a/src/economy/mod.rs
+++ b/src/economy/mod.rs
@@ -5,3 +5,4 @@ pub mod calibrate;
 pub mod efficiency;
 pub mod handler_stats;
 pub mod nudge;
+pub mod preservation;

--- a/src/economy/preservation.rs
+++ b/src/economy/preservation.rs
@@ -1,0 +1,373 @@
+//! Information-preservation scoring — detect over-compression that would force
+//! Claude to re-investigate.
+//!
+//! Background: the rtk competitor regression (rtk-ai/rtk#582) showed that
+//! aggressive bash-output compression which strips structural markers (file
+//! paths, line numbers, error codes) causes the LLM to generate 50% more
+//! output tokens trying to explain or re-derive what was removed — a net
+//! +18% total cost despite "winning" on input tokens.
+//!
+//! This module extracts structural anchors from baseline output and measures
+//! what fraction survives compression. Distinct from `quality_score` (which
+//! looks at unique diagnostic words): preservation focuses on the
+//! navigation-critical references the model uses to decide whether further
+//! tool calls are needed.
+//!
+//! All extraction is byte-scan based, zero-dep, deterministic.
+//!
+//! References:
+//! - <https://github.com/rtk-ai/rtk/issues/582>
+
+use std::collections::HashSet;
+
+/// Reduction threshold above which preservation matters most.
+pub const RISK_REDUCTION_THRESHOLD: f64 = 90.0;
+/// Preservation floor below which a high-reduction scenario is flagged.
+pub const RISK_PRESERVATION_FLOOR: f64 = 0.70;
+
+/// Structural anchors extracted from output.
+///
+/// These are the byte patterns Claude relies on to decide whether to make
+/// follow-up tool calls. Losing them forces re-investigation.
+#[derive(Debug, Default, Clone)]
+pub struct Anchors {
+    /// `path/to/file.ext` references (with extension).
+    pub file_paths: HashSet<String>,
+    /// `path/to/file.ext:NN` or `path/to/file.ext(NN,MM)` positions.
+    pub line_refs: HashSet<String>,
+    /// `error[E0432]`, `TS2345`, `error:`, `FAIL`, `panic` markers.
+    pub error_markers: HashSet<String>,
+    /// `N passed`, `N failed`, `N errors`, `N warnings` counts.
+    pub test_verdicts: HashSet<String>,
+}
+
+impl Anchors {
+    /// Total anchor count — denominator for preservation scoring.
+    pub fn total(&self) -> usize {
+        self.file_paths.len()
+            + self.line_refs.len()
+            + self.error_markers.len()
+            + self.test_verdicts.len()
+    }
+}
+
+/// Extract structural anchors from text. Pure, deterministic, zero-dep.
+pub fn extract_anchors(text: &str) -> Anchors {
+    let mut out = Anchors::default();
+    for line in text.lines() {
+        scan_line(line, &mut out);
+    }
+    out
+}
+
+fn scan_line(line: &str, anchors: &mut Anchors) {
+    // ── Test verdicts: "N passed", "N failed", "N errors", "N warnings" ─────
+    // Anchor on count+keyword to avoid matching bare keywords in prose.
+    for (kw, _) in &[
+        ("passed", 6usize),
+        ("failed", 6),
+        ("errors", 6),
+        ("warnings", 8),
+    ] {
+        if let Some(pos) = line.find(kw) {
+            // Walk back to find preceding integer.
+            let prefix = &line[..pos];
+            let trimmed = prefix.trim_end();
+            let mut digit_start = trimmed.len();
+            for (i, c) in trimmed.char_indices().rev() {
+                if c.is_ascii_digit() {
+                    digit_start = i;
+                } else {
+                    break;
+                }
+            }
+            if digit_start < trimmed.len() {
+                let num = &trimmed[digit_start..];
+                anchors
+                    .test_verdicts
+                    .insert(format!("{} {}", num, kw));
+            }
+        }
+    }
+
+    // ── Error markers ───────────────────────────────────────────────────────
+    let lower = line.to_ascii_lowercase();
+    // error[E0432] / error[TS2345] bracketed style
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'[' {
+            let mut j = i + 1;
+            let start = j;
+            while j < bytes.len() && bytes[j].is_ascii_alphanumeric() {
+                j += 1;
+            }
+            if j > start + 2 && j < bytes.len() && bytes[j] == b']' {
+                let code = &line[start..j];
+                let has_alpha = code.bytes().any(|b| b.is_ascii_alphabetic());
+                let has_digit = code.bytes().any(|b| b.is_ascii_digit());
+                if has_alpha && has_digit {
+                    anchors.error_markers.insert(code.to_string());
+                }
+            }
+            i = j.max(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+    // Standalone error codes when line is diagnostic (TS2345, E0432, EACCES, …)
+    let is_diagnostic_line = lower.contains("error")
+        || lower.contains("warning")
+        || lower.contains("fail")
+        || lower.contains("fatal")
+        || lower.contains("panic");
+    if is_diagnostic_line {
+        for tok in line.split(|c: char| !c.is_ascii_alphanumeric()) {
+            if tok.len() < 3 || tok.len() > 8 {
+                continue;
+            }
+            let tb = tok.as_bytes();
+            let mut alpha = 0usize;
+            while alpha < tb.len() && tb[alpha].is_ascii_uppercase() {
+                alpha += 1;
+            }
+            if alpha == 0 || alpha > 4 {
+                continue;
+            }
+            let rest = &tok[alpha..];
+            if rest.len() >= 2 && rest.chars().all(|c| c.is_ascii_digit()) {
+                anchors.error_markers.insert(tok.to_string());
+            }
+        }
+    }
+    // Generic diagnostic keywords
+    for kw in &["error:", "fatal:", "panic", "FAIL"] {
+        let needle_lc = kw.to_ascii_lowercase();
+        if lower.contains(&needle_lc) {
+            anchors.error_markers.insert(kw.to_string());
+        }
+    }
+
+    // ── File paths and line refs ────────────────────────────────────────────
+    for tok in line.split(|c: char| {
+        c.is_whitespace() || c == '(' || c == ')' || c == ',' || c == ';' || c == '"'
+    }) {
+        if tok.is_empty() {
+            continue;
+        }
+        // Strip leading/trailing punctuation
+        let tok = tok.trim_start_matches(|c: char| {
+            !(c.is_ascii_alphanumeric() || c == '/' || c == '.' || c == '_' || c == '-')
+        });
+        let tok = tok.trim_end_matches(|c: char| {
+            !(c.is_ascii_alphanumeric() || c == ')')
+        });
+        if tok.len() < 4 {
+            continue;
+        }
+        // path/file.ext or path/file.ext:NN
+        let has_slash = tok.contains('/') || tok.contains('\\');
+        let has_dot = tok.contains('.');
+        if !has_dot {
+            continue;
+        }
+        // Reject things like "http://..." or "v1.2.3"
+        if tok.starts_with("http://") || tok.starts_with("https://") {
+            continue;
+        }
+        // Try to peel trailing `:LINE` or `:LINE:COL` to expose the path root.
+        let (root, line_ref_present) = peel_line_ref(tok);
+        if !has_extension_like(root) {
+            continue;
+        }
+        if line_ref_present {
+            anchors.line_refs.insert(tok.to_string());
+            anchors.file_paths.insert(root.to_string());
+            continue;
+        }
+        // No line ref — record path/file alone
+        if has_slash {
+            anchors.file_paths.insert(tok.to_string());
+        } else if has_dot && tok.chars().any(|c| c.is_ascii_alphabetic()) {
+            anchors.file_paths.insert(tok.to_string());
+        }
+    }
+
+    // ── Parenthesised position: file.ext(LINE,COL) (TypeScript style) ───────
+    let mut start = 0;
+    while let Some(open) = line[start..].find('(') {
+        let abs_open = start + open;
+        if let Some(close_rel) = line[abs_open..].find(')') {
+            let abs_close = abs_open + close_rel;
+            let inside = &line[abs_open + 1..abs_close];
+            if !inside.is_empty()
+                && inside
+                    .chars()
+                    .all(|c| c.is_ascii_digit() || c == ',')
+                && inside.contains(',')
+            {
+                // Walk back from open to find filename
+                let prefix = &line[..abs_open];
+                let last_space = prefix
+                    .rfind(|c: char| c.is_whitespace())
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+                let path = &prefix[last_space..];
+                if has_extension_like(path) {
+                    anchors
+                        .line_refs
+                        .insert(format!("{}({})", path, inside));
+                    anchors.file_paths.insert(path.to_string());
+                }
+            }
+            start = abs_close + 1;
+        } else {
+            break;
+        }
+    }
+}
+
+/// Peel up to two trailing `:DIGITS` segments (covers `path:LINE` and
+/// `path:LINE:COL`). Returns `(root_without_suffix, suffix_was_present)`.
+fn peel_line_ref(tok: &str) -> (&str, bool) {
+    let mut peeled = false;
+    let mut cur = tok;
+    for _ in 0..2 {
+        if let Some(pos) = cur.rfind(':') {
+            let suffix = &cur[pos + 1..];
+            if !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit()) {
+                cur = &cur[..pos];
+                peeled = true;
+                continue;
+            }
+        }
+        break;
+    }
+    (cur, peeled)
+}
+
+/// Heuristic: does this token end with a plausible file extension?
+fn has_extension_like(tok: &str) -> bool {
+    let last_dot = match tok.rfind('.') {
+        Some(p) => p,
+        None => return false,
+    };
+    let ext = &tok[last_dot + 1..];
+    if ext.is_empty() || ext.len() > 6 {
+        return false;
+    }
+    // Ext must be all alphanumeric and contain at least one letter
+    let mut has_alpha = false;
+    for c in ext.chars() {
+        if !c.is_ascii_alphanumeric() {
+            return false;
+        }
+        if c.is_ascii_alphabetic() {
+            has_alpha = true;
+        }
+    }
+    has_alpha
+}
+
+/// Compute information-preservation score in `[0.0, 1.0]`.
+///
+/// Returns `1.0` when baseline has no structural anchors (trivially
+/// preserved — there was nothing critical to lose).
+pub fn info_preservation(baseline: &str, compressed: &str) -> f64 {
+    let baseline_anchors = extract_anchors(baseline);
+    let total = baseline_anchors.total();
+    if total == 0 {
+        return 1.0;
+    }
+    let compressed_anchors = extract_anchors(compressed);
+    let preserved = baseline_anchors.file_paths.intersection(&compressed_anchors.file_paths).count()
+        + baseline_anchors.line_refs.intersection(&compressed_anchors.line_refs).count()
+        + baseline_anchors.error_markers.intersection(&compressed_anchors.error_markers).count()
+        + baseline_anchors.test_verdicts.intersection(&compressed_anchors.test_verdicts).count();
+    preserved as f64 / total as f64
+}
+
+/// True when reduction is aggressive AND preservation has dropped below the
+/// floor — the regime where rtk regression occurred.
+pub fn is_compression_risk(reduction_pct: f64, preservation: f64) -> bool {
+    reduction_pct >= RISK_REDUCTION_THRESHOLD && preservation < RISK_PRESERVATION_FLOOR
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_rust_error_anchors() {
+        let text = "error[E0432]: unresolved import `crate::missing`\n --> src/main.rs:3:5\n  |\n3 | use crate::missing;\n";
+        let a = extract_anchors(text);
+        assert!(a.error_markers.contains("E0432"), "{:?}", a.error_markers);
+        assert!(a.line_refs.iter().any(|l| l.contains("src/main.rs:3")));
+        assert!(a.file_paths.iter().any(|f| f == "src/main.rs"));
+    }
+
+    #[test]
+    fn extracts_typescript_paren_position() {
+        let text = "src/components/Button.tsx(12,5): error TS2345: Argument type mismatch.\n";
+        let a = extract_anchors(text);
+        assert!(a.error_markers.contains("TS2345"), "{:?}", a.error_markers);
+        assert!(a.line_refs.iter().any(|l| l.contains("(12,5)")), "{:?}", a.line_refs);
+        assert!(a.file_paths.iter().any(|f| f == "src/components/Button.tsx"));
+    }
+
+    #[test]
+    fn extracts_test_verdicts() {
+        let text = "test result: ok. 42 passed; 3 failed; 1 ignored\n";
+        let a = extract_anchors(text);
+        assert!(a.test_verdicts.iter().any(|v| v == "42 passed"), "{:?}", a.test_verdicts);
+        assert!(a.test_verdicts.iter().any(|v| v == "3 failed"));
+    }
+
+    #[test]
+    fn full_preservation_when_identical() {
+        let text = "error[E0308]: mismatched types\n --> src/lib.rs:42:10\n";
+        let score = info_preservation(text, text);
+        assert!((score - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn zero_preservation_when_stripped() {
+        let baseline = "error[E0308]: mismatched types --> src/lib.rs:42:10\nerror[E0432]: unresolved --> src/main.rs:3:5\n";
+        let compressed = "[squeez: 2 errors elided]";
+        let score = info_preservation(baseline, compressed);
+        assert!(score < 0.1, "got {}", score);
+    }
+
+    #[test]
+    fn partial_preservation_for_partial_compression() {
+        let baseline = "error[E0308]: mismatched --> src/lib.rs:42:10\nerror[E0432]: unresolved --> src/main.rs:3:5\nerror[E0277]: trait --> src/foo.rs:99:1\n";
+        let compressed = "error[E0308]: mismatched --> src/lib.rs:42:10\n[squeez: 2 more errors elided]";
+        let score = info_preservation(baseline, compressed);
+        // 1/3 errors + 1/3 files + 1/3 line_refs preserved → ~0.33
+        assert!(score > 0.2 && score < 0.5, "got {}", score);
+    }
+
+    #[test]
+    fn no_anchors_means_trivially_preserved() {
+        let baseline = "Loading...\nDone.\n";
+        let compressed = "Done.";
+        let score = info_preservation(baseline, compressed);
+        assert!((score - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn risk_flag_triggers_only_on_high_reduction_and_low_preservation() {
+        assert!(is_compression_risk(95.0, 0.5));
+        assert!(!is_compression_risk(95.0, 0.85)); // high preservation → safe
+        assert!(!is_compression_risk(70.0, 0.3));  // low reduction → not a concern
+        assert!(!is_compression_risk(89.9, 0.0));  // below threshold
+    }
+
+    #[test]
+    fn rejects_urls_and_versions() {
+        let text = "fetching https://api.example.com/v1.2.3/data and version 1.2.3\n";
+        let a = extract_anchors(text);
+        assert!(a.file_paths.is_empty(), "{:?}", a.file_paths);
+        assert!(a.line_refs.is_empty(), "{:?}", a.line_refs);
+    }
+}


### PR DESCRIPTION
## Linked issue

Closes #127

## Type of change

- [x] `feat:` — new functionality (→ minor bump)
- [ ] `fix:` / `perf:` — bug fix or perf improvement (→ patch bump)
- [ ] `chore:` / `docs:` / `ci:` / `test:` / `refactor:` — no release
- [ ] Breaking change — `!:` or `BREAKING CHANGE:` in commit body (→ major bump)

## Area

- [ ] Handler (`src/commands/*`)
- [ ] Compression pipeline (`src/strategies/`)
- [ ] Context engine (`src/context/`)
- [ ] MCP server (`src/commands/mcp_server.rs`)
- [ ] CI / release / tooling
- [ ] Docs
- [x] Other — new `src/economy/preservation.rs` + benchmark wiring

## Summary

- Adds the `economy::preservation` module that scores how many structural anchors (file paths, `:LINE:COL` refs, `(LINE,COL)` refs, bracketed `[E0432]` and standalone `TS2345` error codes, test verdicts) survive each scenario's compression.
- Flags scenarios that match the rtk-ai/rtk#582 regime (`reduction ≥90% AND preservation <70%`) — the regime where the LLM reportedly inflates output tokens by ~50% to compensate for missing context, producing a net +18% total cost.
- New benchmark column `PRESERV`, new `COMPRESSION RISK` section, new JSON fields (`info_preservation`, `compression_risk`, `compression_risk_count`).

Detector immediately catches `ps_aux` (94% reduction, 8% preservation) on the current fixture suite — a real candidate worth human review.

## Test plan

- [x] `cargo test` passes — 9 new unit tests in `economy::preservation::tests`; full lib suite 168/168
- [x] `bash bench/run.sh` — existing fixtures unchanged (this PR only adds a new column)
- [ ] `bash bench/run_context.sh` — N/A (no context-engine changes)

## Checklist

- [x] Issue is linked above
- [x] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)
