### PR TITLE
fix(codex): emit current PreToolUse/SessionStart hook shapes; silence PostToolUse

### DIFF
--- a/hooks/codex-posttooluse.sh
+++ b/hooks/codex-posttooluse.sh
@@ -12,6 +12,7 @@ fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
 export SQUEEZ_DIR="$HOME/.codex/squeez"
+export SQUEEZ_BIN="$SQUEEZ"
 
 python3 -c "
 import json, sys, subprocess, os
@@ -25,12 +26,16 @@ except json.JSONDecodeError:
     sys.exit(0)
 
 tool = d.get('tool_name') or d.get('tool') or 'unknown'
+# Tracking-only hook: record state, emit nothing. Codex treats exit 0 with no
+# stdout as success, so suppress any subprocess output to keep the channel clean.
 try:
     subprocess.run(
-        [os.environ.get('SQUEEZ') or '$SQUEEZ', 'track-result', tool],
+        [os.environ['SQUEEZ_BIN'], 'track-result', tool],
         input=data,
         timeout=3,
         check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 except Exception:
     pass

--- a/hooks/codex-pretooluse.sh
+++ b/hooks/codex-pretooluse.sh
@@ -30,7 +30,8 @@ except json.JSONDecodeError:
     sys.exit(0)
 
 tool = d.get('tool_name') or d.get('tool') or ''
-if tool not in ('bash', 'Bash', 'shell', 'run_shell_command'):
+if tool not in ('bash', 'Bash', 'shell', 'Shell', 'run_shell_command',
+                'exec_command', 'local_shell', 'shell_command'):
     sys.exit(0)
 
 inp = d.get('tool_input') or {}
@@ -43,7 +44,15 @@ if cmd.startswith(squeez) or 'squeez wrap' in cmd or cmd.startswith('--no-squeez
     sys.exit(0)
 
 inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)
-# Codex runtime explicitly rejects updatedInput for non-Bash PreToolUse
-# (openai/codex#18491). For Bash/shell it still applies the rewrite.
-print(json.dumps({'decision': 'allow', 'updatedInput': inp}))
+# Current Codex requires the rewrite nested under hookSpecificOutput with
+# permissionDecision 'allow'; the older top-level {'decision','updatedInput'}
+# shape is rejected ('hook returned invalid pre-tool-use JSON output').
+# updatedInput for non-Bash tools is still unsupported (openai/codex#18491).
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'PreToolUse',
+        'permissionDecision': 'allow',
+        'updatedInput': inp,
+    }
+}))
 "

--- a/hooks/codex-session-start.sh
+++ b/hooks/codex-session-start.sh
@@ -13,4 +13,20 @@ fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
 export SQUEEZ_DIR="$HOME/.codex/squeez"
-"$SQUEEZ" init --host=codex 2>/dev/null || true
+
+# `init` finalizes the previous session and prints the banner + memory block.
+# Codex expects SessionStart context wrapped under hookSpecificOutput with
+# `additionalContext`; raw stdout is accepted today but not the documented shape.
+SQUEEZ_CONTEXT="$("$SQUEEZ" init --host=codex 2>/dev/null || true)"
+
+if [ -n "$SQUEEZ_CONTEXT" ]; then
+    SQUEEZ_CONTEXT="$SQUEEZ_CONTEXT" python3 -c '
+import json, os
+print(json.dumps({
+    "hookSpecificOutput": {
+        "hookEventName": "SessionStart",
+        "additionalContext": os.environ["SQUEEZ_CONTEXT"],
+    }
+}))
+'
+fi

--- a/src/hosts/codex.rs
+++ b/src/hosts/codex.rs
@@ -10,13 +10,15 @@
 //! Partial hook surface as of Codex 0.123.0 (2026-04-23):
 //! - `apply_patch` now emits `PreToolUse`/`PostToolUse` (PR openai/codex#18391)
 //! - `read_file` and `grep` still have no hook surface
-//! - `updatedInput` in `PreToolUse` responses is explicitly rejected by the
-//!   Codex runtime (`output_parser.rs`: "PreToolUse hook returned unsupported
-//!   updatedInput") — tracked in openai/codex#18491
+//! - `PreToolUse` command rewrites for Bash/shell ARE applied, but only when
+//!   returned in the current shape: `hookSpecificOutput` with
+//!   `permissionDecision: "allow"` + `updatedInput`. The older top-level
+//!   `{"decision":"allow","updatedInput":…}` shape is rejected by the runtime.
+//!   Extending `updatedInput` to non-Bash tools is tracked in openai/codex#18491.
 //!
-//! Until `updatedInput` + `read_file`/`grep` hooks land upstream,
-//! Read/Grep budget enforcement ships as **soft** via a prose hint in the
-//! AGENTS.md block written by `inject_memory`.
+//! `read_file`/`grep` have no hook surface, so Read/Grep budget enforcement
+//! ships as **soft** via a prose hint in the AGENTS.md block written by
+//! `inject_memory`.
 //!
 //! JSON patching of `hooks.json` uses a python3 subprocess, consistent
 //! with every other adapter in this crate.

--- a/tests/test_hosts_codex.rs
+++ b/tests/test_hosts_codex.rs
@@ -173,6 +173,112 @@ fn codex_install_idempotent_no_dup_entries() {
     });
 }
 
+/// Create a fake executable `squeez` under <home>/.claude/squeez/bin so the
+/// hook scripts resolve `$SQUEEZ` to a real path. PreToolUse never executes it
+/// (it only string-builds the rewritten command), so a stub is enough.
+fn fake_squeez(home: &PathBuf) -> PathBuf {
+    let bin = home.join(".claude/squeez/bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let p = bin.join("squeez");
+    std::fs::write(&p, "#!/bin/sh\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    p
+}
+
+fn run_hook(script: &str, home: &PathBuf, stdin: &str) -> std::process::Output {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    let mut child = Command::new("bash")
+        .arg(format!("hooks/{script}"))
+        .env("HOME", home)
+        .env_remove("USERPROFILE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+#[test]
+fn codex_pretooluse_emits_current_hookspecificoutput_shape() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls -la"}}"#;
+        let out = run_hook("codex-pretooluse.sh", home, payload);
+        assert!(out.status.success(), "hook should exit 0");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // Current Codex schema: nested hookSpecificOutput / permissionDecision.
+        assert!(stdout.contains("hookSpecificOutput"), "got: {stdout}");
+        assert!(stdout.contains("\"hookEventName\": \"PreToolUse\"") || stdout.contains("\"hookEventName\":\"PreToolUse\""), "got: {stdout}");
+        assert!(stdout.contains("\"permissionDecision\": \"allow\"") || stdout.contains("\"permissionDecision\":\"allow\""), "got: {stdout}");
+        assert!(stdout.contains("updatedInput"), "got: {stdout}");
+        assert!(stdout.contains("wrap"), "command should be wrapped, got: {stdout}");
+        // Must NOT use the stale top-level decision shape.
+        assert!(!stdout.contains("\"decision\""), "stale shape leaked: {stdout}");
+    });
+}
+
+#[test]
+fn codex_pretooluse_ignores_non_shell_tool() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"read_file","tool_input":{"path":"/etc/hosts"}}"#;
+        let out = run_hook("codex-pretooluse.sh", home, payload);
+        assert!(out.status.success());
+        assert!(out.stdout.is_empty(), "non-shell tool must produce no rewrite");
+    });
+}
+
+#[test]
+fn codex_posttooluse_is_silent_on_success() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"tool_name":"Bash","tool_result":{"content":"ok"}}"#;
+        let out = run_hook("codex-posttooluse.sh", home, payload);
+        assert!(out.status.success(), "tracking hook should exit 0");
+        assert!(out.stdout.is_empty(), "tracking hook must emit no stdout, got: {:?}", String::from_utf8_lossy(&out.stdout));
+    });
+}
+
+#[test]
+fn codex_session_start_wraps_context_when_present() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let out = run_hook("codex-session-start.sh", home, "");
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // The stub squeez emits no init output, so the hook stays silent.
+        // If anything is emitted it must be the documented SessionStart shape.
+        if !stdout.trim().is_empty() {
+            assert!(stdout.contains("hookSpecificOutput"), "got: {stdout}");
+            assert!(stdout.contains("additionalContext"), "got: {stdout}");
+        }
+    });
+}
+
 #[test]
 fn codex_uninstall_removes_hooks_and_strips_memory_block() {
     if python3_missing() {


### PR DESCRIPTION
## Summary

Fixes #140. The Codex hook scripts emitted stale output shapes, so current Codex rejected the `PreToolUse` rewrite (`error: hook returned invalid pre-tool-use JSON output`) and silently dropped the `squeez wrap` rewrite.

Schemas verified against the [official Codex hooks docs](https://developers.openai.com/codex/hooks).

## Changes

- **`codex-pretooluse.sh`** — emit the current shape: `hookSpecificOutput` + `permissionDecision: "allow"` + `updatedInput` (the old top-level `{"decision","updatedInput"}` is rejected). Broaden the shell matcher to `exec_command` / `local_shell` / `shell_command` / `Shell`.
- **`codex-posttooluse.sh`** — fix a latent bug: `$SQUEEZ` was never exported to the Python env, so `track-result` ran against the literal string `$SQUEEZ` and failed. Export `SQUEEZ_BIN` and suppress stdout/stderr (tracking-only hook → exit 0, clean channel).
- **`codex-session-start.sh`** — wrap `init` output under `hookSpecificOutput` / `additionalContext` (documented SessionStart shape).
- **`codex.rs`** — correct the module doc: `updatedInput` IS applied for Bash/shell in the current shape; only non-Bash tools remain unsupported (openai/codex#18491).

## Verification

- `cargo test` → **686 passed, 0 failed** (4 new `test_hosts_codex.rs` replay tests: PreToolUse shape, non-shell ignored, PostToolUse silent, SessionStart shape).
- Replay matches the issue's expected output exactly:
  ```json
  {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow", "updatedInput": {"command": "<squeez-bin> wrap 'ls -la'"}}}
  ```

Closes #140
