### PR TITLE
fix(log-template): recognize number+unit tokens so latency logs collapse

### DIFF
--- a/src/strategies/log_template.rs
+++ b/src/strategies/log_template.rs
@@ -108,6 +108,11 @@ fn looks_like_id(s: &str) -> bool {
     if numeric_shaped {
         return true;
     }
+    // Number + unit: a numeric prefix followed by a short unit suffix
+    // (1ms, 200ms, 5s, 3.2KB, 50%, 1.5x). These dominate latency/size logs.
+    if is_num_unit(s) {
+        return true;
+    }
     // Hex / uuid id: long, hex-or-dash, with at least a couple of digits so we
     // don't eat ordinary lowercase words.
     let hexish = s.len() >= 8
@@ -124,6 +129,26 @@ fn looks_like_id(s: &str) -> bool {
         && s.bytes().any(|b| b == b'-' || b == b'_')
         && s.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'));
     compound
+}
+
+/// True for a numeric value glued to a short unit: `1ms`, `200ms`, `3.2KB`,
+/// `50%`, `1.5x`. Requires a leading digit so identifiers (`utf8`, `x86`) and
+/// versions (`v1`) are not eaten.
+fn is_num_unit(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut saw_digit = false;
+    while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b'.') {
+        if bytes[i].is_ascii_digit() {
+            saw_digit = true;
+        }
+        i += 1;
+    }
+    if !saw_digit || i == 0 || i == bytes.len() {
+        return false; // need digits AND a non-empty suffix
+    }
+    let suffix = &bytes[i..];
+    suffix.len() <= 4 && suffix.iter().all(|b| b.is_ascii_alphabetic() || *b == b'%')
 }
 
 /// A short, single-line example of the raw line for the collapsed marker.
@@ -191,5 +216,25 @@ ready");
         let input = v("worker 1 done\nworker 2 done");
         let out = apply(input.clone(), 3);
         assert_eq!(out, input);
+    }
+
+    #[test]
+    fn collapses_lines_differing_by_number_unit() {
+        // Latency/size values glued to a unit must be treated as variable so
+        // these lines share a template and collapse (#163).
+        let input = v("req done in 1ms\nreq done in 22ms\nreq done in 3ms\nreq done in 450ms");
+        let out = apply(input, 3);
+        assert_eq!(out.len(), 1, "number+unit lines should collapse: {out:?}");
+        assert!(out[0].contains("req done in {}"), "{:?}", out[0]);
+    }
+
+    #[test]
+    fn num_unit_recognizes_common_shapes() {
+        for t in ["1ms", "200ms", "5s", "3.2KB", "50%", "1.5x"] {
+            assert!(is_num_unit(t), "{t} should be a number+unit");
+        }
+        for t in ["utf8", "x86", "v1", "abc", "1234"] {
+            assert!(!is_num_unit(t), "{t} should NOT be a number+unit");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Found during the P1–P5 verification pass. A 301-line timestamped log run through the generic pipeline collapsed to one bogus `2026-06-21T10:./ 301 modified` line **and dropped a buried `ERROR`**.

Root cause: log lines that differ only by a latency value never shared a `log_template` template, because number+unit tokens (`1ms`, `200ms`, `5s`, `3.2KB`, `50%`) weren't treated as variable. So the lines stayed distinct and were left for the downstream `grouping` step, which mis-collapsed them (colon-split on the timestamp) into a count — swallowing the error.

Recognizing number+unit tokens lets those lines collapse to a single `[×N] …` template line **before** grouping runs. `is_num_unit` requires a leading digit, so identifiers (`utf8`, `x86`) and versions (`v1`) are preserved.

## Verification

Before:
```
2026-06-21T10:./  301 modified  [squeez grouped]      # error gone
```
After:
```
[×300] {} INFO worker {} handled request id={} in {}  (e.g. … in 1ms)
2026-06-21T10:05:00 ERROR worker 4812 OutOfMemory: heap exhausted   # preserved
```

- `cargo test` — green; 2 new unit tests (`collapses_lines_differing_by_number_unit`, `num_unit_recognizes_common_shapes`).
- `bash bench/run.sh` — 18/18 (no regression).

## Known follow-up (not in this PR)

`grouping::group_files_by_dir` can still mis-collapse genuinely non-path output (prose, or 5+ distinct timestamped lines) into `N modified`, the same class as #148. A correct fix (only group real directory paths) is entangled with benchmark fixtures (`en_prose`, `pt_br_prose`) that currently rely on that collapse to hit their reduction threshold, so it needs its own PR + fixture review. This PR resolves the reported error-loss symptom without that blast radius.

Closes #163
