### PR TITLE
fix(hooks): strip --no-squeez marker in codex and gemini pretooluse hooks

### DIFF
--- a/hooks/codex-pretooluse.sh
+++ b/hooks/codex-pretooluse.sh
@@ -40,7 +40,17 @@ if not cmd or not isinstance(cmd, str):
     sys.exit(0)
 
 squeez = os.environ['SQUEEZ_BIN']
-if cmd.startswith(squeez) or 'squeez wrap' in cmd or cmd.startswith('--no-squeez'):
+if cmd.startswith(squeez) or 'squeez wrap' in cmd:
+    sys.exit(0)
+if cmd.startswith('--no-squeez'):
+    inp['command'] = cmd[len('--no-squeez'):].lstrip()
+    print(json.dumps({
+        'hookSpecificOutput': {
+            'hookEventName': 'PreToolUse',
+            'permissionDecision': 'allow',
+            'updatedInput': inp,
+        }
+    }))
     sys.exit(0)
 
 inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)

--- a/hooks/gemini-before-tool.sh
+++ b/hooks/gemini-before-tool.sh
@@ -38,7 +38,11 @@ if tool in ('bash', 'Bash', 'run_shell_command'):
     cmd = inp.get('command') or inp.get('cmd')
     if not cmd or not isinstance(cmd, str):
         sys.exit(0)
-    if cmd.startswith(squeez) or 'squeez wrap' in cmd or cmd.startswith('--no-squeez'):
+    if cmd.startswith(squeez) or 'squeez wrap' in cmd:
+        sys.exit(0)
+    if cmd.startswith('--no-squeez'):
+        inp['command'] = cmd[len('--no-squeez'):].lstrip()
+        print(json.dumps({'decision': 'allow', 'updatedInput': inp}))
         sys.exit(0)
     inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)
     print(json.dumps({'decision': 'allow', 'updatedInput': inp}))

--- a/tests/test_hosts_codex.rs
+++ b/tests/test_hosts_codex.rs
@@ -279,6 +279,45 @@ fn codex_session_start_wraps_context_when_present() {
     });
 }
 
+// ── #144/#145: --no-squeez opt-out must strip marker, not leak it ─────────
+
+#[test]
+fn codex_pretooluse_strips_no_squeez_marker() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"--no-squeez cargo test"}}"#;
+        let out = run_hook("codex-pretooluse.sh", home, payload);
+        assert!(out.status.success(), "hook must exit 0");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        // Must emit updatedInput with the marker stripped.
+        assert!(stdout.contains("updatedInput"), "must emit updatedInput: {stdout}");
+        assert!(stdout.contains("cargo test"), "stripped command must appear: {stdout}");
+        assert!(!stdout.contains("--no-squeez"), "marker must be stripped: {stdout}");
+        // Must not wrap the command with squeez wrap.
+        assert!(!stdout.contains("squeez wrap"), "bypass must not wrap: {stdout}");
+    });
+}
+
+#[test]
+fn codex_pretooluse_strips_no_squeez_with_extra_space() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Shell","tool_input":{"command":"--no-squeez  sqlite3 db.sqlite 'SELECT 1'"}}"#;
+        let out = run_hook("codex-pretooluse.sh", home, payload);
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("updatedInput"), "must emit updatedInput: {stdout}");
+        assert!(!stdout.contains("--no-squeez"), "marker must be stripped: {stdout}");
+        assert!(stdout.contains("sqlite3"), "real command must survive: {stdout}");
+    });
+}
+
 #[test]
 fn codex_uninstall_removes_hooks_and_strips_memory_block() {
     if python3_missing() {

--- a/tests/test_hosts_gemini.rs
+++ b/tests/test_hosts_gemini.rs
@@ -214,3 +214,84 @@ fn gemini_uninstall_removes_hooks_and_strips_memory_block() {
         assert!(!md.contains("<!-- squeez:start -->"));
     });
 }
+
+// ── helpers for hook script invocation ────────────────────────────────────
+
+fn fake_squeez(home: &std::path::Path) -> std::path::PathBuf {
+    let bin = home.join(".claude/squeez/bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    let p = bin.join("squeez");
+    std::fs::write(&p, "#!/bin/sh\nexit 0\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    p
+}
+
+fn run_hook(script: &str, home: &std::path::Path, stdin: &str) -> std::process::Output {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+    let mut child = Command::new("bash")
+        .arg(format!("hooks/{script}"))
+        .env("HOME", home)
+        .env_remove("USERPROFILE")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn hook");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(stdin.as_bytes())
+        .unwrap();
+    child.wait_with_output().unwrap()
+}
+
+fn python3_missing() -> bool {
+    std::process::Command::new("python3")
+        .arg("--version")
+        .status()
+        .map(|s| !s.success())
+        .unwrap_or(true)
+}
+
+// ── #145: gemini-before-tool.sh must strip --no-squeez, not leak it ───────
+
+#[test]
+fn gemini_before_tool_strips_no_squeez_marker() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"tool_name":"bash","tool_input":{"command":"--no-squeez cargo test"}}"#;
+        let out = run_hook("gemini-before-tool.sh", home, payload);
+        assert!(out.status.success(), "hook must exit 0");
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("updatedInput"), "must emit updatedInput: {stdout}");
+        assert!(stdout.contains("cargo test"), "stripped command must appear: {stdout}");
+        assert!(!stdout.contains("--no-squeez"), "marker must be stripped: {stdout}");
+        assert!(!stdout.contains("squeez wrap"), "bypass must not wrap: {stdout}");
+    });
+}
+
+#[test]
+fn gemini_before_tool_strips_no_squeez_with_extra_space() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        fake_squeez(home);
+        let payload = r#"{"tool_name":"run_shell_command","tool_input":{"command":"--no-squeez  echo hi"}}"#;
+        let out = run_hook("gemini-before-tool.sh", home, payload);
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("updatedInput"), "must emit updatedInput: {stdout}");
+        assert!(!stdout.contains("--no-squeez"), "marker must be stripped: {stdout}");
+        assert!(stdout.contains("echo hi"), "real command must survive: {stdout}");
+    });
+}


### PR DESCRIPTION
## Summary

- Fixes `codex-pretooluse.sh` and `gemini-before-tool.sh`: when a command starts with `--no-squeez`, both hooks exited `0` **without emitting `updatedInput`**, so the literal `--no-squeez` prefix was passed to the shell verbatim and caused errors like `--no-squeez: command not found`.
- Split the bypass into its own branch: strip the marker with `.lstrip()` (handles extra whitespace), re-emit `updatedInput` with the clean command, then exit. The Claude Code and Copilot hooks already did this correctly; these two hooks now match.

Closes #144. Closes #145.

## Test plan

- [x] `codex_pretooluse_strips_no_squeez_marker` — `--no-squeez cargo test` → `updatedInput.command = "cargo test"`, no `--no-squeez` in output
- [x] `codex_pretooluse_strips_no_squeez_with_extra_space` — `--no-squeez  sqlite3 ...` → leading spaces handled via `.lstrip()`
- [x] `gemini_before_tool_strips_no_squeez_marker` — same for Gemini hook
- [x] `gemini_before_tool_strips_no_squeez_with_extra_space` — same for Gemini hook with extra space
- [x] Existing tests: `cargo test` — all 15 codex + 11 gemini tests pass, full suite clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)