### PR TITLE
feat(hosts): add Hermes Agent adapter (supersedes #172)

### DIFF
--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,96 @@
+"""Hermes plugin adapter for squeez fallback compression.
+
+When installed via `squeez setup --host=hermes`, this plugin is dropped into
+~/.hermes/plugins/squeez-fallback/__init__.py. Hermes auto-discovers plugins
+on session start — no config file patching needed.
+
+The plugin hooks pre_tool_call and wraps unrecognized terminal commands
+with `squeez wrap`. Commands already rewritten by rtk (prefix "rtk ") are
+skipped, so rtk's specialized handlers always take priority.
+
+Requires: squeez binary in PATH (cargo install squeez or npm install -g squeez)
+"""
+
+import shutil
+import subprocess
+import sys
+
+_squeez_available = None
+_squeez_missing_warned = False
+
+# Commands that should never be wrapped (would break functionality)
+_NEVER_WRAP = (
+    "rtk ",          # already rtk-handled — rtk's specialized filters are better
+    "squeez ",       # already squeez-handled (prevents double-wrap)
+    "--no-squeez ",  # explicit bypass prefix
+    "cd ",           # wrapping breaks cwd persistence in Hermes terminal
+    "export ",       # env var setting — must run in parent shell
+    "source ",       # sourcing scripts — must run in parent shell
+    "eval ",         # eval — must run in parent shell
+    ". ",            # POSIX source — must run in parent shell
+    "alias ",        # alias — must run in parent shell
+    "hermes ",       # Hermes CLI commands — avoid recursion
+)
+
+# Shell metacharacters that make wrapping unsafe (squeez wrap handles
+# single commands; compound/piped commands should pass through raw)
+_UNSAFE_CHARS = ("&&", "||", "|", ";", ">", "<", "$(", "`", "\n")
+
+
+def register(ctx):
+    """Register the Hermes pre-tool callback."""
+    if not _check_squeez():
+        return
+    ctx.register_hook("pre_tool_call", _pre_tool_call)
+
+
+def _check_squeez():
+    """Return whether the squeez binary is in PATH, warning once when missing."""
+    global _squeez_available, _squeez_missing_warned
+
+    if _squeez_available is None:
+        _squeez_available = shutil.which("squeez") is not None
+
+    if not _squeez_available and not _squeez_missing_warned:
+        _warn("squeez binary not found in PATH; Hermes hook not registered")
+        _squeez_missing_warned = True
+
+    return _squeez_available
+
+
+def _pre_tool_call(tool_name=None, args=None, **_kwargs):
+    """Wrap terminal commands with squeez when rtk hasn't already handled them.
+
+    Flow:
+      1. rtk-rewrite plugin fires first (alphabetical: rtk < squeez)
+      2. If rtk knows the command → "rtk <cmd>" → we skip (starts with "rtk ")
+      3. If rtk doesn't know it → original command → we wrap with "squeez wrap"
+    """
+    try:
+        if tool_name != "terminal" or not isinstance(args, dict):
+            return
+
+        command = args.get("command")
+        if not isinstance(command, str) or not command.strip():
+            return
+
+        command = command.strip()
+
+        # Skip if already wrapped or shouldn't be wrapped
+        if command.startswith(_NEVER_WRAP):
+            return
+
+        # Skip compound/piped commands (squeez wrap is for single commands)
+        if any(char in command for char in _UNSAFE_CHARS):
+            return
+
+        # Wrap with squeez — squeez wrap executes the command, compresses
+        # output through 4-stage pipeline, and returns the original exit code
+        args["command"] = f"squeez wrap {command}"
+    except Exception as e:
+        _warn(str(e))
+        return
+
+
+def _warn(message):
+    print(f"squeez: hermes plugin warning: {message}", file=sys.stderr)

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,0 +1,6 @@
+name: squeez-fallback
+version: 1.0.0
+description: squeez fallback compression — wraps unrecognized terminal commands with `squeez wrap` so their output is compressed before the model sees it
+author: squeez
+provides_hooks:
+  - pre_tool_call

--- a/src/hosts/hermes.rs
+++ b/src/hosts/hermes.rs
@@ -1,0 +1,199 @@
+//! Hermes Agent adapter.
+//!
+//! [Hermes Agent](https://github.com/NousResearch/hermes-agent) by Nous Research
+//! is a general-purpose AI agent with a plugin system at `~/.hermes/plugins/`.
+//! Each plugin is a Python package with `__init__.py` exposing `register(ctx)`.
+//!
+//! Hermes fires `pre_tool_call` and `post_tool_call` hooks for every tool
+//! invocation. The squeez plugin wraps terminal commands via `pre_tool_call`,
+//! similar to Claude Code's PreToolUse hook.
+//!
+//! Capability ceiling: `BASH_WRAP | SESSION_MEM`.
+//! Hermes does not expose programmatic Read/Grep budget injection — the
+//! `BUDGET_HARD` flag is not set. Budget hints could be injected into the
+//! system prompt via `inject_memory`, but Hermes users typically configure
+//! their SOUL.md / config.yaml system_prompt manually.
+//!
+//! Memory injection: Hermes loads its system prompt from config.yaml at
+//! session start and does not auto-load a markdown file the way Claude Code
+//! loads CLAUDE.md. The adapter writes a squeez persona block into
+//! `~/.hermes/profiles/default/SOUL.md` if it exists, which is the canonical
+//! "personality" file for the default profile.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::persona;
+use crate::config::Config;
+use crate::memory::Summary;
+use crate::session::home_dir;
+
+use super::{memory_size, HostAdapter, HostCaps};
+
+/// The Python plugin dropped into ~/.hermes/plugins/squeez-fallback/__init__.py
+const HERMES_PLUGIN: &str = include_str!("../../plugins/hermes/__init__.py");
+
+pub struct HermesAdapter;
+
+impl HermesAdapter {
+    fn hermes_dir() -> PathBuf {
+        PathBuf::from(format!("{}/.hermes", home_dir()))
+    }
+
+    fn plugins_dir() -> PathBuf {
+        Self::hermes_dir().join("plugins")
+    }
+
+    fn squeez_plugin_dir() -> PathBuf {
+        Self::plugins_dir().join("squeez-fallback")
+    }
+
+    fn soul_md_path() -> PathBuf {
+        Self::hermes_dir()
+            .join("profiles")
+            .join("default")
+            .join("SOUL.md")
+    }
+}
+
+impl HostAdapter for HermesAdapter {
+    fn name(&self) -> &'static str {
+        "hermes"
+    }
+
+    fn is_installed(&self) -> bool {
+        // Detect Hermes by checking for ~/.hermes/ with a hermes-agent subdir
+        // or a config.yaml — either indicates a real installation.
+        let dir = Self::hermes_dir();
+        if !dir.exists() {
+            return false;
+        }
+        dir.join("hermes-agent").exists() || dir.join("config.yaml").exists()
+    }
+
+    fn data_dir(&self) -> PathBuf {
+        std::env::var("SQUEEZ_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| Self::hermes_dir().join("squeez"))
+    }
+
+    fn capabilities(&self) -> HostCaps {
+        // Hermes has pre_tool_call (BASH_WRAP) and session start (SESSION_MEM).
+        // No programmatic Read/Grep budget injection (BUDGET_HARD) or soft
+        // budget hints via markdown (BUDGET_SOFT).
+        HostCaps::BASH_WRAP | HostCaps::SESSION_MEM
+    }
+
+    fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
+        let plugin_dir = Self::squeez_plugin_dir();
+        std::fs::create_dir_all(&plugin_dir)?;
+
+        // Write the Python plugin
+        let plugin_path = plugin_dir.join("__init__.py");
+        std::fs::write(&plugin_path, HERMES_PLUGIN)?;
+
+        // Create data directories
+        let data = self.data_dir();
+        std::fs::create_dir_all(data.join("sessions"))?;
+        std::fs::create_dir_all(data.join("memory"))?;
+
+        // Note: Hermes auto-discovers plugins in ~/.hermes/plugins/ on next
+        // session start — no config file patching needed, unlike Claude Code
+        // which requires settings.json manipulation.
+        Ok(())
+    }
+
+    fn uninstall(&self) -> std::io::Result<()> {
+        let plugin_dir = Self::squeez_plugin_dir();
+        if plugin_dir.exists() {
+            let _ = std::fs::remove_dir_all(&plugin_dir);
+        }
+
+        // Clean persona block from SOUL.md if present
+        let soul = Self::soul_md_path();
+        if soul.exists() {
+            let existing = std::fs::read_to_string(&soul).unwrap_or_default();
+            let cleaned = strip_squeez_block(&existing);
+            if cleaned != existing {
+                let _ = std::fs::write(&soul, cleaned);
+            }
+        }
+        Ok(())
+    }
+
+    fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
+        let soul = Self::soul_md_path();
+        if !soul.exists() {
+            // SOUL.md doesn't exist — skip memory injection. Hermes users
+            // configure their system prompt via config.yaml; we don't create
+            // SOUL.md to avoid overriding their setup.
+            return Ok(());
+        }
+
+        let existing = std::fs::read_to_string(&soul).unwrap_or_default();
+
+        let mut block = String::from("<!-- squeez:start -->\n");
+        if let Some(banner) =
+            memory_size::size_warning(&existing, "SOUL.md", cfg.memory_file_warn_tokens)
+        {
+            block.push_str(&banner);
+        }
+        block.push_str("## squeez — always-on compression\n\n");
+        block.push_str(&format!(
+            "Persona: {} | Bash compression: ON | Memory: ON\n\n",
+            persona::as_str(cfg.persona)
+        ));
+        let persona_text = persona::text_with_lang(cfg.persona, &cfg.lang);
+        if !persona_text.is_empty() {
+            block.push_str(persona_text);
+            if !persona_text.ends_with('\n') {
+                block.push('\n');
+            }
+        }
+        for s in summaries {
+            block.push_str(&format!("- {}\n", s.display_line()));
+        }
+        block.push_str("<!-- squeez:end -->\n");
+
+        let cleaned = strip_squeez_block(&existing);
+        let contents = format!("{}\n{}", block, cleaned.trim_start());
+        std::fs::write(&soul, contents)
+    }
+}
+
+fn strip_squeez_block(s: &str) -> String {
+    if !s.contains("<!-- squeez:start -->") {
+        return s.to_string();
+    }
+    let start = s.find("<!-- squeez:start -->").unwrap_or(0);
+    let end = s
+        .find("<!-- squeez:end -->")
+        .map(|i| i + "<!-- squeez:end -->".len() + 1)
+        .unwrap_or(start);
+    format!("{}{}", &s[..start], &s[end.min(s.len())..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_squeez_block_inside_existing_soul_md() {
+        let s = "# SOUL\n<!-- squeez:start -->\nfoo\n<!-- squeez:end -->\n## after\n";
+        let out = strip_squeez_block(s);
+        assert!(!out.contains("<!-- squeez:start -->"));
+        assert!(out.contains("# SOUL"));
+        assert!(out.contains("## after"));
+    }
+
+    #[test]
+    fn strip_squeez_block_passthrough_when_absent() {
+        let s = "# SOUL\nnothing to strip\n";
+        assert_eq!(strip_squeez_block(s), s);
+    }
+
+    #[test]
+    fn name_is_hermes() {
+        let a = HermesAdapter;
+        assert_eq!(a.name(), "hermes");
+    }
+}

--- a/src/hosts/hermes.rs
+++ b/src/hosts/hermes.rs
@@ -2,7 +2,10 @@
 //!
 //! [Hermes Agent](https://github.com/NousResearch/hermes-agent) by Nous Research
 //! is a general-purpose AI agent with a plugin system at `~/.hermes/plugins/`.
-//! Each plugin is a Python package with `__init__.py` exposing `register(ctx)`.
+//! A directory plugin is a Python package with a `plugin.yaml` manifest plus an
+//! `__init__.py` exposing `register(ctx)`; both files are required for Hermes to
+//! discover it. Discovered plugins are opt-in and must be enabled once via
+//! `hermes plugins enable squeez-fallback`.
 //!
 //! Hermes fires `pre_tool_call` and `post_tool_call` hooks for every tool
 //! invocation. The squeez plugin wraps terminal commands via `pre_tool_call`,
@@ -31,6 +34,10 @@ use super::{memory_size, HostAdapter, HostCaps};
 
 /// The Python plugin dropped into ~/.hermes/plugins/squeez-fallback/__init__.py
 const HERMES_PLUGIN: &str = include_str!("../../plugins/hermes/__init__.py");
+
+/// The manifest dropped alongside it. Hermes only discovers a directory plugin
+/// when both `plugin.yaml` and `__init__.py` are present.
+const HERMES_MANIFEST: &str = include_str!("../../plugins/hermes/plugin.yaml");
 
 pub struct HermesAdapter;
 
@@ -87,18 +94,22 @@ impl HostAdapter for HermesAdapter {
         let plugin_dir = Self::squeez_plugin_dir();
         std::fs::create_dir_all(&plugin_dir)?;
 
-        // Write the Python plugin
-        let plugin_path = plugin_dir.join("__init__.py");
-        std::fs::write(&plugin_path, HERMES_PLUGIN)?;
+        // Write the Python plugin + its manifest. Directory plugins require
+        // both files; without plugin.yaml Hermes will not discover the plugin.
+        std::fs::write(plugin_dir.join("__init__.py"), HERMES_PLUGIN)?;
+        std::fs::write(plugin_dir.join("plugin.yaml"), HERMES_MANIFEST)?;
 
         // Create data directories
         let data = self.data_dir();
         std::fs::create_dir_all(data.join("sessions"))?;
         std::fs::create_dir_all(data.join("memory"))?;
 
-        // Note: Hermes auto-discovers plugins in ~/.hermes/plugins/ on next
-        // session start — no config file patching needed, unlike Claude Code
-        // which requires settings.json manipulation.
+        // Hermes discovers the plugin from ~/.hermes/plugins/ on next session
+        // start, but directory plugins are opt-in — the user must enable it once:
+        //     hermes plugins enable squeez-fallback
+        eprintln!(
+            "squeez: Hermes plugin installed. Enable it once with:\n    hermes plugins enable squeez-fallback"
+        );
         Ok(())
     }
 
@@ -195,5 +206,14 @@ mod tests {
     fn name_is_hermes() {
         let a = HermesAdapter;
         assert_eq!(a.name(), "hermes");
+    }
+
+    #[test]
+    fn manifest_declares_required_fields() {
+        // Hermes won't discover a directory plugin without these.
+        assert!(HERMES_MANIFEST.contains("name: squeez-fallback"));
+        assert!(HERMES_MANIFEST.contains("version:"));
+        assert!(HERMES_MANIFEST.contains("description:"));
+        assert!(HERMES_MANIFEST.contains("pre_tool_call"));
     }
 }

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -14,6 +14,7 @@ pub mod claude_code;
 pub mod codex;
 pub mod copilot;
 pub mod gemini;
+pub mod hermes;
 pub mod memory_size;
 pub mod opencode;
 pub mod pi;
@@ -21,6 +22,7 @@ pub use claude_code::ClaudeCodeAdapter;
 pub use codex::CodexCliAdapter;
 pub use copilot::CopilotCliAdapter;
 pub use gemini::GeminiCliAdapter;
+pub use hermes::HermesAdapter;
 pub use opencode::OpenCodeAdapter;
 pub use pi::PiAdapter;
 
@@ -98,6 +100,7 @@ pub fn all_hosts() -> Vec<Box<dyn HostAdapter>> {
         Box::new(GeminiCliAdapter),
         Box::new(CodexCliAdapter),
         Box::new(PiAdapter),
+        Box::new(HermesAdapter),
     ]
 }
 
@@ -127,5 +130,11 @@ mod tests {
     #[test]
     fn find_returns_none_for_unknown() {
         assert!(find("nonexistent").is_none());
+    }
+
+    #[test]
+    fn find_returns_hermes() {
+        let a = find("hermes").expect("adapter");
+        assert_eq!(a.name(), "hermes");
     }
 }

--- a/tests/test_hosts_registry.rs
+++ b/tests/test_hosts_registry.rs
@@ -1,9 +1,9 @@
 use squeez::hosts::{all_hosts, find, HostCaps};
 
 #[test]
-fn registry_contains_six_adapters() {
+fn registry_contains_seven_adapters() {
     let hosts = all_hosts();
-    assert_eq!(hosts.len(), 6, "expected 6 host adapters");
+    assert_eq!(hosts.len(), 7, "expected 7 host adapters");
 }
 
 #[test]
@@ -50,7 +50,7 @@ fn gemini_and_codex_expose_budget_soft() {
 
 #[test]
 fn find_known_slugs() {
-    for slug in &["claude-code", "copilot", "opencode", "gemini", "codex", "pi"] {
+    for slug in &["claude-code", "copilot", "opencode", "gemini", "codex", "pi", "hermes"] {
         assert!(find(slug).is_some(), "find({}) returned None", slug);
     }
 }


### PR DESCRIPTION
Closes #174

## Summary

Supersedes #172. Adds the **Hermes Agent** ([Nous Research](https://github.com/NousResearch/hermes-agent)) host adapter, with two correctness fixes on top of @ggoldani's original work so the directory plugin actually loads.

Original commit by @ggoldani is preserved; the second commit is the fix.

## What #172 was missing

Hermes **directory plugins** (`~/.hermes/plugins/<name>/`) require **both** a `plugin.yaml` manifest **and** `__init__.py` — without the manifest Hermes never discovers the plugin (verified against the official [plugin docs](https://hermes-agent.nousresearch.com/docs/user-guide/features/plugins) and the [build-a-plugin guide](https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin)). #172 shipped only `__init__.py`. Directory plugins are also opt-in and must be enabled once.

> Note: the upstream `rtk-hermes` plugin needs no manifest because it is a **pip entry-point** plugin, not a directory plugin — a different discovery path.

## Fixes in this PR

- Add `plugins/hermes/plugin.yaml` (`name` / `version` / `description` / `provides_hooks: [pre_tool_call]`).
- `install()` writes `plugin.yaml` alongside `__init__.py`.
- Print the one-time enable step on install: `hermes plugins enable squeez-fallback`.
- Correct the module doc + install comment that claimed "auto-discovers… no config patching needed".
- Add `manifest_declares_required_fields` unit test.

## Verified

- `pre_tool_call` signature + in-place `args["command"]` mutation confirmed against the upstream `rtk-hermes` reference plugin (identical contract).
- `cargo build` + full `cargo test` green (the one failing `wrap_runs_and_shows_header` fails identically on `main` — it depends on local squeez config, unrelated to this change).

## Not verified

End-to-end load inside a live Hermes install (Hermes is not installed in this environment). The plugin now matches the documented directory-plugin contract exactly.
