### PR TITLE
fix(context): don't drop distinct MCP browser snapshots as redundant

### DIFF
--- a/src/commands/compress_output.rs
+++ b/src/commands/compress_output.rs
@@ -123,10 +123,19 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
         })
         .unwrap_or(false);
 
+    // MCP results (DOM snapshots, evaluate_script returns, structured JSON) are
+    // dedup-only, and only EXACT dedup is safe for them: two near-identical
+    // snapshots differ precisely in the fields the model asked for (element
+    // uids, a grid cell value, coordinates), so a fuzzy "~96% similar" drop
+    // omits exactly the payload — the same failure the A2 stale-state guard
+    // prevents for edited files. Suppress fuzzy dedup for MCP; byte-identical
+    // re-emissions still collapse (identical bytes carry no new information).
+    let is_mcp = tool.starts_with("mcp__");
+
     // Redundancy check: if we've seen this content before, replace with a note.
     if cfg.redundancy_cache_enabled {
         if let Some(hit) = context::redundancy::check(&ctx, &lines) {
-            let fuzzy_blocked = hit.similarity.is_some() && edited_since_seen;
+            let fuzzy_blocked = hit.similarity.is_some() && (edited_since_seen || is_mcp);
             if !fuzzy_blocked {
                 let note = match hit.similarity {
                     None => format!(
@@ -153,7 +162,6 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
     // log-oriented summarizer would corrupt, so they participate in the
     // redundancy check above but are never summarized (audit item 2 — track
     // and dedupe MCP traffic, leave first-sight content intact).
-    let is_mcp = tool.starts_with("mcp__");
     let rewritten = if !is_mcp && context::summarize::should_apply_for_tool(&lines, cfg, tool) {
         let summary = context::summarize::apply(lines.clone(), tool);
         if summary.len() < lines.len() {
@@ -280,7 +288,7 @@ fn extract_content(raw: &str) -> Option<String> {
         let after = &rest[idx + 7..];
         let after = after.trim_start();
         if let Some(stripped) = after.strip_prefix('"') {
-            if let Some(end) = stripped.find('"') {
+            if let Some(end) = find_unescaped_quote(stripped) {
                 out.push_str(&unescape(&stripped[..end]));
                 out.push('\n');
             }
@@ -297,7 +305,7 @@ fn extract_string_field(raw: &str, key: &str) -> Option<String> {
         let after = &rest[idx + pat.len()..];
         let after = after.trim_start();
         if let Some(stripped) = after.strip_prefix('"') {
-            if let Some(end) = stripped.find('"') {
+            if let Some(end) = find_unescaped_quote(stripped) {
                 let val = &stripped[..end];
                 if !val.is_empty() {
                     return Some(val.to_string());
@@ -305,6 +313,24 @@ fn extract_string_field(raw: &str, key: &str) -> Option<String> {
             }
         }
         rest = &rest[idx + pat.len()..];
+    }
+    None
+}
+
+/// Byte offset of the first `"` in `s` that terminates a JSON string — i.e. the
+/// first `"` not part of an escape sequence. A naive `find('"')` stops at the
+/// escaped quote inside values like `class=\"grid\"`, truncating the content to
+/// its pre-first-quote prefix; for DOM snapshots that prefix is constant across
+/// calls, so distinct snapshots collide on the exact-hash dedup and get dropped.
+fn find_unescaped_quote(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2, // skip the escaped char (\" or \\ etc.)
+            b'"' => return Some(i),
+            _ => i += 1,
+        }
     }
     None
 }

--- a/tests/test_repro_mcp_fuzzy.rs
+++ b/tests/test_repro_mcp_fuzzy.rs
@@ -1,0 +1,94 @@
+// Regression: squeez was dropping distinct browser (chrome-devtools) MCP
+// snapshots as redundant, forcing the model to work around it by dumping
+// snapshots to a file to read the real element uids.
+//
+// Two independent defects combined:
+//   1. extract_string_field truncated JSON-escaped content at the first `\"`,
+//      collapsing every DOM snapshot to its constant pre-quote prefix → exact
+//      dedup fired across genuinely different snapshots.
+//   2. Fuzzy (~similar) dedup applied to MCP results, where the diff between two
+//      near-identical snapshots IS the payload the model asked for.
+
+use squeez::commands::compress_output::compute_rewrite;
+use squeez::config::Config;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tmp() -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let d = std::env::temp_dir().join(format!(
+        "squeez_repro_{}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        n
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+const TOOL: &str = "mcp__chrome-devtools__take_snapshot";
+
+/// A PostToolUse payload whose content is a JSON-escaped string, exactly as
+/// Claude Code delivers it — inner attribute quotes arrive as `\"`.
+fn pt(content_escaped: &str) -> String {
+    format!(r#"{{"tool_name":"{TOOL}","tool_result":{{"content":"{content_escaped}"}}}}"#)
+}
+
+/// DOM snapshot with escaped quotes; `uid` seeds the element ids (what the
+/// model needs). `extra` appends a trailing distinguishing value.
+fn snapshot(uid: &str, cells: usize, extra: &str) -> String {
+    let mut s = String::from("<body>\\n  <div class=\\\"grid\\\">");
+    for c in 0..cells {
+        s.push_str(&format!(
+            "\\n    uid={uid}_{c} <button class=\\\"cell\\\">Cell {c}</button>"
+        ));
+    }
+    s.push_str(&format!("\\n    <span id=\\\"total\\\">{extra}</span>"));
+    s.push_str("\\n  </div>\\n</body>");
+    s
+}
+
+#[test]
+fn escaped_snapshot_differing_in_uids_not_dropped() {
+    let dir = tmp();
+    let cfg = Config::default();
+    compute_rewrite(&pt(&snapshot("1", 8, "x")), TOOL, &dir, &cfg);
+    // Different uids — extraction must see past the escaped quotes so the hash
+    // differs and this survives.
+    let second = compute_rewrite(&pt(&snapshot("2", 8, "x")), TOOL, &dir, &cfg);
+    assert!(
+        second.is_none(),
+        "distinct snapshot dropped by dedup: {second:?}"
+    );
+}
+
+#[test]
+fn near_identical_snapshot_not_fuzzy_dropped() {
+    let dir = tmp();
+    let cfg = Config::default();
+    // 30 identical cells, only the trailing value differs — ~96% similar, but
+    // that value is the payload. Fuzzy dedup must not swallow it.
+    compute_rewrite(&pt(&snapshot("n", 30, "score: 41")), TOOL, &dir, &cfg);
+    let second = compute_rewrite(&pt(&snapshot("n", 30, "score: 99")), TOOL, &dir, &cfg);
+    assert!(
+        second.is_none(),
+        "near-identical MCP snapshot fuzzy-dropped, losing the changed value: {second:?}"
+    );
+}
+
+#[test]
+fn byte_identical_mcp_still_dedups() {
+    let dir = tmp();
+    let cfg = Config::default();
+    let snap = pt(&snapshot("1", 8, "x"));
+    compute_rewrite(&snap, TOOL, &dir, &cfg);
+    // Exact re-emission carries no new information — still worth collapsing.
+    let again = compute_rewrite(&snap, TOOL, &dir, &cfg);
+    assert!(
+        again.as_deref().map(|s| s.contains("identical")).unwrap_or(false),
+        "byte-identical MCP output should still exact-dedup: {again:?}"
+    );
+}


### PR DESCRIPTION
## Problem

Browser MCP outputs (`chrome-devtools` `take_snapshot` / `evaluate_script`) were being collapsed as redundant, so the model lost the real element uids and had to work around it by dumping snapshots to a file.

## Root cause — two composing defects

1. **Broken JSON-escape handling in extraction.** `extract_string_field` and the `"text":` extractor scanned for the first `"` byte, which in JSON-escaped tool content is the escaped quote *inside* a value (`class=\"grid\"`). Content was truncated to its pre-first-quote prefix; for DOM snapshots that prefix is constant across calls, so distinct snapshots collided on the exact-hash dedup and were dropped. Fixed with `find_unescaped_quote()`, which scans past escape sequences.

2. **Fuzzy dedup on MCP results.** Two near-identical snapshots differ precisely in the payload the model asked for (a uid, a grid cell value), so a `~96% similar` drop omits exactly what's needed. Fuzzy dedup is now suppressed for MCP the same way the A2 stale-state guard does for edited files. Byte-identical re-emissions still collapse.

## Tests

`tests/test_repro_mcp_fuzzy.rs`: escaped-quote snapshot differing in uids, near-identical snapshot differing in one value, and byte-identical still-dedups. Full suite green.

Closes #180