### PR TITLE
fix(security): gate bash wrapping; honor native permission rules for risky commands

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,59 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately via **GitHub Security Advisories**
+(the "Report a vulnerability" button under the repository's *Security* tab),
+not in public issues. We aim to acknowledge reports within a few days.
+
+## Bash command wrapping & host permission rules
+
+squeez compresses Bash output by rewriting a proposed command to
+`squeez wrap '<original command>'` in the host's PreToolUse hook. Two properties
+of that mechanism are security-relevant, so they're documented here explicitly.
+
+### What squeez does
+
+For an ordinary command, the PreToolUse hook rewrites it to `squeez wrap '…'`
+and returns `permissionDecision: "allow"`, so the wrapped command runs and its
+output is compressed.
+
+### The risk
+
+Because the host matches permission rules (`allow`/`ask`/`deny`) against the
+string that actually executes, a rule written against the original command
+(e.g. `Bash(git push *)`) does not match the rewritten `squeez wrap '…'`
+string, and the hardcoded `allow` skips the host's default confirmation prompt.
+(Reported in #150.)
+
+### Mitigations (shipped)
+
+squeez does **not** wrap a command when any of these hold — instead it leaves
+the command untouched (no rewrite, no `permissionDecision`), so the host
+evaluates your native `deny`/`ask` rules and default prompt against the
+**original** command:
+
+- **Risky commands.** Commands matching `bash_risk_patterns` (default: `rm -rf`,
+  `git push --force`, `git reset --hard`, `npm/yarn/pnpm publish`, `dd if=`,
+  `mkfs`, `> /dev/sd`, …) run unwrapped. Extend the list to match the rules you
+  rely on:
+  ```
+  squeez config set bash_risk_patterns "rm -rf,git push --force,terraform apply,…"
+  ```
+- **Bypassed commands.** Anything in `bypass` (default: `ssh`, `psql`, `mysql`,
+  `docker exec`) runs unwrapped.
+- **Wrapping disabled.** Set `squeez config set wrap_bash false` to disable Bash
+  wrapping entirely — no command is ever rewritten and your host's permission
+  flow is fully intact (you lose Bash output compression in exchange).
+
+The check is **fail-safe**: if it can't run, the command is left unwrapped.
+
+### Residual
+
+For commands that are *not* risky/bypassed and with `wrap_bash` on, squeez still
+rewrites + allows, so a `deny`/`ask` rule on such a command won't fire while
+squeez is active. If you depend on host permission rules for the full command
+surface, set `wrap_bash false`. A deeper fix (compressing Bash output in
+PostToolUse so the original command runs under native permission evaluation)
+is tracked as a follow-up; it has a capture-before-host-truncation trade-off
+still being evaluated.

--- a/hooks/codex-pretooluse.sh
+++ b/hooks/codex-pretooluse.sh
@@ -19,7 +19,7 @@ fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
 SQUEEZ_BIN="$SQUEEZ" python3 -c "
-import json, os, shlex, sys
+import json, os, shlex, subprocess, sys
 
 data = sys.stdin.read()
 if not data.strip():
@@ -51,6 +51,14 @@ if cmd.startswith('--no-squeez'):
             'updatedInput': inp,
         }
     }))
+    sys.exit(0)
+
+# Security gate (#150): leave risky/bypassed/wrap-disabled commands untouched
+# so the host's native deny/ask rules apply to the original command.
+try:
+    if subprocess.run([squeez, 'should-wrap', cmd], timeout=2).returncode != 0:
+        sys.exit(0)
+except Exception:
     sys.exit(0)
 
 inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)

--- a/hooks/copilot-pretooluse.sh
+++ b/hooks/copilot-pretooluse.sh
@@ -44,6 +44,14 @@ if tool == 'Bash':
         print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
         sys.exit(0)
 
+    # Security gate (#150): leave risky/bypassed/wrap-disabled commands untouched
+    # so the host's native deny/ask rules apply to the original command.
+    try:
+        if subprocess.run([squeez, 'should-wrap', cmd], timeout=2).returncode != 0:
+            sys.exit(0)
+    except Exception:
+        sys.exit(0)
+
     d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
     print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
     sys.exit(0)

--- a/hooks/gemini-before-tool.sh
+++ b/hooks/gemini-before-tool.sh
@@ -18,7 +18,7 @@ fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
 SQUEEZ_BIN="$SQUEEZ" python3 -c "
-import json, os, shlex, sys
+import json, os, shlex, subprocess, sys
 
 data = sys.stdin.read()
 if not data.strip():
@@ -43,6 +43,13 @@ if tool in ('bash', 'Bash', 'run_shell_command'):
     if cmd.startswith('--no-squeez'):
         inp['command'] = cmd[len('--no-squeez'):].lstrip()
         print(json.dumps({'decision': 'allow', 'updatedInput': inp}))
+        sys.exit(0)
+    # Security gate (#150): leave risky/bypassed/wrap-disabled commands untouched
+    # so the host's native permission flow applies to the original command.
+    try:
+        if subprocess.run([squeez, 'should-wrap', cmd], timeout=2).returncode != 0:
+            sys.exit(0)
+    except Exception:
         sys.exit(0)
     inp['command'] = squeez + ' wrap ' + shlex.quote(cmd)
     print(json.dumps({'decision': 'allow', 'updatedInput': inp}))

--- a/hooks/pretooluse.sh
+++ b/hooks/pretooluse.sh
@@ -37,6 +37,18 @@ if tool == 'Bash':
         print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
         sys.exit(0)
 
+    # Security gate (#150): only rewrite to 'squeez wrap …' when squeez deems
+    # it safe. Risky (rm -rf, git push --force, …), bypassed, or wrap-disabled
+    # commands are left UNTOUCHED — we emit no updatedInput and no
+    # permissionDecision, so the host evaluates the user's native deny/ask
+    # rules against the ORIGINAL command instead of the wrapper. Fail-safe: any
+    # error in the check means we do not wrap (and do not silently allow).
+    try:
+        if subprocess.run([squeez, 'should-wrap', cmd], timeout=2).returncode != 0:
+            sys.exit(0)
+    except Exception:
+        sys.exit(0)
+
     d['tool_input']['command'] = squeez + ' wrap ' + shlex.quote(cmd)
     print(json.dumps({'hookSpecificOutput': {'hookEventName': 'PreToolUse', 'permissionDecision': 'allow', 'updatedInput': d['tool_input']}}))
     sys.exit(0)

--- a/src/commands/config_cmd.rs
+++ b/src/commands/config_cmd.rs
@@ -107,6 +107,8 @@ const SCHEMA: &[(&str, Kind)] = &[
     ("log_template_enabled", Kind::Bool),
     ("log_template_min", Kind::Usize),
     ("relevance_truncation_enabled", Kind::Bool),
+    ("wrap_bash", Kind::Bool),
+    ("bash_risk_patterns", Kind::List),
 ];
 
 fn kind_of(key: &str) -> Option<Kind> {
@@ -182,6 +184,8 @@ fn field_value(c: &Config, key: &str) -> Option<String> {
         "log_template_enabled" => c.log_template_enabled.to_string(),
         "log_template_min" => c.log_template_min.to_string(),
         "relevance_truncation_enabled" => c.relevance_truncation_enabled.to_string(),
+        "wrap_bash" => c.wrap_bash.to_string(),
+        "bash_risk_patterns" => c.bash_risk_patterns.join(","),
         _ => return None,
     };
     Some(v)

--- a/src/config.rs
+++ b/src/config.rs
@@ -148,6 +148,19 @@ pub struct Config {
     /// (error/signal words + command query terms) instead of a blind head.
     /// Default: true.
     pub relevance_truncation_enabled: bool,
+    // ── Bash-wrap safety (#150) ──────────────────────────────────────────────
+    /// Master switch for rewriting Bash commands to `squeez wrap '…'` in the
+    /// PreToolUse hook. When false, commands run unwrapped (no output
+    /// compression) and the host's native permission flow applies untouched.
+    /// Default: true.
+    pub wrap_bash: bool,
+    /// Substring patterns marking a command too risky to wrap. A matching
+    /// command is passed through UNWRAPPED with no permission decision, so the
+    /// host evaluates the user's deny/ask rules against the *original* command
+    /// (e.g. a `Bash(git push *)` deny rule keeps working). A safety net, not a
+    /// sandbox — extend it to match your own rules. Default: common destructive
+    /// operations.
+    pub bash_risk_patterns: Vec<String>,
 }
 
 impl Default for Config {
@@ -216,6 +229,21 @@ impl Default for Config {
             log_template_enabled: true,
             log_template_min: 3,
             relevance_truncation_enabled: true,
+            wrap_bash: true,
+            bash_risk_patterns: vec![
+                "rm -rf".to_string(),
+                "rm -fr".to_string(),
+                "rm -r -f".to_string(),
+                "git push --force".to_string(),
+                "git push -f".to_string(),
+                "git reset --hard".to_string(),
+                "npm publish".to_string(),
+                "yarn publish".to_string(),
+                "pnpm publish".to_string(),
+                "dd if=".to_string(),
+                "mkfs".to_string(),
+                "> /dev/sd".to_string(),
+            ],
         }
     }
 }
@@ -391,6 +419,11 @@ impl Config {
                     "relevance_truncation_enabled" => {
                         c.relevance_truncation_enabled = v == "true"
                     }
+                    "wrap_bash" => c.wrap_bash = v == "true",
+                    "bash_risk_patterns" => {
+                        c.bash_risk_patterns =
+                            v.split(',').map(|s| s.trim().to_string()).collect()
+                    }
                     _ => {}
                 }
             }
@@ -410,5 +443,63 @@ impl Config {
 
     pub fn is_bypassed(&self, cmd: &str) -> bool {
         self.bypass.iter().any(|b| cmd.starts_with(b.as_str()))
+    }
+
+    /// True if `cmd` matches a risk pattern — too dangerous to wrap, so it must
+    /// run unwrapped under the host's native permission flow (#150).
+    pub fn is_risky(&self, cmd: &str) -> bool {
+        self.bash_risk_patterns
+            .iter()
+            .any(|p| !p.is_empty() && cmd.contains(p.as_str()))
+    }
+
+    /// Whether the PreToolUse hook should rewrite `cmd` to `squeez wrap '…'`.
+    /// False when squeez is off, bash-wrap is disabled, the command is bypassed,
+    /// or it's risky — in all those cases the original command runs and the
+    /// host's native deny/ask rules apply to it unchanged.
+    pub fn should_wrap_bash(&self, cmd: &str) -> bool {
+        self.enabled && self.wrap_bash && !self.is_bypassed(cmd) && !self.is_risky(cmd)
+    }
+}
+
+#[cfg(test)]
+mod wrap_safety_tests {
+    use super::*;
+
+    #[test]
+    fn risky_commands_are_not_wrapped() {
+        let c = Config::default();
+        for cmd in [
+            "rm -rf /tmp/x",
+            "git push --force origin main",
+            "git push -f",
+            "npm publish",
+            "git reset --hard HEAD~3",
+        ] {
+            assert!(c.is_risky(cmd), "{cmd} should be risky");
+            assert!(!c.should_wrap_bash(cmd), "{cmd} must not be wrapped");
+        }
+    }
+
+    #[test]
+    fn ordinary_commands_are_wrapped() {
+        let c = Config::default();
+        for cmd in ["ls -la", "git status", "cargo test", "grep -rn TODO src/"] {
+            assert!(!c.is_risky(cmd));
+            assert!(c.should_wrap_bash(cmd), "{cmd} should be wrapped");
+        }
+    }
+
+    #[test]
+    fn disabling_wrap_bash_stops_all_wrapping() {
+        let mut c = Config::default();
+        c.wrap_bash = false;
+        assert!(!c.should_wrap_bash("ls -la"));
+    }
+
+    #[test]
+    fn bypassed_commands_are_not_wrapped() {
+        let c = Config::default(); // bypass includes ssh, psql, …
+        assert!(!c.should_wrap_bash("ssh host uptime"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,14 @@ fn main() {
             // so it survives /compact. See commands/compact.rs.
             std::process::exit(squeez::commands::compact::run());
         }
+        Some("should-wrap") => {
+            // PreToolUse hook gate (#150): exit 0 → safe to rewrite to
+            // `squeez wrap '…'`; exit 1 → leave the command alone so the host's
+            // native permission flow evaluates the original (risky/bypassed/off).
+            let cmd = args[2..].join(" ");
+            let ok = squeez::config::Config::load().should_wrap_bash(&cmd);
+            std::process::exit(if ok { 0 } else { 1 });
+        }
         Some("compress-md") => {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::commands::compress_md::run(&rest));


### PR DESCRIPTION
## Summary

Closes the reported security gap. squeez's PreToolUse hook rewrote **every** Bash command to `squeez wrap '…'` and returned `permissionDecision: "allow"` unconditionally. Because the host matches `deny`/`ask` rules against the string that actually executes, a rule like `Bash(git push *)` no longer matched the wrapper, and the hardcoded `allow` skipped the default confirmation prompt.

## Mitigations

- **`should-wrap` gate.** New `Config::should_wrap_bash(cmd)` (exposed as `squeez should-wrap <cmd>`). A command is left **untouched** — no rewrite, no `permissionDecision`, so the host evaluates the user's native `deny`/`ask` rules against the **original** command — when it is:
  - **risky** — matches `bash_risk_patterns` (default: `rm -rf`, `git push --force`, `git reset --hard`, `npm/yarn/pnpm publish`, `dd if=`, `mkfs`, `> /dev/sd`, …),
  - **bypassed** (existing `bypass` list), or
  - **wrap disabled** via the new `wrap_bash` master switch.
- **All four shell hooks** (Claude Code, Copilot, Codex, Gemini) consult the gate before wrapping. The check is **fail-safe**: any error → don't wrap and don't allow.
- New config keys `wrap_bash` (default true) and `bash_risk_patterns` round-trip through `squeez config`.
- **SECURITY.md** added (model, mitigations, residual, reporting); **GitHub private vulnerability reporting enabled**.

## Verification

E2E against the real `pretooluse.sh`:
- `ls -la` → `{… permissionDecision:"allow", command:"squeez wrap 'ls -la'"}` (compression intact)
- `rm -rf /tmp/x` → **no hook output** → host's native permission flow runs the original
- `git push --force origin main` → **no hook output** → native flow

- `cargo test` — green; 4 new wrap-safety unit tests; all four hooks pass a Python syntax check.
- `bash bench/run.sh` — 18/18.

## Residual (documented in SECURITY.md)

Non-risky commands with `wrap_bash` on are still wrapped+allowed, so a `deny`/`ask` rule on such a command won't fire while squeez is active; users who rely on host rules for the full command surface can set `wrap_bash false`. A PostToolUse re-architecture (run the original command under native evaluation, compress its output afterward) is the deeper fix, tracked separately — it has a capture-before-host-truncation trade-off still being evaluated.

Closes #150
