### PR TITLE
fix(context): key budget/pressure to the real window, not cumulative counters

### DIFF
--- a/src/commands/track_result.rs
+++ b/src/commands/track_result.rs
@@ -56,6 +56,18 @@ pub fn run_with_dir_cfg(tool: &str, raw: &str, sessions_dir: &Path, cfg: &Config
         if let Some((cr, _io)) = crate::context::transcript::last_context_cache_ratio(path) {
             ctx.real_cache_read_tokens = cr;
         }
+        // Detect the host's real context window so budget/pressure math keys
+        // off the actual window (e.g. 1M) instead of the legacy 112.5K default
+        // (CF-2). Combine the model-id baseline with the largest observed
+        // context: any context >200K can only be the 1M tier. `transcript_path`
+        // is read above, so `real_ctx_tokens` is already current here.
+        let model_window = crate::context::transcript::detect_window(path).unwrap_or(0);
+        // Monotonic: a window never shrinks mid-session, and real_ctx_tokens
+        // fluctuates turn-to-turn (cache dynamics). Once any turn proves the 1M
+        // tier (>200K observed), stay there rather than dropping back to 200K.
+        let inferred =
+            crate::context::transcript::infer_window(model_window, ctx.real_ctx_tokens);
+        ctx.real_ctx_window = ctx.real_ctx_window.max(inferred);
     }
 
     // Bump the call counter for context tracking; tool calls advance state too.

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -525,9 +525,18 @@ fn record_bash_event(
     session::append_event(&dir, &current.session_file, &event);
 
     // Real measured context (CF-1) is authoritative over squeez's own byte
-    // counters when available; budget honors `context_window_tokens` (CF-2).
-    let effective_used = current.total_tokens.max(real_ctx_tokens);
-    let budget = crate::context::intensity::budget(config);
+    // counters: total_tokens is a cumulative monotonic sum of all tool I/O, not
+    // context occupancy, so on a long session it balloons past the true context
+    // and would falsely trip the critical warning. Use the measured value when
+    // present. Budget keys off the real window detected from the transcript
+    // model id, honoring `context_window_tokens` config first (CF-2).
+    let ctx = crate::context::cache::SessionContext::load(&dir);
+    let effective_used = if real_ctx_tokens > 0 {
+        real_ctx_tokens
+    } else {
+        current.total_tokens
+    };
+    let budget = crate::context::intensity::budget_for(config, ctx.real_ctx_window);
     let pct = effective_used * 100 / budget.max(1);
 
     let compact_trigger = if config.context_window_tokens > 0 {
@@ -539,8 +548,7 @@ fn record_bash_event(
     };
     let warning = if !current.compact_warned && effective_used >= compact_trigger {
         current.compact_warned = true;
-        // Load context for per-tool breakdown
-        let ctx = crate::context::cache::SessionContext::load(&dir);
+        // Per-tool breakdown from the already-loaded context.
         Some(format!(
             "⚠️  squeez: session ~{}K tokens ({}% of budget). Run /compact to free context.\n    Token breakdown: Bash {}K | Read {}K | Grep {}K | Other {}K",
             effective_used / 1000,
@@ -555,7 +563,6 @@ fn record_bash_event(
         let critical = if pct >= 90 {
             true
         } else {
-            let ctx = crate::context::cache::SessionContext::load(&dir);
             crate::economy::burn_rate::calls_remaining(&ctx, config)
                 .map(|r| r <= config.state_warn_calls)
                 .unwrap_or(false)

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -173,6 +173,12 @@ pub struct SessionContext {
     /// 0 = never observed. Feeds adaptive intensity and burn-rate math so
     /// they track the real context, not just squeez-processed bytes.
     pub real_ctx_tokens: u64,
+    /// Context window (tokens) of the host model, detected from the transcript's
+    /// `model` id (e.g. `[1m]` → 1_000_000, else 200_000). 0 = never observed.
+    /// Budget/pressure math keys off this so squeez warns against the real
+    /// window instead of the legacy 112.5K default. `context_window_tokens`
+    /// config still overrides it.
+    pub real_ctx_window: u64,
     /// `cache_read_input_tokens` of the latest measured API turn. Used to
     /// compute the cache-read:I/O ratio for context-leak detection (G1).
     /// 0 = not yet measured.
@@ -248,6 +254,7 @@ impl Default for SessionContext {
             skill_inject_fp: Vec::new(),
             skill_inject_call: Vec::new(),
             real_ctx_tokens: 0,
+            real_ctx_window: 0,
             real_cache_read_tokens: 0,
             calls_this_minute: 0,
             calls_minute_ts: 0,
@@ -935,7 +942,7 @@ impl SessionContext {
 \"cmd_repeat_name\":{},\"cmd_repeat_n\":{},\
 \"nudged_keys\":{},\
 \"skill_inject_fp\":{},\"skill_inject_call\":{},\
-\"real_ctx_tokens\":{},\"real_cache_read_tokens\":{},\"calls_this_minute\":{},\"calls_minute_ts\":{},\"pending_warnings\":{},\
+\"real_ctx_tokens\":{},\"real_ctx_window\":{},\"real_cache_read_tokens\":{},\"calls_this_minute\":{},\"calls_minute_ts\":{},\"pending_warnings\":{},\
 \"image_fp\":{},\"image_call\":{},\
 \"last_activity_ts\":{},\"subagent_file_map_ids\":{},\"subagent_file_map_paths\":{}}}",
             json_util::escape_str(&self.session_file),
@@ -982,6 +989,7 @@ impl SessionContext {
             json_util::u64_array(&self.skill_inject_fp),
             json_util::u64_array(&self.skill_inject_call),
             self.real_ctx_tokens,
+            self.real_ctx_window,
             self.real_cache_read_tokens,
             self.calls_this_minute,
             self.calls_minute_ts,
@@ -1146,6 +1154,7 @@ impl SessionContext {
         // Real-context + pending warnings + image dedup — optional for
         // backward compat with older context.json files.
         c.real_ctx_tokens = json_util::map_u64(&map, "real_ctx_tokens").unwrap_or(0);
+        c.real_ctx_window = json_util::map_u64(&map, "real_ctx_window").unwrap_or(0);
         c.real_cache_read_tokens = json_util::map_u64(&map, "real_cache_read_tokens").unwrap_or(0);
         c.calls_this_minute = json_util::map_u64(&map, "calls_this_minute").unwrap_or(0) as u32;
         c.calls_minute_ts = json_util::map_u64(&map, "calls_minute_ts").unwrap_or(0);
@@ -1204,8 +1213,10 @@ mod tests {
     fn real_ctx_tokens_survives_roundtrip() {
         let mut c = SessionContext::default();
         c.real_ctx_tokens = 286_129;
+        c.real_ctx_window = 1_000_000;
         let restored = SessionContext::from_json(&c.to_json());
         assert_eq!(restored.real_ctx_tokens, 286_129);
+        assert_eq!(restored.real_ctx_window, 1_000_000);
     }
 
     #[test]

--- a/src/context/intensity.rs
+++ b/src/context/intensity.rs
@@ -24,8 +24,20 @@ impl Intensity {
 /// the actual window (e.g. 200000, or 1000000 for a `[1m]` model). Otherwise
 /// falls back to the legacy `compact_threshold_tokens * 5 / 4` formula.
 pub fn budget(cfg: &Config) -> u64 {
+    budget_for(cfg, 0)
+}
+
+/// Budget keyed to the real host window. Precedence: explicit
+/// `context_window_tokens` config > `real_ctx_window` detected from the
+/// transcript model id > legacy `compact_threshold_tokens * 5/4`. This is what
+/// stops squeez warning against the wrong window (e.g. treating 17%-of-1M as
+/// "critical" because it assumed the 112.5K legacy budget).
+pub fn budget_for(cfg: &Config, real_ctx_window: u64) -> u64 {
     if cfg.context_window_tokens > 0 {
         return cfg.context_window_tokens;
+    }
+    if real_ctx_window > 0 {
+        return real_ctx_window;
     }
     cfg.compact_threshold_tokens.saturating_mul(5) / 4
 }
@@ -48,10 +60,16 @@ pub const ULTRA_TRIGGER_DEN: u64 = 100;
 ///
 /// The threshold is configurable via `ultra_trigger_pct` (default 0.65).
 pub fn derive(used: u64, cfg: &Config) -> Intensity {
+    derive_with(used, cfg, 0)
+}
+
+/// Like [`derive`] but keyed to the real host window (`real_ctx_window`, 0 =
+/// unknown → legacy budget).
+pub fn derive_with(used: u64, cfg: &Config, real_ctx_window: u64) -> Intensity {
     if !cfg.adaptive_intensity {
         return Intensity::Lite;
     }
-    let b = budget(cfg);
+    let b = budget_for(cfg, real_ctx_window);
     if b == 0 {
         // Misconfigured budget — fall back to the previous always-Ultra behavior.
         return Intensity::Ultra;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -27,11 +27,17 @@ pub fn pre_pass(
     // Phase 5: apply configurable tunables so all methods use user's values.
     ctx.init_tunables_from_config(cfg);
     // Real-context tracking (CF-1): squeez's own accounting only counts bytes
-    // it processed; the transcript-measured context (when observed via hooks)
-    // is authoritative. Use whichever signal is larger so intensity escalates
-    // in MCP/image-heavy sessions squeez's byte counters never see.
-    let effective_used = used_tokens.max(ctx.real_ctx_tokens);
-    let level = intensity::derive(effective_used, cfg);
+    // it processed. The transcript-measured context (when observed via hooks)
+    // is authoritative — squeez's own counters are cumulative monotonic sums of
+    // tool I/O, not context occupancy, so on long sessions they over-report and
+    // would pin intensity at Ultra. Use the measured value when present; fall
+    // back to the byte counter only when no transcript has been seen.
+    let effective_used = if ctx.real_ctx_tokens > 0 {
+        ctx.real_ctx_tokens
+    } else {
+        used_tokens
+    };
+    let level = intensity::derive_with(effective_used, cfg, ctx.real_ctx_window);
     let scaled = intensity::scale(cfg, level);
     (ctx, level, scaled)
 }

--- a/src/context/transcript.rs
+++ b/src/context/transcript.rs
@@ -99,6 +99,76 @@ pub fn last_cache_ratio_in(text: &str) -> Option<(u64, u64)> {
     None
 }
 
+/// Context window (in tokens) implied by a model id string. Claude models
+/// ship a 200K window by default; the `[1m]` / `-1m` long-context variants
+/// expose 1M. squeez keys budget/pressure math to this so it never warns
+/// against the wrong window (e.g. flagging 17%-of-1M as "critical" because it
+/// assumed 200K). Unknown ids fall back to the conservative 200K standard.
+pub fn window_for_model(model: &str) -> u64 {
+    let m = model.to_ascii_lowercase();
+    if m.contains("[1m]") || m.contains("-1m") || m.contains(" 1m") {
+        1_000_000
+    } else {
+        200_000
+    }
+}
+
+/// The standard Claude context window. The only larger tier is 1M, so any
+/// observed context above this implies the host is on the 1M window.
+pub const STANDARD_WINDOW: u64 = 200_000;
+
+/// Infer the real context window from two signals: the model id's baseline
+/// window and the largest context actually observed. The Claude transcript
+/// records the base model id (`claude-opus-4-8`) WITHOUT the `[1m]` suffix even
+/// on 1M sessions, so the model id alone can't prove 1M — but a model that has
+/// already accepted >200K of context cannot be on the 200K tier, so the
+/// observed ceiling promotes it to 1M. Below 200K the two tiers are
+/// indistinguishable from the transcript; set `context_window_tokens` to pin it.
+pub fn infer_window(model_window: u64, observed_ctx: u64) -> u64 {
+    let base = if model_window > 0 {
+        model_window
+    } else {
+        STANDARD_WINDOW
+    };
+    if observed_ctx > STANDARD_WINDOW {
+        base.max(1_000_000)
+    } else {
+        base
+    }
+}
+
+/// Detect the host's context window from the most recent non-sidechain
+/// assistant record's `model` field. Returns `None` when no model id is found.
+pub fn detect_window_in(text: &str) -> Option<u64> {
+    for line in text.lines().rev() {
+        if !line.contains("\"type\":\"assistant\"") {
+            continue;
+        }
+        if line.contains("\"isSidechain\":true") {
+            continue;
+        }
+        if let Some(model) = extract_str(line, "model") {
+            return Some(window_for_model(&model));
+        }
+    }
+    None
+}
+
+/// File wrapper for [`detect_window_in`]: tail-read the transcript and detect
+/// the window from its last assistant record.
+pub fn detect_window(path: &Path) -> Option<u64> {
+    tail_read(path).and_then(|t| detect_window_in(&t))
+}
+
+/// Extract the first `"key":"<value>"` string occurrence from `line`.
+fn extract_str(line: &str, key: &str) -> Option<String> {
+    let pat = format!("\"{}\":\"", key);
+    let idx = line.find(&pat)?;
+    let after = &line[idx + pat.len()..];
+    let end = after.find('"')?;
+    Some(after[..end].to_string())
+}
+
 /// Extract the first `"key":<number>` occurrence from `line`.
 /// `"input_tokens"` must not match `"cache_read_input_tokens"`, so the
 /// match is anchored on the full quoted key.
@@ -163,6 +233,43 @@ mod tests {
             last_context_tokens(Path::new("/nonexistent/squeez/transcript.jsonl")),
             None
         );
+    }
+
+    #[test]
+    fn infer_window_promotes_on_observed_ceiling() {
+        // Base model id maps to 200K, but 223K observed can only be the 1M tier.
+        assert_eq!(infer_window(200_000, 223_328), 1_000_000);
+        // Below the standard window: stays at the model-id baseline.
+        assert_eq!(infer_window(200_000, 150_000), 200_000);
+        // Explicit 1M model id stays 1M regardless of observed.
+        assert_eq!(infer_window(1_000_000, 10_000), 1_000_000);
+        // Unknown model id (0) defaults to standard, still promotes on ceiling.
+        assert_eq!(infer_window(0, 50_000), 200_000);
+        assert_eq!(infer_window(0, 250_000), 1_000_000);
+    }
+
+    #[test]
+    fn window_for_model_detects_1m_and_default() {
+        assert_eq!(window_for_model("claude-opus-4-8[1m]"), 1_000_000);
+        assert_eq!(window_for_model("claude-sonnet-5"), 200_000);
+        assert_eq!(window_for_model("claude-opus-4-8"), 200_000);
+    }
+
+    #[test]
+    fn detect_window_reads_model_from_last_assistant() {
+        let line = r#"{"type":"assistant","message":{"model":"claude-opus-4-8[1m]","usage":{"input_tokens":1}}}"#;
+        assert_eq!(detect_window_in(line), Some(1_000_000));
+        let std = r#"{"type":"assistant","message":{"model":"claude-sonnet-5","usage":{"input_tokens":1}}}"#;
+        assert_eq!(detect_window_in(std), Some(200_000));
+    }
+
+    #[test]
+    fn detect_window_skips_sidechain_and_handles_missing() {
+        let side = r#"{"type":"assistant","isSidechain":true,"message":{"model":"x[1m]"}}"#;
+        let main = r#"{"type":"assistant","message":{"model":"claude-sonnet-5"}}"#;
+        assert_eq!(detect_window_in(&format!("{}\n{}", side, main)), Some(200_000));
+        assert_eq!(detect_window_in(""), None);
+        assert_eq!(detect_window_in(r#"{"type":"user"}"#), None);
     }
 
     #[test]

--- a/src/economy/burn_rate.rs
+++ b/src/economy/burn_rate.rs
@@ -28,11 +28,18 @@ pub fn calls_remaining(ctx: &SessionContext, cfg: &Config) -> Option<u64> {
         // Mostly-empty window — no reliable estimate (mirrors the old avg==0 guard).
         return None;
     }
-    let budget = crate::context::intensity::budget(cfg);
-    // Real measured context (when observed) is authoritative over squeez's
-    // own byte counters, which miss MCP/image traffic entirely (CF-1).
+    let budget = crate::context::intensity::budget_for(cfg, ctx.real_ctx_window);
+    // Real measured context (when observed) is authoritative over squeez's own
+    // byte counters: those are cumulative monotonic sums of all tool I/O, not
+    // context occupancy, so in a long session they balloon far past the true
+    // context and would falsely zero out the remaining budget. Use the measured
+    // value when present; fall back to counters only when no transcript is seen.
     let counted = ctx.tokens_bash + ctx.tokens_read + ctx.tokens_grep + ctx.tokens_other;
-    let used = counted.max(ctx.real_ctx_tokens);
+    let used = if ctx.real_ctx_tokens > 0 {
+        ctx.real_ctx_tokens
+    } else {
+        counted
+    };
     if used >= budget {
         return Some(0);
     }


### PR DESCRIPTION
## Problem
The context-pressure monitor fired `context critical (100%)` / `budget: ~0 calls left` while the real context sat at ~17% of a 1M window.

## Root cause (two compounding defects)
1. **Denominator** — `intensity::budget()` fell back to the legacy `compact_threshold*5/4` (~112.5K) whenever `context_window_tokens` was unset — ~9× too small on a 1M model.
2. **Numerator** — `used = counted.max(real_ctx_tokens)` at three sites, but `total_tokens`/`tokens_*` are cumulative monotonic sums of all tool I/O, not context occupancy. On long sessions they balloon past the true context, so `max()` let the inflated counter win — contradicting the code's own comment that measured context is authoritative.

## Fix
- `transcript.rs`: `window_for_model` + `infer_window` (model-id baseline **+ observed ceiling** — any context >200K can only be the 1M tier, since the transcript records the base model id without the `[1m]` suffix) + `detect_window`.
- `track_result.rs`: populate `real_ctx_window` **monotonically** (a window never shrinks; `real_ctx_tokens` fluctuates with cache dynamics).
- `cache.rs`: persist `real_ctx_window` (serde + default).
- `intensity.rs`: `budget_for(cfg, window)` / `derive_with` — precedence: explicit config > detected window > legacy formula.
- `burn_rate.rs`, `wrap.rs`, `context/mod.rs`: measured `real_ctx_tokens` is the numerator when present; counters are fallback only.

## Testing
- Full suite green (new tests: `infer_window`, `window_for_model`, `detect_window`, `real_ctx_window` serde roundtrip).
- End-to-end with `context_window_tokens=0` (pure detection): `real_ctx_window` auto-detects `1000000`, header drops from `context critical (100%)` to `[adaptive: Full]` with a positive calls-left estimate.

Closes #177