### PR TITLE
fix(fs): stop collapsing ls/find listings to "N modified" count

### DIFF
--- a/src/commands/fs.rs
+++ b/src/commands/fs.rs
@@ -1,6 +1,6 @@
 use crate::commands::Handler;
 use crate::config::Config;
-use crate::strategies::{grouping, smart_filter, truncation};
+use crate::strategies::{smart_filter, truncation};
 
 pub struct FsHandler;
 
@@ -402,15 +402,13 @@ impl Handler for FsHandler {
             return truncation::apply(filtered, 80, truncation::Keep::Head);
         }
 
-        // Viewer commands (cat/head/tail/less/more/bat) emit file CONTENT,
-        // not file LISTS — grouping by parent-dir would collapse every line
-        // into a single "./ N modified" summary. Skip grouping for those.
-        let is_viewer = base_cmd(cmd).map(|b| VIEWER_CMDS.contains(&b)).unwrap_or(false);
-        let lines = if is_viewer {
-            lines
-        } else {
-            grouping::group_files_by_dir(lines, 5)
-        };
+        // Do NOT collapse listings to a per-dir count. For `ls`/`find`/`du`
+        // (and viewer content) the lines ARE the payload — they are exactly
+        // what the caller asked for. `group_files_by_dir` was designed for
+        // git-status output, where the path list is incidental context; using
+        // it here discards every name and mislabels a plain listing as a
+        // change-set ("N modified"). Bound size with truncation instead, which
+        // keeps the names visible (head) + a `[... N truncated]` marker. See #148.
         let keep = if should_keep_tail(cmd) {
             truncation::Keep::Tail
         } else {

--- a/tests/test_filter_dispatch.rs
+++ b/tests/test_filter_dispatch.rs
@@ -43,14 +43,54 @@ fn monitor_routes_without_panic() {
 }
 
 #[test]
-fn bfs_output_is_compressible_like_find() {
-    // bfs should use FsHandler — many files in same dir should be grouped
+fn bfs_output_is_handled_like_find() {
+    // bfs uses FsHandler. The file names are the payload, so a listing under
+    // the truncation limit passes through verbatim (see #148).
     let many_files: Vec<String> = (0..10)
         .map(|i| format!("/project/src/file{i}.rs"))
         .collect();
-    let out = filter::compress("bfs /project/src -name '*.rs'", many_files, &cfg());
-    // FsHandler groups sibling files; output should be shorter than input
-    assert!(!out.is_empty());
+    let out = filter::compress("bfs /project/src -name '*.rs'", many_files.clone(), &cfg());
+    assert_eq!(out, many_files, "listing under the limit should pass through unchanged");
+}
+
+#[test]
+fn ls_listing_is_not_collapsed_to_modified_count() {
+    // Regression for #148: `ls`/`find` listings must NOT be collapsed to a
+    // per-dir "N modified" count. The names are the answer the caller asked
+    // for, and nothing was "modified" — that verb is borrowed from git-status.
+    let files: Vec<String> = (0..8)
+        .map(|i| format!("src/datamodel/Booking/file{i}.rs"))
+        .collect();
+    let out = filter::compress("ls -1 src/datamodel/Booking/", files.clone(), &cfg());
+    assert!(
+        !out.iter().any(|l| l.contains("modified")),
+        "listing must not be mislabeled as a change-set: {out:?}"
+    );
+    assert!(
+        !out.iter().any(|l| l.contains("[squeez grouped]")),
+        "listing must not be collapsed to a count: {out:?}"
+    );
+    // Every name is still visible (8 < find_max_results default of 50).
+    assert_eq!(out, files, "names are the payload and must pass through");
+}
+
+#[test]
+fn long_find_listing_is_truncated_not_grouped() {
+    // A genuinely long listing is bounded by truncation (visible head + a
+    // truncation marker), never collapsed to a single dir count.
+    let files: Vec<String> = (0..120).map(|i| format!("deep/dir/f{i}.rs")).collect();
+    let out = filter::compress("find deep -type f", files, &cfg());
+    assert!(out.len() < 120, "long listing should be bounded");
+    assert!(
+        out.iter().any(|l| l.contains("truncated")),
+        "expected a truncation marker, got: {out:?}"
+    );
+    assert!(
+        !out.iter().any(|l| l.contains("modified") || l.contains("[squeez grouped]")),
+        "must truncate, not group: {out:?}"
+    );
+    // The first names are still visible verbatim.
+    assert_eq!(out[0], "deep/dir/f0.rs");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`FsHandler` ran `grouping::group_files_by_dir(lines, 5)` on every non-viewer fs command, collapsing any directory with ≥5 siblings to a single `<dir>/  N modified  [squeez grouped]` line. That strategy is designed for **git-status** output, where the path list is incidental context. For `ls`/`find`/`du` the **names are the payload** — so the collapse discarded the exact answer the caller asked for and mislabeled a plain listing as a change-set (nothing was "modified").

This routes listings straight to truncation, which keeps the names visible (head) and bounds size with a `[... N truncated]` marker. Listings under `find_max_results` (default 50) now pass through verbatim; genuinely long ones are truncated, never collapsed to a count. `git.rs` still uses grouping, where it's correct.

This is the issue's recommended minimal fix (**A + D**): stop grouping listings, and the wrong "modified" verb disappears for listing commands as a consequence.

## Verification

Real binary, reproducing the issue's scenario (8-entry dir):

```
$ squeez wrap "ls -1 /tmp/sq148/Booking"
# squeez [ls] 17→17 tokens ...
fare.rs
flight.rs
leg.rs
price.rs
route.rs
seat.rs
segment.rs
tax.rs
```

Previously this printed `./  8 modified  [squeez grouped]`.

- `cargo test` — all green; 3 new regression tests in `tests/test_filter_dispatch.rs`.
- `bash bench/run.sh` — 18/18 pass; all FsHandler fixtures stay above the 30% floor (`find_deep` 69%→35%, `ls_la` 52% and `ps_aux` 95% unchanged).

Closes #148
