### PR TITLE
feat(retrieve): reversible compression + squeez_retrieve MCP tool

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -101,6 +101,9 @@ const SCHEMA: &[(&str, Kind)] = &[
     ("parallel_agent_burst_threshold", Kind::Usize),
     ("subagent_total_warn_tokens", Kind::U64),
     ("call_rate_warn_per_min", Kind::U32),
+    ("retrieve_enabled", Kind::Bool),
+    ("retrieve_ttl_days", Kind::U64),
+    ("retrieve_min_lines", Kind::Usize),
 ];
 
 fn kind_of(key: &str) -> Option<Kind> {
@@ -170,6 +173,9 @@ fn field_value(c: &Config, key: &str) -> Option<String> {
         "parallel_agent_burst_threshold" => c.parallel_agent_burst_threshold.to_string(),
         "subagent_total_warn_tokens" => c.subagent_total_warn_tokens.to_string(),
         "call_rate_warn_per_min" => c.call_rate_warn_per_min.to_string(),
+        "retrieve_enabled" => c.retrieve_enabled.to_string(),
+        "retrieve_ttl_days" => c.retrieve_ttl_days.to_string(),
+        "retrieve_min_lines" => c.retrieve_min_lines.to_string(),
         _ => return None,
     };
     Some(v)

--- a/src/commands/mcp_server.rs
+++ b/src/commands/mcp_server.rs
@@ -201,6 +201,11 @@ const TOOLS: &[(&str, &str, &str)] = &[
         "Enterprise-transport mode (Bedrock/Vertex/OTEL) plus USD-saved estimate for the current session at Anthropic's public Sonnet 4.6 rate. Use this to quantify the dollar value of compression on usage-based enterprise workspaces.",
         "{\"type\":\"object\",\"properties\":{}}",
     ),
+    (
+        "squeez_retrieve",
+        "Expand a compressed output back to its verbatim original. When squeez compresses a large bash output it prints a marker like `[squeez: full N-line output stored — call squeez_retrieve with key=\\\"<id>\\\" to expand]`. Pass that id as `key` to get the full original text back. Use only when the compressed view dropped something you actually need.",
+        "{\"type\":\"object\",\"properties\":{\"key\":{\"type\":\"string\",\"description\":\"the 16-hex blob id from a squeez retrieve marker\"}},\"required\":[\"key\"]}",
+    ),
 ];
 
 /// Render the `tools/list` response.
@@ -241,6 +246,7 @@ fn tools_call_response(id: &str, line: &str) -> String {
     let query = crate::json_util::extract_str(line, "query").unwrap_or_default();
     let path_arg = crate::json_util::extract_str(line, "path").unwrap_or_default();
     let date_arg = crate::json_util::extract_str(line, "date").unwrap_or_default();
+    let key_arg = crate::json_util::extract_str(line, "key").unwrap_or_default();
 
     let cfg = crate::config::Config::load();
     let text = match name.as_str() {
@@ -260,6 +266,7 @@ fn tools_call_response(id: &str, line: &str) -> String {
         "squeez_context_pressure" => tool_context_pressure(),
         "squeez_handler_stats" => tool_handler_stats(),
         "squeez_enterprise_savings" => tool_enterprise_savings(),
+        "squeez_retrieve" => tool_retrieve(&key_arg),
         other => return error_response(id, -32602, &format!("unknown tool: {}", other)),
     };
     text_result_response(id, &text)
@@ -809,6 +816,21 @@ fn tool_enterprise_savings() -> String {
     )
 }
 
+/// Expand a stashed original by blob id. Returns the verbatim text, or a clear
+/// not-found message when the id is malformed / expired / missing.
+fn tool_retrieve(key: &str) -> String {
+    if key.is_empty() {
+        return "squeez_retrieve: missing 'key' — pass the id from a [squeez: ... key=\"<id>\"] marker.".to_string();
+    }
+    match crate::context::retrieve::retrieve(key) {
+        Some(original) => original,
+        None => format!(
+            "squeez_retrieve: no stored output for key '{}'. It may be malformed, expired (past retrieve_ttl_days), or never stored.",
+            key
+        ),
+    }
+}
+
 /// Context pressure advisor: pressure %, calls remaining, tokens_saved, recommendation.
 fn tool_context_pressure() -> String {
     let ctx = load_ctx();
@@ -939,9 +961,19 @@ mod tests {
             "squeez_context_pressure",
             "squeez_handler_stats",
             "squeez_enterprise_savings",
+            "squeez_retrieve",
         ] {
             assert!(resp.contains(name), "missing tool {}", name);
         }
+    }
+
+    #[test]
+    fn tool_retrieve_handles_missing_and_bad_keys() {
+        // Round-trip through the real store is covered in context::retrieve.
+        // Here we lock down the dispatcher's safety branches (no global env).
+        assert!(tool_retrieve("").contains("missing 'key'"));
+        assert!(tool_retrieve("../etc/passwd").contains("no stored output"));
+        assert!(tool_retrieve("ZZZZ").contains("no stored output"));
     }
 
     #[test]

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -150,6 +150,7 @@ pub fn run(cmd_str: &str) -> i32 {
 
     let input_tokens = combined.len() / 4;
     let lines: Vec<String> = combined.lines().map(String::from).collect();
+    let orig_line_count = lines.len();
 
     // ── Summarize fallback for huge outputs (pre-handler) ──────────────
     // Decision based on raw line count so handlers can't hide huge inputs.
@@ -194,6 +195,28 @@ pub fn run(cmd_str: &str) -> i32 {
 
     let output_str = compressed.join("\n");
     let output_tokens = output_str.len() / 4;
+
+    // ── Reversible compression: stash the original so the model can recover it ──
+    // When a large output was meaningfully compressed, save the verbatim
+    // original to a content-addressed blob and surface a retrieve marker. This
+    // is the safety net that lets compression be aggressive: the dropped lines
+    // are one `squeez_retrieve` away instead of gone. Skipped on a redundancy
+    // hit (the prior call already holds the content).
+    let retrieve_marker = if config.retrieve_enabled
+        && !redundancy_hit
+        && orig_line_count >= config.retrieve_min_lines
+        && output_str.len() + 256 < combined.len()
+    {
+        context::retrieve::prune(config.retrieve_ttl_days.saturating_mul(86_400));
+        context::retrieve::store(&combined).map(|id| {
+            format!(
+                "[squeez: full {}-line output stored — call squeez_retrieve with key=\"{}\" to expand]",
+                orig_line_count, id
+            )
+        })
+    } else {
+        None
+    };
 
     // ── Artifact capture + session tracking ───────────────────────────────
     let files      = extract_file_paths(&combined);
@@ -292,6 +315,9 @@ pub fn run(cmd_str: &str) -> i32 {
     // the next bash output is the first surface the model actually reads.
     for w in ctx.drain_warnings() {
         println!("{}", w);
+    }
+    if let Some(ref marker) = retrieve_marker {
+        println!("{}", marker);
     }
     if !output_str.is_empty() {
         println!("{}", output_str);

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,15 @@ pub struct Config {
     /// Tool calls per 60-second window that triggers a high-call-rate warning.
     /// Detects runaway agent loops. 0 = disabled. Default: 20.
     pub call_rate_warn_per_min: u32,
+    // ── Reversible compression (P1, headroom CCR-style) ──────────────────────
+    /// Stash the verbatim original when a large output is compressed so the
+    /// model can recover it via the `squeez_retrieve` MCP tool. Default: true.
+    pub retrieve_enabled: bool,
+    /// Days a stashed blob lives before pruning. 0 = never prune. Default: 7.
+    pub retrieve_ttl_days: u64,
+    /// Minimum original line count before squeez bothers stashing a blob.
+    /// Default: 40.
+    pub retrieve_min_lines: usize,
 }
 
 impl Default for Config {
@@ -190,6 +199,9 @@ impl Default for Config {
             parallel_agent_burst_threshold: 5,
             subagent_total_warn_tokens: 50_000,
             call_rate_warn_per_min: 20,
+            retrieve_enabled: true,
+            retrieve_ttl_days: 7,
+            retrieve_min_lines: 40,
         }
     }
 }
@@ -350,6 +362,13 @@ impl Config {
                     "call_rate_warn_per_min" => {
                         c.call_rate_warn_per_min =
                             v.parse().unwrap_or(c.call_rate_warn_per_min)
+                    }
+                    "retrieve_enabled" => c.retrieve_enabled = v == "true",
+                    "retrieve_ttl_days" => {
+                        c.retrieve_ttl_days = v.parse().unwrap_or(c.retrieve_ttl_days)
+                    }
+                    "retrieve_min_lines" => {
+                        c.retrieve_min_lines = v.parse().unwrap_or(c.retrieve_min_lines)
                     }
                     _ => {}
                 }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -2,6 +2,7 @@ pub mod cache;
 pub mod hash;
 pub mod intensity;
 pub mod redundancy;
+pub mod retrieve;
 pub mod summarize;
 pub mod transcript;
 

--- a/src/context/retrieve.rs
+++ b/src/context/retrieve.rs
@@ -1,0 +1,137 @@
+//! Reversible compression store (P1 — headroom CCR-style).
+//!
+//! When squeez compresses a large output it stashes the verbatim original in a
+//! content-addressed blob so the model can recover it on demand via the
+//! `squeez_retrieve` MCP tool — instead of the dropped content being lost
+//! forever. This is what lets compression be aggressive without information
+//! loss: trim hard, but keep a safety net the model can pull back.
+//!
+//! Layout: `~/.claude/squeez/blobs/<id>` where `<id>` is the 16-hex FNV-1a
+//! hash of the content (so identical outputs dedup to one blob). TTL pruning
+//! keeps the directory bounded. Zero-dep — stdlib fs + the existing hasher.
+
+use crate::context::hash::fnv1a_64;
+use crate::session::squeez_dir;
+use std::path::{Path, PathBuf};
+
+/// Directory holding stashed originals.
+pub fn blobs_dir() -> PathBuf {
+    squeez_dir().join("blobs")
+}
+
+/// A retrieval id is exactly 16 lowercase hex chars. Validated on the way in
+/// (retrieve) so a model-supplied id can never escape `blobs_dir` via `..`
+/// or an absolute path.
+pub fn is_valid_id(id: &str) -> bool {
+    id.len() == 16 && id.bytes().all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// Store `content` verbatim and return its retrieval id. Content-addressed:
+/// identical content maps to the same id and reuses the blob. Returns `None`
+/// on any I/O failure (best-effort — a failed stash just means no marker).
+pub fn store(content: &str) -> Option<String> {
+    store_in(&blobs_dir(), content)
+}
+
+/// Retrieve a previously stored blob by id. `None` if the id is malformed, the
+/// blob is missing, or it was pruned.
+pub fn retrieve(id: &str) -> Option<String> {
+    retrieve_in(&blobs_dir(), id)
+}
+
+/// Remove blobs whose last modification is older than `ttl_secs`. Best-effort;
+/// a `ttl_secs` of 0 disables pruning (keeps everything).
+pub fn prune(ttl_secs: u64) {
+    prune_in(&blobs_dir(), ttl_secs)
+}
+
+// ── Dir-injected cores (so tests don't race on the global SQUEEZ_DIR env) ────
+
+fn store_in(dir: &Path, content: &str) -> Option<String> {
+    let id = format!("{:016x}", fnv1a_64(content.as_bytes()));
+    std::fs::create_dir_all(dir).ok()?;
+    // Rewriting an existing blob is fine — it refreshes the mtime so an output
+    // the model keeps re-encountering stays alive past the TTL.
+    std::fs::write(dir.join(&id), content).ok()?;
+    Some(id)
+}
+
+fn retrieve_in(dir: &Path, id: &str) -> Option<String> {
+    if !is_valid_id(id) {
+        return None;
+    }
+    std::fs::read_to_string(dir.join(id)).ok()
+}
+
+fn prune_in(dir: &Path, ttl_secs: u64) {
+    if ttl_secs == 0 {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(meta) = entry.metadata() else { continue };
+        let Ok(modified) = meta.modified() else { continue };
+        // `elapsed()` errors only if mtime is in the future — treat as fresh.
+        let age = modified.elapsed().map(|d| d.as_secs()).unwrap_or(0);
+        if age > ttl_secs {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Unique temp dir per test → fully parallel-safe, no global SQUEEZ_DIR.
+    fn tmp(tag: &str) -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "sqret-{tag}-{}-{}",
+            std::process::id(),
+            tag.len()
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn store_then_retrieve_round_trips() {
+        let dir = tmp("rt");
+        let original = "line one\nline two\nline three\n".repeat(50);
+        let id = store_in(&dir, &original).expect("store should succeed");
+        assert!(is_valid_id(&id), "id must be 16 hex chars: {id}");
+        assert_eq!(retrieve_in(&dir, &id).as_deref(), Some(original.as_str()));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn identical_content_is_content_addressed() {
+        let dir = tmp("ca");
+        let a = store_in(&dir, "same content").unwrap();
+        let b = store_in(&dir, "same content").unwrap();
+        assert_eq!(a, b, "identical content must map to the same blob id");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rejects_path_traversal_and_bad_ids() {
+        let dir = tmp("sec");
+        assert!(retrieve_in(&dir, "../../etc/passwd").is_none());
+        assert!(retrieve_in(&dir, "not-hex-at-all!!").is_none());
+        assert!(retrieve_in(&dir, "ABCDEF0123456789").is_none(), "uppercase rejected");
+        assert!(retrieve_in(&dir, "deadbeef").is_none(), "wrong length rejected");
+    }
+
+    #[test]
+    fn prune_keeps_fresh_blobs() {
+        let dir = tmp("prune");
+        let id = store_in(&dir, "prune me please, this is long enough").unwrap();
+        prune_in(&dir, 0); // ttl 0 disables pruning entirely
+        assert!(retrieve_in(&dir, &id).is_some());
+        prune_in(&dir, 86_400); // just-written blob is younger than 1 day → survives
+        assert!(retrieve_in(&dir, &id).is_some());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}


### PR DESCRIPTION
## Summary

First of the headroom-inspired token-savings features (#153). squeez used to **discard the original** whenever it truncated/summarized/deduped an output — so the model could never recover dropped content, which forced conservative compression. This adds headroom's **CCR (reversible compression)** idea: stash the verbatim original locally, let the model pull it back on demand via MCP. With a safety net, compression can be far more aggressive.

## What's new

- **`src/context/retrieve.rs`** — content-addressed blob store at `~/.claude/squeez/blobs/<id>` (16-hex FNV id → identical content dedups to one blob), TTL pruning, and path-traversal-safe id validation (a model-supplied id can never escape the store). Zero-dep, stdlib fs only.
- **`wrap.rs`** — when a large bash output is meaningfully compressed (≥ `retrieve_min_lines`, real reduction, not a redundancy hit), stash the original and print:
  `[squeez: full N-line output stored — call squeez_retrieve with key="<id>" to expand]`
- **`mcp_server.rs`** — new `squeez_retrieve` tool returns the verbatim original by id, with clear not-found handling for malformed/expired/missing ids.
- **Config** — `retrieve_enabled` (default true), `retrieve_ttl_days` (7), `retrieve_min_lines` (40); all round-trip through the `squeez config` CLI.

## Verification

- **E2E (real binary):** `squeez wrap "seq 1 600"` emits the marker with a valid 16-hex id; the blob lands on disk; `squeez_retrieve` via MCP returns the **byte-identical 600 lines** (first=1, last=600).
- `cargo test` — all green; new unit tests for round-trip, content-addressing, path-traversal rejection, prune, and the MCP dispatcher's safety branches.
- `bash bench/run.sh` — 18/18, no ratio regression.

## Follow-ups (not in this PR)
Extend stashing to the Read/Grep PostToolUse path (`compress_output.rs`) so large file reads are recoverable too.

Closes #153
