### PR TITLE
refactor(skills): session-long re-injection dedup; drop lexical skill compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ squeez optimizes what it can reach — the surfaces exposed by each host's hook 
 ### Secondary wins (not compression, but token-saving)
 
 - **Cross-call redundancy dedup** — exact-hash and fuzzy-trigram collapsing across 16 recent calls (see [Context engine](#what-it-does))
+- **Skill re-injection dedup** — when the same skill body is injected by the Skill tool more than once in a session, the repeat collapses to `[squeez: identical to Skill #N]`. Keyed by body hash in a session-long store (not the 16-call window), so it fires even when injections recur far apart
 - **File-access cache** — subsequent Bash commands trimmed when re-reading a file squeez has already fingerprinted
 - **Burn-rate warnings** — `[budget: ~N calls left]` nudges so the user changes behavior before context pressure spikes
 

--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -46,7 +46,7 @@ printf '%s' "$input" | "$SQUEEZ" track-result "$tool" 2>/dev/null || true
 # updatedToolOutput. compress-output prints hookSpecificOutput JSON if content
 # is redundant, oversized, or contains strippable boilerplate; prints nothing
 # if the original should be kept as-is.
-if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ] || [ "$tool" = "Agent" ] || [ "$tool" = "Task" ] || [ "$tool" = "Edit" ] || [ "$tool" = "Write" ]; then
+if [ "$tool" = "Read" ] || [ "$tool" = "Grep" ] || [ "$tool" = "Glob" ] || [ "$tool" = "Monitor" ] || [ "$tool" = "Agent" ] || [ "$tool" = "Task" ] || [ "$tool" = "Edit" ] || [ "$tool" = "Write" ] || [ "$tool" = "Skill" ]; then
     rewrite=$(printf '%s' "$input" | "$SQUEEZ" compress-output "$tool" 2>/dev/null || true)
     if [ -n "$rewrite" ]; then
         printf '%s\n' "$rewrite"

--- a/spike/README.md
+++ b/spike/README.md
@@ -1,0 +1,57 @@
+# Layer 0 spike — UserPromptExpansion rewrite capability
+
+Goal: prove (or rule out) whether the `UserPromptExpansion` hook can **rewrite**
+the expanded slash-command/skill body before the model sees it. This gates
+Layer 3 (runtime compression of user-typed `/skill` bodies — the largest bloat
+source in the band-graph transcript).
+
+This needs a **fresh interactive Claude Code session** to observe — it cannot be
+verified from inside a running turn.
+
+## Steps
+
+1. Make the probe executable:
+   ```bash
+   chmod +x spike/userpromptexpansion-spike.sh
+   ```
+
+2. Register it temporarily in `~/.claude/settings.json` under
+   `hooks.UserPromptExpansion` (matcher `*` or a specific skill name):
+   ```json
+   {
+     "hooks": {
+       "UserPromptExpansion": [
+         { "matcher": "*",
+           "hooks": [ { "type": "command",
+             "command": "bash /ABSOLUTE/PATH/squeez/spike/userpromptexpansion-spike.sh" } ] }
+       ]
+     }
+   }
+   ```
+
+3. Start a **new** session. Invoke any skill, e.g. `/DEBUG_error-detective`.
+
+4. Immediately ask: *"Repeat the slash-command body you just received, verbatim."*
+
+5. Interpret:
+   - Model echoes `SQUEEZ_REWRITE_SENTINEL` → **rewrite supported** → implement Layer 3
+     (note which field won, shown in the sentinel text).
+   - Model echoes the original skill body but a `SQUEEZ_FIRED_SENTINEL` line is
+     present → hook fired, **rewrite NOT supported** → skip Layer 3, file a CC
+     feature request, rely on Layers 1+2.
+   - Neither sentinel → hook didn't fire for this expansion type.
+
+6. Inspect `spike/expansion-input.json` for the exact hook input schema
+   (field names like `prompt` / `command_name` / `expansion_type`).
+
+7. **Unregister** the hook from `settings.json` when done.
+
+## Result
+
+Record the outcome here, then delete the `spike/` directory:
+
+```
+DATE:
+WINNING FIELD (if any):
+DECISION: [ build Layer 3 | skip Layer 3 + file feature request ]
+```

--- a/spike/README.md
+++ b/spike/README.md
@@ -46,12 +46,29 @@ verified from inside a running turn.
 
 7. **Unregister** the hook from `settings.json` when done.
 
-## Result
+## Result — RESOLVED (run headless via `claude -p "/spike-probe" --settings ...`)
 
-Record the outcome here, then delete the `spike/` directory:
+**`UserPromptExpansion` fires, but the body cannot be rewritten.**
+
+Verified input schema (no body is passed — only the command name + raw prompt):
+```json
+{"session_id":"…","transcript_path":"…","cwd":"…","permission_mode":"auto",
+ "hook_event_name":"UserPromptExpansion","expansion_type":"slash_command",
+ "command_name":"spike-probe","command_args":"","command_source":"projectSettings",
+ "prompt":"/spike-probe"}
+```
+
+- Rewrite sentinel reached the model: **0 times** (every candidate field ignored).
+- The model received the **original** command body verbatim.
 
 ```
-DATE:
-WINNING FIELD (if any):
-DECISION: [ build Layer 3 | skip Layer 3 + file feature request ]
+WINNING FIELD: none — rewrite is not supported, and the body is not even in the hook input
+DECISION: skip Layer 3 (no runtime hook)
 ```
+
+**Why this is fine:** a user-typed `/skill` is expanded by reading the body
+**from the on-disk SKILL.md** — which Layer 1 pre-compresses at SessionStart.
+Confirmed end-to-end: after `squeez compress-md` shrank a command body on disk,
+`/spike-probe` delivered the **compressed** text to the model. Layer 1 closes the
+user-typed-skill gap at the source; Layer 2 covers the Skill-tool path. No
+`UserPromptExpansion` hook is needed.

--- a/spike/userpromptexpansion-spike.sh
+++ b/spike/userpromptexpansion-spike.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Layer 0 spike — does Claude Code's UserPromptExpansion hook let us REWRITE the
+# expanded skill/slash-command body before the model sees it?
+#
+# This script is a throwaway probe. It:
+#   1. logs the raw hook JSON it receives to spike/expansion-input.json
+#   2. emits candidate output JSON trying every plausible rewrite field at once,
+#      replacing the body with a unique sentinel, plus an additionalContext
+#      sentinel that proves the hook fired even if rewrite is unsupported.
+#
+# After running a /skill in a session with this hook registered, ask the model:
+#   "Repeat the slash-command body you just received, verbatim."
+#
+# Interpretation:
+#   - Model echoes SQUEEZ_REWRITE_SENTINEL  → rewrite IS supported → build Layer 3.
+#   - Model echoes the ORIGINAL skill body, but mentions SQUEEZ_FIRED_SENTINEL
+#       → hook fired but rewrite NOT supported → Layer 3 not viable; file a CC
+#         feature request and rely on Layers 1+2.
+#   - Neither sentinel appears → hook did not fire for this expansion type.
+
+SPIKE_DIR="$(cd "$(dirname "$0")" && pwd)"
+input=$(cat)
+printf '%s\n' "$input" > "$SPIKE_DIR/expansion-input.json"
+
+# Candidate rewrite fields. We deliberately emit several shapes; Claude Code
+# ignores keys it doesn't recognise, so the one that "wins" tells us the API.
+cat <<'JSON'
+{
+  "updatedPrompt": "SQUEEZ_REWRITE_SENTINEL (updatedPrompt field)",
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptExpansion",
+    "updatedExpansion": "SQUEEZ_REWRITE_SENTINEL (hookSpecificOutput.updatedExpansion)",
+    "updatedPrompt": "SQUEEZ_REWRITE_SENTINEL (hookSpecificOutput.updatedPrompt)",
+    "additionalContext": "SQUEEZ_FIRED_SENTINEL — UserPromptExpansion hook executed."
+  }
+}
+JSON

--- a/src/commands/compress_md/mod.rs
+++ b/src/commands/compress_md/mod.rs
@@ -124,10 +124,7 @@ pub fn run(args: &[String]) -> i32 {
 pub fn run_all_quietly() -> i32 {
     let cfg = crate::config::Config::load();
     let locale = Locale::from_code(&cfg.lang);
-    let mut files = all_targets();
-    if cfg.compress_skills {
-        files.extend(skill_targets());
-    }
+    let files = all_targets();
     for f in &files {
         if !f.exists() {
             continue;
@@ -135,38 +132,6 @@ pub fn run_all_quietly() -> i32 {
         let _ = process_file(f, Mode::Ultra, false, true, locale);
     }
     0
-}
-
-/// Recursively collect every `*.md` under `~/.claude/skills/` — skill bodies
-/// (`SKILL.md`) and their reference files. Zero-dep manual recursion (no
-/// walkdir). Skips our own `*.original.md` backups.
-fn skill_targets() -> Vec<PathBuf> {
-    let home = home_dir();
-    let root = PathBuf::from(format!("{}/.claude/skills", home));
-    let mut out = Vec::new();
-    collect_md(&root, &mut out, 0);
-    out
-}
-
-fn collect_md(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
-    if depth > 6 {
-        return;
-    }
-    let entries = match std::fs::read_dir(dir) {
-        Ok(e) => e,
-        Err(_) => return,
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            collect_md(&path, out, depth + 1);
-        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
-            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-            if !name.ends_with(".original.md") {
-                out.push(path);
-            }
-        }
-    }
 }
 
 fn print_help() {

--- a/src/commands/compress_md/mod.rs
+++ b/src/commands/compress_md/mod.rs
@@ -124,7 +124,10 @@ pub fn run(args: &[String]) -> i32 {
 pub fn run_all_quietly() -> i32 {
     let cfg = crate::config::Config::load();
     let locale = Locale::from_code(&cfg.lang);
-    let files = all_targets();
+    let mut files = all_targets();
+    if cfg.compress_skills {
+        files.extend(skill_targets());
+    }
     for f in &files {
         if !f.exists() {
             continue;
@@ -132,6 +135,38 @@ pub fn run_all_quietly() -> i32 {
         let _ = process_file(f, Mode::Ultra, false, true, locale);
     }
     0
+}
+
+/// Recursively collect every `*.md` under `~/.claude/skills/` — skill bodies
+/// (`SKILL.md`) and their reference files. Zero-dep manual recursion (no
+/// walkdir). Skips our own `*.original.md` backups.
+fn skill_targets() -> Vec<PathBuf> {
+    let home = home_dir();
+    let root = PathBuf::from(format!("{}/.claude/skills", home));
+    let mut out = Vec::new();
+    collect_md(&root, &mut out, 0);
+    out
+}
+
+fn collect_md(dir: &Path, out: &mut Vec<PathBuf>, depth: usize) {
+    if depth > 6 {
+        return;
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_md(&path, out, depth + 1);
+        } else if path.extension().and_then(|e| e.to_str()) == Some("md") {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !name.ends_with(".original.md") {
+                out.push(path);
+            }
+        }
+    }
 }
 
 fn print_help() {
@@ -283,6 +318,21 @@ pub fn compress_text_with_locale(
 
     let lines: Vec<&str> = input.split('\n').collect();
     let mut i = 0;
+
+    // Preserve a leading YAML front-matter block verbatim. Skill SKILL.md files
+    // open with `---` … `---` carrying `name:`/`description:`; abbreviating those
+    // would corrupt skill identity and activation matching.
+    if lines.first().map(|l| l.trim_end()) == Some("---") {
+        if let Some(close) = lines.iter().skip(1).position(|l| l.trim_end() == "---") {
+            let end = close + 1; // index of the closing `---`
+            for line in &lines[..=end] {
+                out.push_str(line);
+                out.push('\n');
+            }
+            i = end + 1;
+        }
+    }
+
     while i < lines.len() {
         let line = lines[i];
         match state {

--- a/src/commands/compress_output.rs
+++ b/src/commands/compress_output.rs
@@ -91,10 +91,25 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
         }
     }
 
-    // Summarize fallback for large outputs. Read tool uses a lower threshold
-    // (default 150 lines) since most code files fall in the 80-300 range and
-    // were slipping past the global default of 300.
-    let rewritten = if context::summarize::should_apply_for_tool(&lines, cfg, tool) {
+    // Skill bodies (SKILL.md injected when Claude invokes the Skill tool) are
+    // prose-heavy and often large. Shrink them losslessly via the markdown
+    // compressor — front-matter, code blocks, URLs and headings are preserved —
+    // rather than the lossy summarizer, since the user wants the skill's actual
+    // instructions, just denser. Original lines are still recorded below so a
+    // later identical injection dedups to a note.
+    let rewritten = if tool == "Skill" {
+        let joined = lines.join("\n");
+        let compressed = crate::commands::compress_md::compress_text_with_locale(
+            &joined,
+            crate::commands::compress_md::Mode::Ultra,
+            crate::commands::compress_md::Locale::from_code(&cfg.lang),
+        );
+        if compressed.safe && compressed.stats.new_bytes + 64 < compressed.stats.orig_bytes {
+            Some(compressed.output)
+        } else {
+            None
+        }
+    } else if context::summarize::should_apply_for_tool(&lines, cfg, tool) {
         let summary = context::summarize::apply(lines.clone(), tool);
         if summary.len() < lines.len() {
             Some(summary.join("\n"))

--- a/src/commands/compress_output.rs
+++ b/src/commands/compress_output.rs
@@ -70,6 +70,30 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
 
     let mut ctx = context::cache::SessionContext::load(sessions_dir);
 
+    // Skill bodies (SKILL.md injected when Claude invokes the Skill tool) are
+    // large, structured, and EXACTLY repeatable: the same skill re-injected
+    // later in a session is byte-identical. The real win is dropping that
+    // duplicate, not lexically abbreviating prose (skill bodies are checklists
+    // and code, not prose — lexical compression nets ~1%). Re-injections recur
+    // at arbitrary distance, so the windowed `redundancy::check` (last 16 calls)
+    // misses them; use the session-long skill-injection store instead.
+    if tool == "Skill" {
+        if cfg.redundancy_cache_enabled {
+            let fp = crate::context::hash::fnv1a_64(content.as_bytes());
+            if let Some(call_n) = ctx.skill_dedup_lookup(fp) {
+                ctx.exact_dedup_hits += 1;
+                ctx.save(sessions_dir);
+                return Some(format!(
+                    "[squeez: identical to Skill #{call_n} — body omitted]"
+                ));
+            }
+            ctx.skill_dedup_record(fp);
+            ctx.save(sessions_dir);
+        }
+        // First injection: recorded, kept full-size.
+        return None;
+    }
+
     // Redundancy check: if we've seen this content before, replace with a note.
     if cfg.redundancy_cache_enabled {
         if let Some(hit) = context::redundancy::check(&ctx, &lines) {
@@ -91,25 +115,9 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
         }
     }
 
-    // Skill bodies (SKILL.md injected when Claude invokes the Skill tool) are
-    // prose-heavy and often large. Shrink them losslessly via the markdown
-    // compressor — front-matter, code blocks, URLs and headings are preserved —
-    // rather than the lossy summarizer, since the user wants the skill's actual
-    // instructions, just denser. Original lines are still recorded below so a
-    // later identical injection dedups to a note.
-    let rewritten = if tool == "Skill" {
-        let joined = lines.join("\n");
-        let compressed = crate::commands::compress_md::compress_text_with_locale(
-            &joined,
-            crate::commands::compress_md::Mode::Ultra,
-            crate::commands::compress_md::Locale::from_code(&cfg.lang),
-        );
-        if compressed.safe && compressed.stats.new_bytes + 64 < compressed.stats.orig_bytes {
-            Some(compressed.output)
-        } else {
-            None
-        }
-    } else if context::summarize::should_apply_for_tool(&lines, cfg, tool) {
+    // Large benign outputs get summarized (Skill is handled earlier via the
+    // session-long dedup store and never reaches here).
+    let rewritten = if context::summarize::should_apply_for_tool(&lines, cfg, tool) {
         let summary = context::summarize::apply(lines.clone(), tool);
         if summary.len() < lines.len() {
             Some(summary.join("\n"))

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -19,6 +19,12 @@ pub fn run() -> i32 {
     if let Some(adapter) = crate::hosts::find("claude-code") {
         let _ = adapter.inject_memory(&cfg, &[]);
     }
+    // Auto-compress known memory files + skill bodies (idempotent — backups are
+    // never clobbered). Runs only on the real binary entry, after memory
+    // injection has rewritten CLAUDE.md.
+    if cfg.auto_compress_md {
+        let _ = compress_md::run_all_quietly();
+    }
     // Warn if CLAUDE.md is larger than ~1K tokens (research recommendation).
     check_claude_md_size();
     code
@@ -174,10 +180,11 @@ pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) ->
     }
     println!("────────────────────────────────────────────────────────────");
 
-    // 5. Auto-compress known memory files (idempotent — backup is never clobbered)
-    if config.auto_compress_md {
-        let _ = compress_md::run_all_quietly();
-    }
+    // Note: auto-compression of memory files / skill bodies is a global
+    // filesystem side-effect and lives in the binary entry points (run /
+    // run_copilot / run_for_host), NOT here — this keeps run_with_dirs a pure
+    // session-init function so tests don't rewrite the developer's real
+    // ~/.claude/CLAUDE.md or ~/.claude/skills/.
 
     0
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,9 +21,6 @@ pub struct Config {
     // ── Output / memory-file flags ──────────────────────────────────────
     pub persona: Persona,
     pub auto_compress_md: bool,
-    /// Also compress skill bodies under ~/.claude/skills/**/*.md when
-    /// auto_compress_md runs at SessionStart (front-matter preserved). Default true.
-    pub compress_skills: bool,
     pub lang: String,
     // ── Token economy (phase 7) ───────────────────────────────────────────
     /// Fraction of budget at which sub-agent cost triggers a warning (default 0.50).
@@ -124,7 +121,6 @@ impl Default for Config {
             summarize_threshold_lines: 300,
             persona: Persona::Ultra,
             auto_compress_md: true,
-            compress_skills: true,
             lang: "en".to_string(),
             agent_warn_threshold_pct: 0.50,
             burn_rate_warn_calls: 30,
@@ -198,7 +194,6 @@ impl Config {
                     }
                     "persona" => c.persona = crate::commands::persona::from_str(v),
                     "auto_compress_md" => c.auto_compress_md = v == "true",
-                    "compress_skills" => c.compress_skills = v == "true",
                     "lang" => c.lang = v.to_string(),
                     "agent_warn_threshold_pct" => {
                         c.agent_warn_threshold_pct =

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,9 @@ pub struct Config {
     // ── Output / memory-file flags ──────────────────────────────────────
     pub persona: Persona,
     pub auto_compress_md: bool,
+    /// Also compress skill bodies under ~/.claude/skills/**/*.md when
+    /// auto_compress_md runs at SessionStart (front-matter preserved). Default true.
+    pub compress_skills: bool,
     pub lang: String,
     // ── Token economy (phase 7) ───────────────────────────────────────────
     /// Fraction of budget at which sub-agent cost triggers a warning (default 0.50).
@@ -121,6 +124,7 @@ impl Default for Config {
             summarize_threshold_lines: 300,
             persona: Persona::Ultra,
             auto_compress_md: true,
+            compress_skills: true,
             lang: "en".to_string(),
             agent_warn_threshold_pct: 0.50,
             burn_rate_warn_calls: 30,
@@ -194,6 +198,7 @@ impl Config {
                     }
                     "persona" => c.persona = crate::commands::persona::from_str(v),
                     "auto_compress_md" => c.auto_compress_md = v == "true",
+                    "compress_skills" => c.compress_skills = v == "true",
                     "lang" => c.lang = v.to_string(),
                     "agent_warn_threshold_pct" => {
                         c.agent_warn_threshold_pct =

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -157,6 +157,16 @@ pub struct SessionContext {
     /// Nudge keys already emitted this session — prevents duplicate hints.
     /// Format: `err:<hex>`, `file:<path>`, `cmd:<name>`.
     pub nudged_keys: Vec<String>,
+    // ── Skill-injection dedup (session-long) ───────────────────────────────
+    /// FNV-1a-64 fingerprints of skill bodies injected this session. Unlike
+    /// `call_log` (capped at `max_call_log`, searched within `recent_window`),
+    /// this store is unbounded and never windowed — skill re-injections recur
+    /// at arbitrary distance and must dedup across the whole session.
+    /// Parallel to `skill_inject_call`.
+    pub skill_inject_fp: Vec<u64>,
+    /// `call_n` of the FIRST injection for each fingerprint (parallel to
+    /// `skill_inject_fp`). Referenced in the `identical to Skill #N` note.
+    pub skill_inject_call: Vec<u64>,
     // ── Tunables (phase 5) — set from Config at session start, not persisted ─
     pub max_call_log: usize,
     pub recent_window: usize,
@@ -194,6 +204,8 @@ impl Default for SessionContext {
             cmd_repeat_name: Vec::new(),
             cmd_repeat_n: Vec::new(),
             nudged_keys: Vec::new(),
+            skill_inject_fp: Vec::new(),
+            skill_inject_call: Vec::new(),
             max_call_log: DEFAULT_MAX_CALL_LOG,
             recent_window: DEFAULT_RECENT_WINDOW,
             similarity_threshold: DEFAULT_SIMILARITY_THRESHOLD,
@@ -264,6 +276,27 @@ impl SessionContext {
     pub fn next_call_n(&mut self) -> u64 {
         self.call_counter = self.call_counter.saturating_add(1);
         self.call_counter
+    }
+
+    /// Session-long lookup for a previously-injected skill body, keyed by its
+    /// FNV-1a-64 fingerprint. Returns the `call_n` of the first injection on an
+    /// exact hit. Unlike `lookup_recent`, this scans the entire session (no
+    /// `recent_window` bound) because skill re-injections recur far apart.
+    pub fn skill_dedup_lookup(&self, fp: u64) -> Option<u64> {
+        self.skill_inject_fp
+            .iter()
+            .position(|&f| f == fp)
+            .map(|i| self.skill_inject_call[i])
+    }
+
+    /// Record a skill body fingerprint as injected this session and return the
+    /// assigned `call_n`. Caller should only invoke after `skill_dedup_lookup`
+    /// returned `None` (first injection).
+    pub fn skill_dedup_record(&mut self, fp: u64) -> u64 {
+        let call_n = self.next_call_n();
+        self.skill_inject_fp.push(fp);
+        self.skill_inject_call.push(call_n);
+        call_n
     }
 
     pub fn record_call(
@@ -730,7 +763,8 @@ impl SessionContext {
 \"error_count_fp\":{},\"error_count_n\":{},\
 \"file_mod_path\":{},\"file_mod_n\":{},\
 \"cmd_repeat_name\":{},\"cmd_repeat_n\":{},\
-\"nudged_keys\":{}}}",
+\"nudged_keys\":{},\
+\"skill_inject_fp\":{},\"skill_inject_call\":{}}}",
             json_util::escape_str(&self.session_file),
             self.call_counter,
             json_util::u64_array(&cl_n),
@@ -772,6 +806,8 @@ impl SessionContext {
             json_util::str_array(&self.cmd_repeat_name),
             json_util::u64_array(&cr_n_u64),
             json_util::str_array(&self.nudged_keys),
+            json_util::u64_array(&self.skill_inject_fp),
+            json_util::u64_array(&self.skill_inject_call),
         )
     }
 
@@ -917,6 +953,13 @@ impl SessionContext {
 
         c.nudged_keys = json_util::map_str_array(&map, "nudged_keys");
 
+        // Skill-injection dedup store — optional for backward compat.
+        let si_fp = json_util::map_u64_array(&map, "skill_inject_fp");
+        let si_call = json_util::map_u64_array(&map, "skill_inject_call");
+        let si_len = si_fp.len().min(si_call.len());
+        c.skill_inject_fp = si_fp.iter().take(si_len).copied().collect();
+        c.skill_inject_call = si_call.iter().take(si_len).copied().collect();
+
         c
     }
 }
@@ -924,6 +967,24 @@ impl SessionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skill_dedup_lookup_and_record() {
+        let mut c = SessionContext::default();
+        assert_eq!(c.skill_dedup_lookup(0xABCD), None);
+        let call_n = c.skill_dedup_record(0xABCD);
+        assert_eq!(c.skill_dedup_lookup(0xABCD), Some(call_n));
+        // A different fingerprint is independent.
+        assert_eq!(c.skill_dedup_lookup(0x1234), None);
+    }
+
+    #[test]
+    fn skill_dedup_survives_json_roundtrip() {
+        let mut c = SessionContext::default();
+        let call_n = c.skill_dedup_record(0xDEADBEEF);
+        let restored = SessionContext::from_json(&c.to_json());
+        assert_eq!(restored.skill_dedup_lookup(0xDEADBEEF), Some(call_n));
+    }
 
     #[test]
     fn normalize_replaces_digits_paths_hex() {

--- a/tests/test_compress_md_skills.rs
+++ b/tests/test_compress_md_skills.rs
@@ -1,0 +1,73 @@
+// Layer 1 — skill-body compression. Verifies the markdown compressor preserves
+// a leading YAML front-matter block verbatim (skill `name:`/`description:` drive
+// identity + activation matching and must not be abbreviated) while still
+// compressing the prose body. Idempotence: a second pass must stay safe and not
+// re-touch the protected front-matter.
+
+use squeez::commands::compress_md::{compress_text, Mode};
+
+const FRONT_MATTER: &str = "---\nname: DEBUG_error-detective\ndescription: \"Use this agent when you need to diagnose why errors are occurring in your system without delay.\"\ntools: Read, Write, Edit, Bash, Glob, Grep\nmodel: sonnet\n---\n";
+
+#[test]
+fn front_matter_preserved_verbatim() {
+    let input = format!(
+        "{}\nConfigure the function with these parameters because of the documentation.\n",
+        FRONT_MATTER
+    );
+    let r = compress_text(&input, Mode::Ultra);
+    assert!(r.safe, "compression must pass integrity check");
+
+    // Every front-matter line survives byte-for-byte.
+    assert!(r.output.contains("name: DEBUG_error-detective"));
+    assert!(r.output.contains(
+        "description: \"Use this agent when you need to diagnose why errors are occurring in your system without delay.\""
+    ));
+    assert!(r.output.contains("tools: Read, Write, Edit, Bash, Glob, Grep"));
+    assert!(r.output.contains("model: sonnet"));
+
+    // The front-matter `with`/`because`/`documentation` must NOT be abbreviated.
+    let fm_end = r.output.find("---\n\n").or_else(|| r.output.find("---\n")).unwrap();
+    let (fm, _body) = r.output.split_at(fm_end);
+    assert!(!fm.contains("w/"), "front-matter must not be abbreviated: {}", fm);
+    assert!(!fm.contains("b/c"), "front-matter must not be abbreviated: {}", fm);
+}
+
+#[test]
+fn prose_body_still_compressed() {
+    let input = format!(
+        "{}\nConfigure the function with these parameters because of the documentation.\n",
+        FRONT_MATTER
+    );
+    let r = compress_text(&input, Mode::Ultra);
+    // The body (after front-matter) gets the usual Ultra substitutions.
+    assert!(r.output.contains("fn"), "body should abbreviate function→fn");
+    assert!(r.output.contains("w/"), "body should abbreviate with→w/");
+    assert!(r.output.contains("param"), "body should abbreviate parameters→param");
+    assert!(r.output.contains("b/c"), "body should abbreviate because→b/c");
+    assert!(r.stats.new_bytes < r.stats.orig_bytes, "must reduce overall size");
+}
+
+#[test]
+fn idempotent_second_pass_safe() {
+    let input = format!(
+        "{}\nThe system should correlate errors across services to find the root cause.\n",
+        FRONT_MATTER
+    );
+    let first = compress_text(&input, Mode::Ultra);
+    assert!(first.safe);
+    let second = compress_text(&first.output, Mode::Ultra);
+    assert!(second.safe, "second pass must remain safe");
+    // Front-matter still intact after a re-run.
+    assert!(second.output.contains("name: DEBUG_error-detective"));
+    assert!(second.output.contains("model: sonnet"));
+}
+
+#[test]
+fn no_front_matter_file_unaffected() {
+    // A plain prose file (no leading `---`) compresses exactly as before.
+    let input = "Configure the function with these parameters because of the docs.\n";
+    let r = compress_text(input, Mode::Ultra);
+    assert!(r.safe);
+    assert!(r.output.contains("fn"));
+    assert!(r.output.contains("w/"));
+}

--- a/tests/test_compress_output_skill.rs
+++ b/tests/test_compress_output_skill.rs
@@ -1,0 +1,80 @@
+// Layer 2 — Skill tool output rewriting in PostToolUse. When Claude invokes a
+// skill via the Skill tool, squeez compresses the (prose-heavy) skill body and
+// dedups a second identical injection to a reference note.
+
+use squeez::commands::compress_output::compute_rewrite;
+use squeez::config::Config;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tmp() -> std::path::PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let d = std::env::temp_dir().join(format!(
+        "squeez_skill_out_{}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        n
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+// A prose-heavy skill body (10+ lines) modelled on the real DEBUG_error-detective
+// skill: substitutable words (with/because/function/configuration/documentation)
+// so Ultra compression clears the 64-byte savings gate.
+fn skill_body() -> String {
+    let mut s = String::from(
+        "You are a senior error detective with expertise in analyzing error patterns.\n",
+    );
+    for i in 0..12 {
+        s.push_str(&format!(
+            "Step {i}: configure the function with these parameters because of the documentation and the configuration.\n"
+        ));
+    }
+    s
+}
+
+fn skill_json(body: &str) -> String {
+    let esc = body
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
+    format!(r#"{{"tool_name":"Skill","tool_result":{{"content":"{}"}}}}"#, esc)
+}
+
+#[test]
+fn skill_body_is_compressed_on_first_injection() {
+    let dir = tmp();
+    let cfg = Config::default();
+    let body = skill_body();
+    let json = skill_json(&body);
+
+    let rewrite = compute_rewrite(&json, "Skill", &dir, &cfg);
+    assert!(rewrite.is_some(), "first skill injection should be compressed");
+    let out = rewrite.unwrap();
+    assert!(out.len() < body.len(), "compressed body must be smaller");
+    assert!(out.contains("fn"), "function→fn substitution expected");
+    assert!(out.contains("w/"), "with→w/ substitution expected");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn duplicate_skill_injection_is_deduped() {
+    let dir = tmp();
+    let cfg = Config::default();
+    let json = skill_json(&skill_body());
+
+    // First call records the original body.
+    let _ = compute_rewrite(&json, "Skill", &dir, &cfg);
+    // Second identical call must collapse to a reference note.
+    let second = compute_rewrite(&json, "Skill", &dir, &cfg);
+    assert!(second.is_some(), "duplicate injection should be rewritten");
+    let note = second.unwrap();
+    assert!(
+        note.contains("identical to Skill"),
+        "expected dedup note, got: {note}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/tests/test_compress_output_skill.rs
+++ b/tests/test_compress_output_skill.rs
@@ -1,6 +1,8 @@
-// Layer 2 — Skill tool output rewriting in PostToolUse. When Claude invokes a
-// skill via the Skill tool, squeez compresses the (prose-heavy) skill body and
-// dedups a second identical injection to a reference note.
+// Layer 2 — Skill tool output handling in PostToolUse. When Claude invokes a
+// skill via the Skill tool, squeez keeps the first injection full-size (skill
+// bodies are structured checklists, not prose — lexical compression nets ~1%)
+// and dedups any later identical injection to a reference note via a
+// session-long store that is NOT bounded by the 16-call redundancy window.
 
 use squeez::commands::compress_output::compute_rewrite;
 use squeez::config::Config;
@@ -21,9 +23,7 @@ fn tmp() -> std::path::PathBuf {
     d
 }
 
-// A prose-heavy skill body (10+ lines) modelled on the real DEBUG_error-detective
-// skill: substitutable words (with/because/function/configuration/documentation)
-// so Ultra compression clears the 64-byte savings gate.
+// A skill body (10+ lines) modelled on the real DEBUG_error-detective skill.
 fn skill_body() -> String {
     let mut s = String::from(
         "You are a senior error detective with expertise in analyzing error patterns.\n",
@@ -44,19 +44,27 @@ fn skill_json(body: &str) -> String {
     format!(r#"{{"tool_name":"Skill","tool_result":{{"content":"{}"}}}}"#, esc)
 }
 
+fn read_json(n: usize) -> String {
+    // Distinct multi-line Read output to advance call_log / call_counter.
+    let body = format!("line one of read {n}\nline two of read {n}\nline three {n}");
+    format!(
+        r#"{{"tool_name":"Read","tool_result":{{"content":"{}"}}}}"#,
+        body.replace('\n', "\\n")
+    )
+}
+
 #[test]
-fn skill_body_is_compressed_on_first_injection() {
+fn first_skill_injection_is_recorded_not_rewritten() {
     let dir = tmp();
     let cfg = Config::default();
-    let body = skill_body();
-    let json = skill_json(&body);
+    let json = skill_json(&skill_body());
 
+    // First injection: recorded in the session-long store, body kept full-size.
     let rewrite = compute_rewrite(&json, "Skill", &dir, &cfg);
-    assert!(rewrite.is_some(), "first skill injection should be compressed");
-    let out = rewrite.unwrap();
-    assert!(out.len() < body.len(), "compressed body must be smaller");
-    assert!(out.contains("fn"), "function→fn substitution expected");
-    assert!(out.contains("w/"), "with→w/ substitution expected");
+    assert!(
+        rewrite.is_none(),
+        "first skill injection should be kept full-size, got: {rewrite:?}"
+    );
     let _ = std::fs::remove_dir_all(&dir);
 }
 
@@ -75,6 +83,32 @@ fn duplicate_skill_injection_is_deduped() {
     assert!(
         note.contains("identical to Skill"),
         "expected dedup note, got: {note}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn skill_dedup_survives_beyond_recent_window() {
+    // The session-long skill store must catch a re-injection even when far more
+    // than `recent_window` (16) other tool calls intervene — exactly the case
+    // the windowed `redundancy::check` would miss.
+    let dir = tmp();
+    let cfg = Config::default();
+    let json = skill_json(&skill_body());
+
+    // First injection.
+    assert!(compute_rewrite(&json, "Skill", &dir, &cfg).is_none());
+
+    // 25 distinct Read calls push the skill far outside any 16-call window.
+    for n in 0..25 {
+        let _ = compute_rewrite(&read_json(n), "Read", &dir, &cfg);
+    }
+
+    // Re-injection still dedups.
+    let again = compute_rewrite(&json, "Skill", &dir, &cfg);
+    assert!(
+        again.as_deref().is_some_and(|s| s.contains("identical to Skill")),
+        "re-injection after 25 calls should still dedup, got: {again:?}"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Summary

Pivots the skill-body work from **lexical** compression (measured ~1% on real skill bodies) to **structural** dedup of repeated skill injections (measured ~15% of a real session).

Measuring `compress-md --ultra` on the real `DEBUG_error-detective` body: **6755 → 6709 B = -0.7%**. Skill bodies are structured checklists + code, not prose — there is almost nothing to abbreviate. The real cost is the *same skill injected twice* in a session (byte-identical), which the existing dedup misses because `redundancy::check` only scans the last `recent_window = 16` calls and the injections recur far apart.

## Changes

- **New session-long skill-injection dedup** (`SessionContext`): unbounded store keyed by FNV-1a hash of the body, outside the 16-call window. A repeat collapses to `[squeez: identical to Skill #N — body omitted]`.
- **Remove on-disk skill compression** (`skill_targets`/`collect_md` + `compress_skills` config): ~1% gain, pollutes skill dirs with `.original.md`; `references/*.md` are already summarized via the Read PostToolUse path.
- **Remove the lexical `compress-md` pass** on the Skill branch + fix the false "prose-heavy" comment.
- README: document the new skill re-injection dedup under secondary wins.

## Verification

- `cargo test` → **682 passed, 0 failed**.
- New tests: `cache.rs` round-trip/persistence of the store; `test_compress_output_skill.rs` first-injection-kept, duplicate-deduped, and **`skill_dedup_survives_beyond_recent_window`** (proves dedup fires after 25 intervening calls).
- E2E against the real `DEBUG_error-detective` body: 6755 B → 123 B rewrite payload, dedup fires across 25 intervening Read calls.

Closes #141
