### PR TITLE
feat(log-template): collapse near-identical log lines

### DIFF
--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -104,6 +104,8 @@ const SCHEMA: &[(&str, Kind)] = &[
     ("retrieve_enabled", Kind::Bool),
     ("retrieve_ttl_days", Kind::U64),
     ("retrieve_min_lines", Kind::Usize),
+    ("log_template_enabled", Kind::Bool),
+    ("log_template_min", Kind::Usize),
 ];
 
 fn kind_of(key: &str) -> Option<Kind> {
@@ -176,6 +178,8 @@ fn field_value(c: &Config, key: &str) -> Option<String> {
         "retrieve_enabled" => c.retrieve_enabled.to_string(),
         "retrieve_ttl_days" => c.retrieve_ttl_days.to_string(),
         "retrieve_min_lines" => c.retrieve_min_lines.to_string(),
+        "log_template_enabled" => c.log_template_enabled.to_string(),
+        "log_template_min" => c.log_template_min.to_string(),
         _ => return None,
     };
     Some(v)

--- a/src/commands/docker.rs
+++ b/src/commands/docker.rs
@@ -1,6 +1,6 @@
 use crate::commands::Handler;
 use crate::config::Config;
-use crate::strategies::{dedup, smart_filter, truncation};
+use crate::strategies::{dedup, log_template, smart_filter, truncation};
 
 pub struct DockerHandler;
 
@@ -8,6 +8,11 @@ impl Handler for DockerHandler {
     fn compress(&self, _cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
         let lines = smart_filter::apply(lines);
         let lines = dedup::apply(lines, config.dedup_min);
+        let lines = if config.log_template_enabled {
+            log_template::apply(lines, config.log_template_min)
+        } else {
+            lines
+        };
         truncation::apply(lines, config.docker_logs_max_lines, truncation::Keep::Tail)
     }
 }

--- a/src/commands/generic.rs
+++ b/src/commands/generic.rs
@@ -1,6 +1,6 @@
 use crate::commands::Handler;
 use crate::config::Config;
-use crate::strategies::{dedup, grouping, smart_filter, truncation};
+use crate::strategies::{dedup, grouping, log_template, smart_filter, truncation};
 
 pub struct GenericHandler;
 
@@ -8,6 +8,11 @@ impl Handler for GenericHandler {
     fn compress(&self, _cmd: &str, lines: Vec<String>, config: &Config) -> Vec<String> {
         let lines = smart_filter::apply(lines);
         let lines = dedup::apply(lines, config.dedup_min);
+        let lines = if config.log_template_enabled {
+            log_template::apply(lines, config.log_template_min)
+        } else {
+            lines
+        };
         let lines = grouping::group_files_by_dir(lines, 5);
         truncation::apply(lines, config.max_lines, truncation::Keep::Head)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,12 @@ pub struct Config {
     /// Minimum original line count before squeez bothers stashing a blob.
     /// Default: 40.
     pub retrieve_min_lines: usize,
+    // ── Log-template compaction (P2) ─────────────────────────────────────────
+    /// Collapse near-identical log lines (differing only by timestamps/ids/
+    /// numbers) into a single `[×N] <template>` line. Default: true.
+    pub log_template_enabled: bool,
+    /// Minimum recurrence before a template is collapsed. Default: 3.
+    pub log_template_min: usize,
 }
 
 impl Default for Config {
@@ -202,6 +208,8 @@ impl Default for Config {
             retrieve_enabled: true,
             retrieve_ttl_days: 7,
             retrieve_min_lines: 40,
+            log_template_enabled: true,
+            log_template_min: 3,
         }
     }
 }
@@ -369,6 +377,10 @@ impl Config {
                     }
                     "retrieve_min_lines" => {
                         c.retrieve_min_lines = v.parse().unwrap_or(c.retrieve_min_lines)
+                    }
+                    "log_template_enabled" => c.log_template_enabled = v == "true",
+                    "log_template_min" => {
+                        c.log_template_min = v.parse().unwrap_or(c.log_template_min)
                     }
                     _ => {}
                 }

--- a/src/strategies/log_template.rs
+++ b/src/strategies/log_template.rs
@@ -1,0 +1,195 @@
+//! Log-template compaction (P2).
+//!
+//! `dedup` collapses only byte-identical lines. Real logs and stack traces
+//! rarely repeat verbatim — they differ by a timestamp, pid, request id, hex
+//! hash, or counter. This strategy normalizes those variable tokens to `{}`,
+//! groups lines by the resulting template, and collapses a recurring template
+//! to a single `[×N] <template>  (e.g. <sample>)` line. The N near-identical
+//! lines that carried one bit of information now cost one line.
+//!
+//! Conservative by design:
+//!   - Only collapses a template that actually abstracts a variable — a
+//!     template with no `{}` slot is left to `dedup`.
+//!   - Only collapses when it recurs at least `min_count` times.
+//!   - The collapsed line is emitted at the position of the first occurrence,
+//!     preserving order; unique lines pass through verbatim.
+//!
+//! Zero-dep — hand-rolled token classification, no regex.
+
+use std::collections::{HashMap, HashSet};
+
+const SLOT: &str = "{}";
+
+/// Collapse near-identical lines into templated counts. `min_count` is the
+/// recurrence threshold (a template must appear at least this many times).
+pub fn apply(lines: Vec<String>, min_count: usize) -> Vec<String> {
+    if min_count < 2 || lines.len() < min_count {
+        return lines;
+    }
+
+    let templates: Vec<String> = lines.iter().map(|l| normalize(l)).collect();
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for t in &templates {
+        *counts.entry(t.as_str()).or_insert(0) += 1;
+    }
+
+    let mut emitted: HashSet<&str> = HashSet::new();
+    let mut out = Vec::with_capacity(lines.len());
+    for (i, line) in lines.iter().enumerate() {
+        let t = templates[i].as_str();
+        let recurs = counts[t] >= min_count && t.contains(SLOT);
+        if recurs {
+            if emitted.insert(t) {
+                out.push(format!("[×{}] {}  (e.g. {})", counts[t], t, sample(line)));
+            }
+            // subsequent occurrences are dropped
+        } else {
+            out.push(line.clone());
+        }
+    }
+    out
+}
+
+/// Replace variable-looking whitespace tokens with `{}`. Structure (the
+/// non-variable words, and the key in `key=value`) is preserved so the
+/// template stays readable.
+fn normalize(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut first = true;
+    for tok in line.split_whitespace() {
+        if !first {
+            out.push(' ');
+        }
+        first = false;
+        out.push_str(&templatize(tok));
+    }
+    out
+}
+
+/// Map one token to its template form: the variable part becomes `{}`, but the
+/// key of a `key=value` pair is kept (`id=1001` → `id={}`).
+fn templatize(tok: &str) -> String {
+    if let Some((key, val)) = tok.split_once('=') {
+        if !key.is_empty() && !val.is_empty() && looks_like_id(val) {
+            return format!("{key}={SLOT}");
+        }
+    }
+    if is_variable(tok) {
+        SLOT.to_string()
+    } else {
+        tok.to_string()
+    }
+}
+
+/// True if a whole token looks like a variable value (timestamp, number, ip,
+/// float, hex/uuid). `key=value` pairs are handled in `templatize`.
+fn is_variable(tok: &str) -> bool {
+    // Strip surrounding punctuation so `(4821)` and `a3f2,` classify by core.
+    let core = tok.trim_matches(|c: char| {
+        matches!(c, ',' | ';' | '(' | ')' | '[' | ']' | '{' | '}' | '"' | '\'' | '<' | '>')
+    });
+    if core.is_empty() {
+        return false;
+    }
+    looks_like_id(core)
+}
+
+/// Heuristic: does `s` look like a numeric / timestamp / hash value?
+fn looks_like_id(s: &str) -> bool {
+    let digits = s.bytes().filter(|b| b.is_ascii_digit()).count();
+    if digits == 0 {
+        return false; // pure words (incl. ERROR, INFO) are structure, not values
+    }
+    // Numeric/timestamp/ip/float/date: digits plus the separators that appear
+    // *between* digits. Covers 12:30:45, 2026-06-21T10:30:45, 192.168.0.1, 3.14.
+    let numeric_shaped = s
+        .bytes()
+        .all(|b| b.is_ascii_digit() || matches!(b, b'.' | b':' | b'-' | b'/' | b'T' | b'+'));
+    if numeric_shaped {
+        return true;
+    }
+    // Hex / uuid id: long, hex-or-dash, with at least a couple of digits so we
+    // don't eat ordinary lowercase words.
+    let hexish = s.len() >= 8
+        && digits >= 2
+        && s.bytes().all(|b| b.is_ascii_hexdigit() || b == b'-');
+    if hexish {
+        return true;
+    }
+    // Compound id: an alphanumeric token that carries a digit and a `-`/`_`
+    // separator (req-1, pod-abc-7, session_42). Catches the ids that dominate
+    // structured logs. Version strings (v1.24.0, 1.2.3) have no `-`/`_`, so
+    // they're preserved.
+    let compound = digits >= 1
+        && s.bytes().any(|b| b == b'-' || b == b'_')
+        && s.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'));
+    compound
+}
+
+/// A short, single-line example of the raw line for the collapsed marker.
+fn sample(line: &str) -> String {
+    const MAX: usize = 100;
+    let t = line.trim();
+    if t.chars().count() <= MAX {
+        t.to_string()
+    } else {
+        let cut: String = t.chars().take(MAX).collect();
+        format!("{cut}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v(s: &str) -> Vec<String> {
+        s.lines().map(String::from).collect()
+    }
+
+    #[test]
+    fn collapses_lines_differing_only_by_variables() {
+        let input = v("\
+2026-06-21T10:30:01 worker 4821 processing job a3f2c1d4e50
+2026-06-21T10:30:02 worker 4822 processing job b1c9d2e3f4a
+2026-06-21T10:30:03 worker 4823 processing job d7e0f1a2b3c");
+        let out = apply(input, 3);
+        assert_eq!(out.len(), 1, "three near-identical lines → one: {out:?}");
+        assert!(out[0].starts_with("[×3] "), "{:?}", out[0]);
+        assert!(out[0].contains("{}"), "template must carry slots: {:?}", out[0]);
+        assert!(out[0].contains("worker"), "structure preserved: {:?}", out[0]);
+    }
+
+    #[test]
+    fn preserves_unique_lines_and_versions() {
+        let input = v("\
+starting squeez v1.24.0
+listening on port 8787
+ready");
+        let out = apply(input.clone(), 3);
+        assert_eq!(out, input, "no recurring template → unchanged");
+    }
+
+    #[test]
+    fn leaves_byte_identical_recurrence_to_dedup() {
+        // No variable slot → not our job; pass through so dedup handles it.
+        let input = v("retrying...\nretrying...\nretrying...");
+        let out = apply(input.clone(), 3);
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn key_value_pairs_template_on_the_value() {
+        let input = v("conn id=1001 ok\nconn id=1002 ok\nconn id=1003 ok\nconn id=1004 ok");
+        let out = apply(input, 3);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("conn id={} ok"), "{:?}", out[0]);
+        assert!(out[0].starts_with("[×4]"));
+    }
+
+    #[test]
+    fn below_threshold_is_untouched() {
+        let input = v("worker 1 done\nworker 2 done");
+        let out = apply(input.clone(), 3);
+        assert_eq!(out, input);
+    }
+}

--- a/src/strategies/mod.rs
+++ b/src/strategies/mod.rs
@@ -1,5 +1,6 @@
 pub mod dedup;
 pub mod grouping;
+pub mod log_template;
 pub mod smart_filter;
 pub mod toon;
 pub mod truncation;


### PR DESCRIPTION
## Summary

P2 of the headroom-inspired token-savings roadmap (#155). `dedup` only collapses **byte-identical** lines, but real logs and stack traces differ by a timestamp, pid, request id, hex hash, or counter — so N lines carrying one bit of information cost N lines of tokens.

New zero-dep strategy `src/strategies/log_template.rs` normalizes variable tokens to `{}` and collapses a recurring template into one line:

```
[×10] {} worker {} processing request id={} status={}  (e.g. 2026-06-21T10:30:01 worker 481 processing request id=req-1 status=200)
```

Recognized as variable: timestamps, numbers, ips, floats, hex/uuids, **compound ids** (`req-1`, `pod-abc-7`, `session_42`), and the value side of `key=value`. Conservative by design:
- Only collapses a template that actually abstracts a variable — pure-identical recurrence stays `dedup`'s job.
- Only collapses at ≥ `log_template_min` (default 3).
- Unique lines and version strings (`v1.24.0`) are preserved; the collapsed line keeps a raw sample and the `key=` of any pair.

Plugged after `dedup` in `GenericHandler` and `DockerHandler`. Config: `log_template_enabled` (true), `log_template_min` (3), both round-trip through `squeez config`.

## Verification

- **E2E:** 10 near-identical worker log lines + 1 unique `FATAL` → one `[×10] …` count line + the preserved FATAL error.
- `cargo test` — all green; 5 new unit tests (collapse, key=value templating, version preservation, identical-recurrence left to dedup, below-threshold untouched).
- `bash bench/run.sh` — 18/18, `docker_logs` at 73%.

Closes #155
