### PR TITLE
feat(sig-mode): capture indented method signatures inside impl/class blocks

### DIFF
--- a/src/commands/fs.rs
+++ b/src/commands/fs.rs
@@ -227,10 +227,46 @@ fn is_signature(line: &str, lang: &str) -> bool {
     }
 }
 
+/// Returns true if `line` starts with whitespace and after trimming looks like
+/// a signature — i.e., a method/function inside an impl block or class.
+/// Only called when `sig_mode_include_indented` is enabled.
+///
+/// TypeScript extra rules: positively match class-member access modifiers
+/// (`public`/`private`/…); veto `const`/`let`/`var`/`type`/`interface`/`enum`
+/// when indented so they are not mistaken for method signatures.
+fn is_indented_signature(line: &str, lang: &str) -> bool {
+    if !line.starts_with(|c: char| c.is_whitespace()) {
+        return false;
+    }
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() {
+        return false;
+    }
+    match lang {
+        "ts" => {
+            const BODY_VETOES: &[&str] = &[
+                "const ", "let ", "var ", "type ", "interface ", "enum ",
+            ];
+            if BODY_VETOES.iter().any(|v| trimmed.starts_with(v)) {
+                return false;
+            }
+            const CLASS_MODIFIERS: &[&str] = &[
+                "public ", "private ", "protected ", "static ", "async ",
+                "get ", "set ", "readonly ", "abstract ", "override ",
+            ];
+            if CLASS_MODIFIERS.iter().any(|m| trimmed.starts_with(m)) {
+                return true;
+            }
+            is_signature(trimmed, lang)
+        }
+        _ => is_signature(trimmed, lang),
+    }
+}
+
 /// Compress to signature lines, preserving first-3 and last-3 verbatim,
-/// plus indented method signatures inside `impl`/`class` blocks, plus any
-/// **single** attribute / decorator line that immediately precedes a kept
-/// signature.
+/// plus (optionally) indented method signatures inside `impl`/`class` blocks,
+/// plus any **single** attribute / decorator line that immediately precedes a
+/// kept signature.
 ///
 /// Why single-slot instead of a full doc-block buffer: dense-signature files
 /// (10 structs × 5 methods × 1 doc each) would double the kept-line count
@@ -238,7 +274,15 @@ fn is_signature(line: &str, lang: &str) -> bool {
 /// then *cost* tokens instead of saving them. Attributes (`#[inline]`,
 /// `@staticmethod`) carry the highest-density semantic information per byte,
 /// so they're the cell we keep.
-fn compress_signatures(lines: Vec<String>, lang: &str) -> Vec<String> {
+///
+/// Indented-sig cap: total middle lines are capped at `max_total_middle` to
+/// keep sig-mode output under the pipeline's `find_max_results` budget.
+fn compress_signatures(
+    lines: Vec<String>,
+    lang: &str,
+    include_indented: bool,
+    max_total_middle: usize,
+) -> Vec<String> {
     let total = lines.len();
     let anchor_count = 3.min(total / 2); // don't overlap on tiny files
 
@@ -250,6 +294,7 @@ fn compress_signatures(lines: Vec<String>, lang: &str) -> Vec<String> {
 
     let mut middle: Vec<String> = Vec::new();
     let mut pending: Option<String> = None;
+    let mut indented_count: usize = 0;
     for (i, line) in lines.iter().enumerate() {
         if i < head_end || i >= tail_start {
             pending = None;
@@ -260,7 +305,15 @@ fn compress_signatures(lines: Vec<String>, lang: &str) -> Vec<String> {
             pending = Some(line.clone());
             continue;
         }
-        if is_signature(s, lang) {
+        let is_top_level = is_signature(s, lang);
+        let is_indented = !is_top_level
+            && include_indented
+            && indented_count < max_total_middle
+            && is_indented_signature(s, lang);
+        if is_top_level || is_indented {
+            if is_indented {
+                indented_count += 1;
+            }
             if let Some(ctx) = pending.take() {
                 middle.push(ctx);
             }
@@ -288,7 +341,13 @@ impl Handler for FsHandler {
                 let k = lines.len();
                 if k >= config.sig_mode_threshold_lines {
                     let filtered = smart_filter::apply(lines);
-                    let compressed = compress_signatures(filtered, lang);
+                    let max_middle = config.find_max_results.saturating_sub(6);
+                    let compressed = compress_signatures(
+                        filtered,
+                        lang,
+                        config.sig_mode_include_indented,
+                        max_middle,
+                    );
                     let n_sigs = compressed.len();
                     let marker = format!(
                         "[squeez: sig-mode {} signatures from {} lines — use `sed -n A,Bp {}` for a range]",

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,8 @@ pub struct Config {
     pub sig_mode_enabled: bool,
     /// Minimum line count to trigger signature-mode (default 400).
     pub sig_mode_threshold_lines: usize,
+    /// Also capture indented method signatures inside impl/class blocks (default false).
+    pub sig_mode_include_indented: bool,
     // ── Memory-file size warning (US-002) ───────────────────────────────────
     /// Token threshold above which inject_memory emits a size warning banner
     /// inside the squeez block. Set to 0 to disable. Default: 1000.
@@ -168,6 +170,7 @@ impl Default for Config {
             state_warn_calls: 10,
             sig_mode_enabled: true,
             sig_mode_threshold_lines: 400,
+            sig_mode_include_indented: false,
             memory_file_warn_tokens: 1000,
             summary_format: "auto".to_string(),
             agent_prompt_max_tokens: 2000,
@@ -279,6 +282,9 @@ impl Config {
                     "sig_mode_threshold_lines" => {
                         c.sig_mode_threshold_lines =
                             v.parse().unwrap_or(c.sig_mode_threshold_lines)
+                    }
+                    "sig_mode_include_indented" => {
+                        c.sig_mode_include_indented = v == "true"
                     }
                     "memory_file_warn_tokens" => {
                         c.memory_file_warn_tokens =

--- a/tests/test_sig_mode.rs
+++ b/tests/test_sig_mode.rs
@@ -320,3 +320,145 @@ fn python_decorator_above_signature_is_kept() {
         result.join("\n"),
     );
 }
+
+// ── #139: sig_mode_include_indented — capture methods inside impl/class ───
+
+/// Rust impl block: methods are indented and currently invisible to sig-mode.
+fn make_rust_impl_heavy(n: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push("//! Library with impl-heavy structure.".to_string());
+    lines.push("use std::fmt;".to_string());
+    lines.push("".to_string());
+    let mut i = 0usize;
+    while lines.len() + 25 <= n {
+        lines.push(format!("pub struct Widget{} {{", i));
+        lines.push(format!("    pub id: u64,"));
+        lines.push("}".to_string());
+        lines.push("".to_string());
+        lines.push(format!("impl Widget{} {{", i));
+        for j in 0..4usize {
+            lines.push(format!("    pub fn method_{}_{}(&self) -> u64 {{", i, j));
+            for k in 0..3usize {
+                lines.push(format!("        let x{} = self.id + {};", k, k));
+            }
+            lines.push("    }".to_string());
+        }
+        lines.push("}".to_string());
+        lines.push("".to_string());
+        i += 1;
+    }
+    while lines.len() < n {
+        lines.push(format!("// padding {}", lines.len()));
+    }
+    lines.truncate(n);
+    lines
+}
+
+/// TypeScript class: methods are indented.
+fn make_ts_class_heavy(n: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push("// TypeScript class fixture".to_string());
+    lines.push("import { Injectable } from '@angular/core';".to_string());
+    lines.push("".to_string());
+    let mut i = 0usize;
+    while lines.len() + 20 <= n {
+        lines.push(format!("export class Service{} {{", i));
+        for j in 0..3usize {
+            lines.push(format!("  public method_{}_{}(x: number): string {{", i, j));
+            for k in 0..4usize {
+                lines.push(format!("    const v{} = x + {};", k, k));
+            }
+            lines.push("  }".to_string());
+        }
+        lines.push("}".to_string());
+        lines.push("".to_string());
+        i += 1;
+    }
+    while lines.len() < n {
+        lines.push(format!("// pad {}", lines.len()));
+    }
+    lines.truncate(n);
+    lines
+}
+
+#[test]
+fn indented_sig_mode_off_by_default_no_impl_methods() {
+    let lines = make_rust_impl_heavy(500);
+    let cfg = Config::default(); // sig_mode_include_indented defaults to false
+    let result = FsHandler.compress("cat src/lib.rs", lines, &cfg);
+    // Sig-mode fires (file >400 lines) but indented methods are NOT captured.
+    assert!(
+        result[0].starts_with("[squeez: sig-mode"),
+        "sig-mode must fire: {:?}",
+        result[0]
+    );
+    let body = result[1..].join("\n");
+    // Top-level impl declarations ARE captured (they're at column 0).
+    // Indented method sigs (pub fn method_0_0) are NOT in default mode.
+    assert!(
+        !body.contains("pub fn method_0_0"),
+        "indented methods must NOT appear without flag: {body}",
+    );
+}
+
+#[test]
+fn rust_impl_methods_captured_when_include_indented_enabled() {
+    let lines = make_rust_impl_heavy(500);
+    let mut cfg = Config::default();
+    cfg.sig_mode_include_indented = true;
+    let result = FsHandler.compress("cat src/lib.rs", lines, &cfg);
+    assert!(
+        result[0].starts_with("[squeez: sig-mode"),
+        "sig-mode must fire: {:?}",
+        result[0]
+    );
+    let body = result[1..].join("\n");
+    assert!(
+        body.contains("pub fn method_0_0"),
+        "indented Rust methods must be captured: {body}",
+    );
+    assert!(
+        body.contains("pub fn method_0_1"),
+        "multiple indented methods must be captured: {body}",
+    );
+}
+
+#[test]
+fn ts_class_methods_captured_when_include_indented_enabled() {
+    let lines = make_ts_class_heavy(500);
+    let mut cfg = Config::default();
+    cfg.sig_mode_include_indented = true;
+    let result = FsHandler.compress("cat src/service.ts", lines, &cfg);
+    assert!(
+        result[0].starts_with("[squeez: sig-mode"),
+        "sig-mode must fire: {:?}",
+        result[0]
+    );
+    let body = result[1..].join("\n");
+    assert!(
+        body.contains("public method_0_0"),
+        "indented TS class methods must be captured: {body}",
+    );
+}
+
+#[test]
+fn indented_sig_cap_limits_indented_count() {
+    // The cap on indented sigs is (find_max_results - 6) to guard against runaway
+    // growth on dense impl-heavy files. Top-level sigs remain uncapped.
+    let lines = make_rust_impl_heavy(500);
+    let mut cfg = Config::default();
+    cfg.sig_mode_include_indented = true;
+    let result = FsHandler.compress("cat src/lib.rs", lines, &cfg);
+    assert!(
+        result[0].starts_with("[squeez: sig-mode"),
+        "sig-mode must fire: {:?}",
+        result[0]
+    );
+    // Count captured indented method lines (they contain "pub fn method_").
+    let indented_captured = result.iter().filter(|l| l.contains("pub fn method_")).count();
+    let cap = cfg.find_max_results.saturating_sub(6);
+    assert!(
+        indented_captured <= cap,
+        "indented sigs captured ({indented_captured}) must not exceed cap ({cap})",
+    );
+}


### PR DESCRIPTION
## Summary

- Adds  (opt-in) to config — when true, sig-mode also captures methods indented inside Rust `impl` blocks, TypeScript/Python/Java class bodies, etc.
- Before this change, `is_signature` only matched lines at column 0, so `impl Foo {}` + `class Bar {}` dominated the kept-line budget while their actual methods were invisible.
- TypeScript: class-member modifiers (`public`/`private`/`protected`/`static`/`async`/`get`/`set`/`readonly`/`abstract`/`override`) are positively matched; body-content prefixes (`const`/`let`/`var`/`type`/`interface`/`enum`) are vetoed.
- Cap: indented sigs limited to `find_max_results - 6` (default 44) so dense impl-heavy files stay bounded. Top-level sigs remain uncapped (no behavior change).
- Default `false` → the `sig_mode_delta_vs_pipeline` benchmark proof is unaffected.

Closes #139.

## Test plan

- [x] `indented_sig_mode_off_by_default_no_impl_methods` — default config: indented methods absent from sig-mode output
- [x] `rust_impl_methods_captured_when_include_indented_enabled` — `pub fn method_0_0` and `method_0_1` appear when flag enabled
- [x] `ts_class_methods_captured_when_include_indented_enabled` — TS `public method_0_0(…)` captured when flag enabled
- [x] `indented_sig_cap_limits_indented_count` — captured indented count ≤ `find_max_results - 6`
- [x] All existing sig-mode tests pass (17/17)
- [x] Full suite clean (`cargo test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)