### PR TITLE
feat(compact): post-compact dense state re-injection

### DIFF
--- a/hooks/postcompact.sh
+++ b/hooks/postcompact.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# squeez PostCompact hook — re-arms squeez after context compaction.
+# squeez PostCompact hook — re-injects session state after context compaction.
 #
-# PostCompact fires after Claude Code compacts the context window. The model's
-# context is now shorter; session memory injected at SessionStart may have
-# been trimmed. We log the event and emit a brief re-arm reminder so the
-# model knows compression is still active for the remainder of the session.
+# PostCompact fires after Claude Code compacts the context window. Compaction
+# can drop concrete state (files touched, errors hit, git refs). squeez already
+# tracks that, so we re-inject it as `additionalContext` — the documented,
+# reliable way to add context that survives into the compacted session — plus
+# pointers to any squeez_retrieve blobs holding dropped output.
 set -euo pipefail
 
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
@@ -16,6 +17,7 @@ fi
 
 "$SQUEEZ" track PostCompact 0 2>/dev/null || true
 
-# Emit a terse re-arm note. Claude Code may surface this to the model
-# as a system-level context injection depending on hook output handling.
-printf '[squeez] context compacted — compression still active\n'
+# Emit the PostCompact hookSpecificOutput JSON (or nothing if there's no state
+# worth restoring). This is the reliable injection path; a plain echo is not
+# guaranteed to reach the model's context.
+"$SQUEEZ" compact-summary 2>/dev/null || true

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -1,0 +1,124 @@
+//! `squeez compact-summary` — post-compact dense state re-injection (#166).
+//!
+//! Conversation history is the biggest token sink in long sessions, and
+//! squeez's per-tool hooks can't reach it. After every `/compact`, Claude
+//! Code loses concrete state — which files it touched, which errors it hit,
+//! recent git refs — and re-discovers it with fresh tool calls.
+//!
+//! A PreCompact hook can't steer the built-in summarizer (researched: no
+//! custom-instructions / transcript-rewrite API; it can only block). But a
+//! **PostCompact** hook can return `additionalContext` that survives into the
+//! freshly-compacted context. So squeez re-injects its own accumulated session
+//! state — which it already tracks in `SessionContext` — as a dense block,
+//! plus pointers to any `squeez_retrieve` blobs holding outputs that
+//! compaction dropped.
+//!
+//! Output is the Claude Code PostCompact hook JSON shape; the hook script
+//! prints it on stdout.
+
+use crate::context::cache::SessionContext;
+use crate::context::retrieve;
+use crate::session;
+
+/// Build the post-compact `additionalContext` text from current session state.
+/// Returns `None` when there's nothing worth re-injecting.
+pub fn build_summary() -> Option<String> {
+    let ctx = SessionContext::load(&session::sessions_dir());
+    let cur = session::CurrentSession::load(&session::sessions_dir());
+
+    let mut parts: Vec<String> = Vec::new();
+
+    // Recently-touched files (newest first), with access mode.
+    if !ctx.seen_files.is_empty() {
+        let mut files = ctx.seen_files.clone();
+        files.sort_by(|a, b| b.last_seen_call.cmp(&a.last_seen_call));
+        let listed: Vec<String> = files
+            .iter()
+            .take(8)
+            .map(|f| format!("{}({})", f.path, f.access.as_char()))
+            .collect();
+        parts.push(format!("files: {}", listed.join(", ")));
+    }
+
+    // Distinct error snippets (most recent first), trimmed.
+    if !ctx.error_snippets.is_empty() {
+        let listed: Vec<String> = ctx
+            .error_snippets
+            .iter()
+            .rev()
+            .take(3)
+            .map(|(_, snip)| trim_snippet(snip))
+            .collect();
+        parts.push(format!("errors: {}", listed.join(" | ")));
+    }
+
+    // Recent git refs.
+    if !ctx.seen_git_refs.is_empty() {
+        let refs: Vec<String> = ctx.seen_git_refs.iter().rev().take(5).cloned().collect();
+        parts.push(format!("git: {}", refs.join(", ")));
+    }
+
+    // Retrievable blobs for outputs compaction may have dropped.
+    let ids = retrieve::recent_ids(3);
+    if !ids.is_empty() {
+        parts.push(format!(
+            "retrievable: call squeez_retrieve with key in [{}]",
+            ids.join(", ")
+        ));
+    }
+
+    if let Some(c) = cur {
+        if c.tokens_saved > 0 {
+            parts.push(format!(
+                "squeez saved ~{}tk over {} calls this session",
+                c.tokens_saved, c.total_calls
+            ));
+        }
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "[squeez session state — restored after compaction] {}",
+        parts.join("; ")
+    ))
+}
+
+fn trim_snippet(s: &str) -> String {
+    let one_line = s.replace('\n', " ");
+    let t = one_line.trim();
+    const MAX: usize = 80;
+    if t.chars().count() <= MAX {
+        t.to_string()
+    } else {
+        let cut: String = t.chars().take(MAX).collect();
+        format!("{cut}…")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trim_snippet_collapses_newlines_and_caps_length() {
+        assert_eq!(trim_snippet("  a\nb  "), "a b");
+        let long = "x".repeat(200);
+        let out = trim_snippet(&long);
+        assert!(out.ends_with('…'));
+        assert!(out.chars().count() <= 81);
+    }
+}
+
+/// Emit the PostCompact hook JSON on stdout. Always exits 0 — re-injection is
+/// best-effort and must never disrupt the host.
+pub fn run() -> i32 {
+    if let Some(text) = build_summary() {
+        println!(
+            "{{\"hookSpecificOutput\":{{\"hookEventName\":\"PostCompact\",\"additionalContext\":\"{}\"}}}}",
+            crate::json_util::escape_str(&text)
+        );
+    }
+    0
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub trait Handler {
 pub mod compress_output;
 pub mod build;
 pub mod cloud;
+pub mod compact;
 pub mod compress_md;
 pub mod compress_prompt;
 pub mod config_cmd;

--- a/src/context/retrieve.rs
+++ b/src/context/retrieve.rs
@@ -45,6 +45,27 @@ pub fn prune(ttl_secs: u64) {
     prune_in(&blobs_dir(), ttl_secs)
 }
 
+/// The ids of the most recently stored blobs (newest first), up to `n`. Used
+/// by the post-compact summary to point the model at outputs it can re-expand.
+pub fn recent_ids(n: usize) -> Vec<String> {
+    let Ok(entries) = std::fs::read_dir(blobs_dir()) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<(std::time::SystemTime, String)> = entries
+        .flatten()
+        .filter_map(|e| {
+            let name = e.file_name().into_string().ok()?;
+            if !is_valid_id(&name) {
+                return None;
+            }
+            let mtime = e.metadata().ok()?.modified().ok()?;
+            Some((mtime, name))
+        })
+        .collect();
+    ids.sort_by(|a, b| b.0.cmp(&a.0));
+    ids.into_iter().take(n).map(|(_, id)| id).collect()
+}
+
 // ── Dir-injected cores (so tests don't race on the global SQUEEZ_DIR env) ────
 
 fn store_in(dir: &Path, content: &str) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,9 +35,10 @@ fn main() {
             };
             std::process::exit(exit_code);
         }
-        Some("compact") => {
-            eprintln!("squeez: compact not yet implemented");
-            std::process::exit(1);
+        Some("compact-summary") => {
+            // PostCompact hook: emit dense session state as additionalContext
+            // so it survives /compact. See commands/compact.rs.
+            std::process::exit(squeez::commands::compact::run());
         }
         Some("compress-md") => {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
@@ -107,6 +108,7 @@ fn main() {
             eprintln!("       squeez update [--check] [--insecure]");
             eprintln!("       squeez mcp                       — JSON-RPC 2.0 server over stdio");
             eprintln!("       squeez protocol                  — print the auto-teach payload");
+            eprintln!("       squeez compact-summary           — PostCompact hook: re-inject session state");
             eprintln!("       squeez calibrate                 — auto-tune config from benchmarks");
             eprintln!("       squeez budget-params <tool>        — output JSON budget patch for tool");
             eprintln!("       squeez --version");


### PR DESCRIPTION
## Summary

Implements the history-reach feature. Conversation history is the biggest token sink in long sessions and squeez's per-tool hooks can't touch it. After every `/compact`, Claude Code loses concrete state (files touched, errors, git refs) and re-discovers it with fresh tool calls.

Research (logged in #166) established the constraints: a **PreCompact** hook *cannot* steer the built-in summarizer (no custom-instructions / transcript-rewrite API — only `decision: block`), but a **PostCompact** hook *can* return `additionalContext` that survives into the compacted context. So squeez re-injects its own already-tracked `SessionContext`.

- **`squeez compact-summary`** builds a dense `additionalContext` from current session state: recent files + access mode, distinct error snippets, git refs, tokens saved — plus pointers to recent `squeez_retrieve` blob ids, so outputs compaction dropped are still recoverable (ties in P1).
- Emits the PostCompact `hookSpecificOutput` JSON; `postcompact.sh` now calls it instead of a plain `echo` (which isn't a reliable injection path).
- Replaces the empty `compact` stub.

## Verification

E2E (real binary, temp `SQUEEZ_DIR`): after a few wrapped commands,
```json
{"hookSpecificOutput":{"hookEventName":"PostCompact","additionalContext":"[squeez session state — restored after compaction] errors: error: connection refused on db.rs; retrievable: call squeez_retrieve with key in [9e0dd5158a263765]"}}
```
— valid JSON, carries the error snippet and a retrievable blob id.

- `cargo test` — green (new unit test for the snippet trimmer).
- `bash bench/run.sh` — unaffected (18/18).

## Note
The doc says PostCompact `additionalContext` is honored; final confirmation that it reaches the model is a live-`/compact` check (the output shape matches the documented re-inject pattern). Multi-host equivalents (Copilot/OpenCode/Gemini/Codex) are a follow-up.

Closes #166
