### PR TITLE
fix(config): match bypass list against each &&/;-separated segment

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -451,8 +451,14 @@ impl Config {
             .unwrap_or_default()
     }
 
+    /// Checks the bypass list against every `&&`/`;`-separated segment of
+    /// `cmd`, not just the whole string — so `cd /path && npx vitest run`
+    /// bypasses when `npx` is listed, even though the leading token is `cd` (#181).
     pub fn is_bypassed(&self, cmd: &str) -> bool {
-        self.bypass.iter().any(|b| cmd.starts_with(b.as_str()))
+        cmd.split("&&").flat_map(|s| s.split(';')).any(|segment| {
+            let segment = segment.trim();
+            self.bypass.iter().any(|b| segment.starts_with(b.as_str()))
+        })
     }
 
     /// True if `cmd` matches a risk pattern — too dangerous to wrap, so it must
@@ -511,5 +517,26 @@ mod wrap_safety_tests {
     fn bypassed_commands_are_not_wrapped() {
         let c = Config::default(); // bypass includes ssh, psql, …
         assert!(!c.should_wrap_bash("ssh host uptime"));
+    }
+
+    #[test]
+    fn bypass_matches_segment_after_cd_and(){
+        let mut c = Config::default();
+        c.bypass.push("npx vitest".to_string());
+        assert!(c.is_bypassed("cd /path/to/repo && npx vitest run"));
+        assert!(!c.should_wrap_bash("cd /path/to/repo && npx vitest run"));
+    }
+
+    #[test]
+    fn bypass_matches_segment_after_semicolon() {
+        let mut c = Config::default();
+        c.bypass.push("mysql".to_string());
+        assert!(c.is_bypassed("cd /tmp; mysql -u root"));
+    }
+
+    #[test]
+    fn bypass_does_not_match_unrelated_compound_command() {
+        let c = Config::default();
+        assert!(!c.is_bypassed("cd /path/to/repo && npx vitest run"));
     }
 }


### PR DESCRIPTION
## Summary
- `is_bypassed()` used to check `cmd.starts_with(entry)` against the whole command string, so compound commands like `cd /path/to/repo && npx vitest run` were never bypassed even when `npx`/`vitest` were in the bypass list — the leading token was `cd`.
- Now splits on `&&` and `;`, trims each segment, and checks it independently against the bypass list — a match on any segment bypasses compression.
- Added regression tests covering `cd X && <bypassed>`, `;`-separated segments, and the previously-broken case with no matching bypass entry.

Fixes #181

## Test plan
- [x] `cargo test --lib wrap_safety_tests` — 7/7 pass, including 3 new tests
- [x] `cargo test` — full suite green except `wrap_runs_and_shows_header`, confirmed pre-existing/unrelated (fails identically on `main` before this change)