### PR TITLE
feat: pxpipe-inspired savings — factsheet, class density, cache-aware accounting, net-win gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "squeez"
-version = "1.34.6"
+version = "1.35.0"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "squeez"
-version = "1.34.6"
+version = "1.35.0"
 edition = "2021"
 description = "Hook-based token compressor for 5 AI CLI hosts (Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI). Up to 95% bash compression, signature-mode for code reads, cross-call dedup, MCP server, self-teaching protocol. Zero runtime deps."
 repository = "https://github.com/claudioemmanuel/squeez"

--- a/src/commands/benchmark.rs
+++ b/src/commands/benchmark.rs
@@ -574,6 +574,17 @@ fn make_massive_cargo_output() -> String {
 
 // ─── Efficiency proof ─────────────────────────────────────────────────────────
 
+// Anthropic list-price ratios (Fable 5), kept as ratios — not $ — so the
+// accounting stays model-agnostic. Following pxpipe (github.com/teamchong/pxpipe),
+// the SAME rate is applied to both sides of each comparison under the SAME cache
+// state, so the caching discount is never miscounted as compression savings.
+// Savings reported here are per compressed slice ("compressed-only"); end-to-end
+// savings depend on the workload's mix of compressed vs untouched context.
+pub const INPUT_RATE: f64 = 1.0;
+pub const CACHE_WRITE_RATE: f64 = 1.25;
+pub const CACHE_READ_RATE: f64 = 0.1;
+pub const OUTPUT_RATE: f64 = 5.0;
+
 /// One row in the efficiency-proof table.
 pub struct EfficiencyResult {
     pub label: &'static str,
@@ -583,6 +594,41 @@ pub struct EfficiencyResult {
     pub reduction_pct: f64,
     pub floor_pct: f64,
     pub passes: bool,
+    /// Effective cost (token-rate units) on first send of a cacheable block.
+    pub cold_baseline_eff: f64,
+    pub cold_compressed_eff: f64,
+    /// Effective cost when every later turn re-reads the block from cache.
+    pub warm_baseline_eff: f64,
+    pub warm_compressed_eff: f64,
+}
+
+impl EfficiencyResult {
+    /// Build a row, deriving pass/fail and cache-aware effective costs.
+    /// Cold = ×CACHE_WRITE_RATE, warm = ×CACHE_READ_RATE — same rate on both
+    /// sides of the comparison (pxpipe-style), so savings can be negative and
+    /// are not floored.
+    pub fn new(
+        label: &'static str,
+        feature: &'static str,
+        baseline_tokens: usize,
+        compressed_tokens: usize,
+        reduction_pct: f64,
+        floor_pct: f64,
+    ) -> Self {
+        EfficiencyResult {
+            label,
+            feature,
+            baseline_tokens,
+            compressed_tokens,
+            reduction_pct,
+            floor_pct,
+            passes: reduction_pct >= floor_pct,
+            cold_baseline_eff: baseline_tokens as f64 * CACHE_WRITE_RATE,
+            cold_compressed_eff: compressed_tokens as f64 * CACHE_WRITE_RATE,
+            warm_baseline_eff: baseline_tokens as f64 * CACHE_READ_RATE,
+            warm_compressed_eff: compressed_tokens as f64 * CACHE_READ_RATE,
+        }
+    }
 }
 
 /// Run 5 deterministic proof cases and return evidence that each shipped feature
@@ -610,15 +656,14 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
         let reduction = reduction_pct(baseline_tokens, compressed_tokens);
         // FLOOR: 80.0 — sig-mode replaces 1000-line body with ~50-80 sig lines
         let floor = 80.0_f64;
-        results.push(EfficiencyResult {
-            label: "sig_mode_rust_1000",
-            feature: "US-001",
+        results.push(EfficiencyResult::new(
+            "sig_mode_rust_1000",
+            "US-001",
             baseline_tokens,
             compressed_tokens,
-            reduction_pct: reduction,
-            floor_pct: floor,
-            passes: reduction >= floor,
-        });
+            reduction,
+            floor,
+        ));
     }
 
     // ── US-001 / sig_mode_python_1000 ───────────────────────────────────────
@@ -642,15 +687,14 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
         // FLOOR: 65.0 — Python class+def signatures are less keyword-dense
         // but padding lines dominate the 1000-line fixture, giving ≥65% savings.
         let floor = 65.0_f64;
-        results.push(EfficiencyResult {
-            label: "sig_mode_python_1000",
-            feature: "US-001",
+        results.push(EfficiencyResult::new(
+            "sig_mode_python_1000",
+            "US-001",
             baseline_tokens,
             compressed_tokens,
-            reduction_pct: reduction,
-            floor_pct: floor,
-            passes: reduction >= floor,
-        });
+            reduction,
+            floor,
+        ));
     }
 
     // ── US-001 / sig_mode_delta_vs_baseline_pipeline ────────────────────────
@@ -687,15 +731,14 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
 
         let reduction = reduction_pct(baseline_tokens, compressed_tokens);
         let floor = 10.0_f64;
-        results.push(EfficiencyResult {
-            label: "sig_mode_delta_vs_pipeline",
-            feature: "US-001",
+        results.push(EfficiencyResult::new(
+            "sig_mode_delta_vs_pipeline",
+            "US-001",
             baseline_tokens,
             compressed_tokens,
-            reduction_pct: reduction,
-            floor_pct: floor,
-            passes: reduction >= floor,
-        });
+            reduction,
+            floor,
+        ));
     }
 
     // ── US-003 / structured_vs_prose ────────────────────────────────────────
@@ -723,15 +766,14 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
         // we measure the delta — 50% reflects the head/tail savings.
         let floor = 30.0_f64; // FLOOR: 30.0 — conservative to account for large error extracts
         let _ = line_count; // used for documentation; floor reflects actual output shape
-        results.push(EfficiencyResult {
-            label: "structured_vs_prose",
-            feature: "US-003",
+        results.push(EfficiencyResult::new(
+            "structured_vs_prose",
+            "US-003",
             baseline_tokens,
             compressed_tokens,
-            reduction_pct: reduction,
-            floor_pct: floor,
-            passes: reduction >= floor,
-        });
+            reduction,
+            floor,
+        ));
     }
 
     // ── US-004 / hypothesis_c6_vs_c0 ────────────────────────────────────────
@@ -748,26 +790,17 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
             // FLOOR: 80.0 — C6 combines all optimisation levers; any combined
             // config achieving less than 80% vs raw would indicate a regression.
             let floor = 80.0_f64;
-            results.push(EfficiencyResult {
-                label: "hypothesis_c6_vs_c0",
-                feature: "US-004",
+            results.push(EfficiencyResult::new(
+                "hypothesis_c6_vs_c0",
+                "US-004",
                 baseline_tokens,
                 compressed_tokens,
-                reduction_pct: red,
-                floor_pct: floor,
-                passes: red >= floor,
-            });
+                red,
+                floor,
+            ));
         } else {
             // Fallback: should never happen with a well-formed grid
-            results.push(EfficiencyResult {
-                label: "hypothesis_c6_vs_c0",
-                feature: "US-004",
-                baseline_tokens: 0,
-                compressed_tokens: 0,
-                reduction_pct: 0.0,
-                floor_pct: 80.0,
-                passes: false,
-            });
+            results.push(EfficiencyResult::new("hypothesis_c6_vs_c0", "US-004", 0, 0, 0.0, 80.0));
         }
     }
 
@@ -778,13 +811,13 @@ pub fn run_efficiency_proof() -> Vec<EfficiencyResult> {
 pub fn efficiency_to_json(results: &[EfficiencyResult]) -> String {
     let all_pass = results.iter().all(|r| r.passes);
     let mut out = String::new();
-    out.push_str("{\"schema_version\":1,\"efficiency_proof\":[");
+    out.push_str("{\"schema_version\":2,\"efficiency_proof\":[");
     for (i, r) in results.iter().enumerate() {
         if i > 0 {
             out.push(',');
         }
         out.push_str(&format!(
-            "{{\"feature\":\"{}\",\"label\":\"{}\",\"baseline_tokens\":{},\"compressed_tokens\":{},\"reduction_pct\":{:.2},\"floor_pct\":{:.2},\"passes\":{}}}",
+            "{{\"feature\":\"{}\",\"label\":\"{}\",\"baseline_tokens\":{},\"compressed_tokens\":{},\"reduction_pct\":{:.2},\"floor_pct\":{:.2},\"passes\":{},\"cold_baseline_eff\":{:.2},\"cold_compressed_eff\":{:.2},\"warm_baseline_eff\":{:.2},\"warm_compressed_eff\":{:.2},\"net_saving_cold\":{:.2},\"net_saving_warm\":{:.2}}}",
             json_util::escape_str(r.feature),
             json_util::escape_str(r.label),
             r.baseline_tokens,
@@ -792,6 +825,12 @@ pub fn efficiency_to_json(results: &[EfficiencyResult]) -> String {
             r.reduction_pct,
             r.floor_pct,
             r.passes,
+            r.cold_baseline_eff,
+            r.cold_compressed_eff,
+            r.warm_baseline_eff,
+            r.warm_compressed_eff,
+            r.cold_baseline_eff - r.cold_compressed_eff,
+            r.warm_baseline_eff - r.warm_compressed_eff,
         ));
     }
     out.push_str(&format!("],\"all_pass\":{}}}", all_pass));
@@ -806,20 +845,21 @@ fn print_efficiency_proof_table(results: &[EfficiencyResult]) {
     println!("╚═══════════════════════════════════════════════════════════════════════════════════╝");
     println!();
     println!(
-        "{:<8}  {:<28}  {:>8}  {:>10}  {:>9}  {:>6}  {}",
-        "FEATURE", "LABEL", "BASELINE", "COMPRESSED", "REDUCTION", "FLOOR", "STATUS"
+        "{:<8}  {:<28}  {:>8}  {:>10}  {:>9}  {:>6}  {:>10}  {}",
+        "FEATURE", "LABEL", "BASELINE", "COMPRESSED", "REDUCTION", "FLOOR", "WARM-SAVE", "STATUS"
     );
-    println!("{}", "─".repeat(88));
+    println!("{}", "─".repeat(100));
     for r in results {
         let status = if r.passes { "PASS" } else { "FAIL" };
         println!(
-            "{:<8}  {:<28}  {:>6}tk  {:>8}tk  {:>8.1}%  {:>5.1}%  {}",
+            "{:<8}  {:<28}  {:>6}tk  {:>8}tk  {:>8.1}%  {:>5.1}%  {:>10.1}  {}",
             r.feature,
             r.label,
             r.baseline_tokens,
             r.compressed_tokens,
             r.reduction_pct,
             r.floor_pct,
+            r.warm_baseline_eff - r.warm_compressed_eff,
             status,
         );
     }
@@ -830,6 +870,11 @@ fn print_efficiency_proof_table(results: &[EfficiencyResult]) {
     } else {
         println!("FAIL: one or more floors did not pass. See rows above.");
     }
+    println!(
+        "cache-aware: cold=×{} warm=×{}, same state both sides (pxpipe-style); \
+         savings are per compressed slice, end-to-end depends on workload.",
+        CACHE_WRITE_RATE, CACHE_READ_RATE
+    );
     println!();
 }
 

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -148,7 +148,12 @@ pub fn run(cmd_str: &str) -> i32 {
     combined.push_str(&String::from_utf8_lossy(&stderr_bytes));
     combined.push_str(&String::from_utf8_lossy(&stdout_bytes));
 
-    let input_tokens = crate::tokens::estimate_scaled(&combined, config.tokenizer_scale);
+    // Content-class calibrated estimate (R2); flat path via class_density=false.
+    let input_tokens = if config.class_density {
+        crate::tokens::estimate_classed(&combined, config.tokenizer_scale)
+    } else {
+        crate::tokens::estimate_scaled(&combined, config.tokenizer_scale)
+    };
     let lines: Vec<String> = combined.lines().map(String::from).collect();
     let orig_line_count = lines.len();
 
@@ -194,7 +199,28 @@ pub fn run(cmd_str: &str) -> i32 {
     }
 
     let output_str = compressed.join("\n");
-    let output_tokens = crate::tokens::estimate_scaled(&output_str, config.tokenizer_scale);
+    let output_tokens = if config.class_density {
+        crate::tokens::estimate_classed(&output_str, config.tokenizer_scale)
+    } else {
+        crate::tokens::estimate_scaled(&output_str, config.tokenizer_scale)
+    };
+
+    // ── Net-win gate (R4) ──────────────────────────────────────────────
+    // The `# squeez` header itself costs ~15-25 tokens. When compression was
+    // applied but saved less than `net_win_min_tokens`, the call is a net
+    // loss — emit the original output and suppress the header line instead.
+    // Follow-up warnings (compact, burst, cache-idle, cache-ratio) still
+    // print below: they're decision-relevant regardless of this call.
+    // Redundancy hits are exempt: the marker is a cross-call pointer, not a
+    // marginal compression win, and must keep its header context.
+    let compression_applied = output_str != combined.trim_end_matches('\n');
+    let net_win_gate = config.net_win_min_tokens > 0
+        && !redundancy_hit
+        && compression_applied
+        && input_tokens.saturating_sub(output_tokens) < config.net_win_min_tokens;
+    // Session accounting records what is actually emitted — zero savings on
+    // a gated passthrough.
+    let emitted_tokens = if net_win_gate { input_tokens } else { output_tokens };
 
     // ── Reversible compression: stash the original so the model can recover it ──
     // When a large output was meaningfully compressed, save the verbatim
@@ -204,6 +230,7 @@ pub fn run(cmd_str: &str) -> i32 {
     // hit (the prior call already holds the content).
     let retrieve_marker = if config.retrieve_enabled
         && !redundancy_hit
+        && !net_win_gate
         && orig_line_count >= config.retrieve_min_lines
         && output_str.len() + 256 < combined.len()
     {
@@ -225,7 +252,7 @@ pub fn run(cmd_str: &str) -> i32 {
     let test_sum   = extract_test_summary(&combined);
 
     let compact_warning = record_bash_event(
-        cmd_str, input_tokens, output_tokens, &files, &errors, &git_events, &test_sum, &config,
+        cmd_str, input_tokens, emitted_tokens, &files, &errors, &git_events, &test_sum, &config,
         ctx.real_ctx_tokens,
     );
 
@@ -238,39 +265,43 @@ pub fn run(cmd_str: &str) -> i32 {
     let cmd_name = cmd_str.split_whitespace().next().unwrap_or("cmd");
 
     if config.show_header {
-        let intensity_tag = if config.adaptive_intensity {
-            format!(" [adaptive: {}]", intensity.as_str())
-        } else {
-            String::new()
-        };
-        // Token economy: burn rate prediction
-        let budget_tag = crate::economy::burn_rate::pressure_warning(&ctx, &config)
-            .or_else(|| {
-                crate::economy::burn_rate::calls_remaining(&ctx, &config)
-                    .map(|r| crate::economy::burn_rate::format_pressure_header(r))
-            })
-            .unwrap_or_default();
-        let budget_tag = if budget_tag.is_empty() {
-            String::new()
-        } else {
-            format!(" {}", budget_tag)
-        };
-        // Token economy: agent cost warning
-        let agent_tag = crate::economy::agent_tracker::agent_cost_warning(&ctx, &config)
-            .map(|w| format!(" {}", w))
-            .unwrap_or_default();
-        // Token economy: enterprise transport indicator
-        let enterprise_mode = crate::economy::enterprise::detect();
-        let enterprise_tag = if enterprise_mode.is_enterprise() {
-            format!(" {}", crate::economy::enterprise::header_tag(enterprise_mode))
-        } else {
-            String::new()
-        };
-        println!(
-            "# squeez [{}] {}→{} tokens (-{}%) {}ms{}{}{}{}",
-            cmd_name, input_tokens, output_tokens, reduction, elapsed_ms,
-            intensity_tag, budget_tag, agent_tag, enterprise_tag
-        );
+        // Net-win gate: suppress only the header line itself — the warning
+        // lines below stay, they matter independently of compression.
+        if !net_win_gate {
+            let intensity_tag = if config.adaptive_intensity {
+                format!(" [adaptive: {}]", intensity.as_str())
+            } else {
+                String::new()
+            };
+            // Token economy: burn rate prediction
+            let budget_tag = crate::economy::burn_rate::pressure_warning(&ctx, &config)
+                .or_else(|| {
+                    crate::economy::burn_rate::calls_remaining(&ctx, &config)
+                        .map(|r| crate::economy::burn_rate::format_pressure_header(r))
+                })
+                .unwrap_or_default();
+            let budget_tag = if budget_tag.is_empty() {
+                String::new()
+            } else {
+                format!(" {}", budget_tag)
+            };
+            // Token economy: agent cost warning
+            let agent_tag = crate::economy::agent_tracker::agent_cost_warning(&ctx, &config)
+                .map(|w| format!(" {}", w))
+                .unwrap_or_default();
+            // Token economy: enterprise transport indicator
+            let enterprise_mode = crate::economy::enterprise::detect();
+            let enterprise_tag = if enterprise_mode.is_enterprise() {
+                format!(" {}", crate::economy::enterprise::header_tag(enterprise_mode))
+            } else {
+                String::new()
+            };
+            println!(
+                "# squeez [{}] {}→{} tokens (-{}%) {}ms{}{}{}{}",
+                cmd_name, input_tokens, output_tokens, reduction, elapsed_ms,
+                intensity_tag, budget_tag, agent_tag, enterprise_tag
+            );
+        }
         if let Some(ref warning) = compact_warning {
             println!("{}", warning);
         }
@@ -319,7 +350,16 @@ pub fn run(cmd_str: &str) -> i32 {
     if let Some(ref marker) = retrieve_marker {
         println!("{}", marker);
     }
-    if !output_str.is_empty() {
+    if net_win_gate {
+        // Gated passthrough: the header would cost more than compression
+        // saved, so the model gets the verbatim original.
+        if !combined.is_empty() {
+            print!("{}", combined);
+            if !combined.ends_with('\n') {
+                println!();
+            }
+        }
+    } else if !output_str.is_empty() {
         println!("{}", output_str);
     }
 
@@ -338,8 +378,8 @@ pub fn run(cmd_str: &str) -> i32 {
         ctx.note_errors(&errors);
         ctx.note_git(&git_events);
         ctx.note_tool_tokens("Bash", input_tokens as u64);
-        // Token economy: record burn rate
-        ctx.note_burn(output_tokens as u64);
+        // Token economy: record burn rate (what was actually emitted)
+        ctx.note_burn(emitted_tokens as u64);
 
         // ── Auto-curation nudges (item 1) ──────────────────────────────
         let nudges = crate::economy::nudge::evaluate(
@@ -358,7 +398,7 @@ pub fn run(cmd_str: &str) -> i32 {
     // ── Continuous handler calibration (item 2) ────────────────────────
     if config.handler_stats_enabled {
         let mut stats = crate::economy::handler_stats::HandlerStats::load(&sessions_dir_pp);
-        stats.record(cmd_name, input_tokens as u64, output_tokens as u64);
+        stats.record(cmd_name, input_tokens as u64, emitted_tokens as u64);
         stats.save(&sessions_dir_pp);
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,6 +154,19 @@ pub struct Config {
     /// (error/signal words + command query terms) instead of a blind head.
     /// Default: true.
     pub relevance_truncation_enabled: bool,
+    // ── Content-class calibrated density (R2) ────────────────────────────────
+    /// Use the content-class estimator for wrap token accounting: Dense
+    /// payloads (JSON/code/diffs) ≈ chars/2, Prose ≈ chars/3.7, Mixed falls
+    /// back to the char-class estimate. Calibrated on pxpipe measurements
+    /// (~1.91 chars/token dense, ~3.5-3.7 prose). False = flat
+    /// `estimate_scaled` path. Default: true.
+    pub class_density: bool,
+    // ── Net-win gate (R4) ────────────────────────────────────────────────────
+    /// Minimum token savings compression must achieve to be worth the
+    /// ~15-25-token `# squeez` header. Below this, wrap emits the original
+    /// output and suppresses the header (follow-up warnings still print).
+    /// 0 = disabled. Default: 24.
+    pub net_win_min_tokens: usize,
     // ── Bash-wrap safety (#150) ──────────────────────────────────────────────
     /// Master switch for rewriting Bash commands to `squeez wrap '…'` in the
     /// PreToolUse hook. When false, commands run unwrapped (no output
@@ -236,6 +249,8 @@ impl Default for Config {
             log_template_enabled: true,
             log_template_min: 3,
             relevance_truncation_enabled: true,
+            class_density: true,
+            net_win_min_tokens: 24,
             wrap_bash: true,
             bash_risk_patterns: vec![
                 "rm -rf".to_string(),
@@ -428,6 +443,10 @@ impl Config {
                     }
                     "relevance_truncation_enabled" => {
                         c.relevance_truncation_enabled = v == "true"
+                    }
+                    "class_density" => c.class_density = v == "true",
+                    "net_win_min_tokens" => {
+                        c.net_win_min_tokens = v.parse().unwrap_or(c.net_win_min_tokens)
                     }
                     "wrap_bash" => c.wrap_bash = v == "true",
                     "bash_risk_patterns" => {

--- a/src/context/factsheet.rs
+++ b/src/context/factsheet.rs
@@ -1,0 +1,355 @@
+//! Factsheet (R1): deterministic, budget-capped extraction of
+//! precision-critical identifiers from text that is about to be dropped by
+//! the summarizer. When summarize.rs collapses a large output, everything
+//! before the preserved tail vanishes — including exact tokens the model may
+//! need verbatim later (git SHAs, UUIDs, versions, ticket codes, big
+//! numbers). `extract` scans the dropped region and returns a small, stable
+//! list of such identifiers so the summary can carry them forward.
+//!
+//! Zero-dependency: hand-rolled char scanners, no regex.
+
+use std::collections::HashSet;
+
+/// Maximum number of facts returned by `extract`.
+pub const MAX_FACTS: usize = 16;
+/// Total budget for the facts when joined with single separators (~64 tokens).
+const MAX_JOINED_LEN: usize = 256;
+/// Only the first 256 KiB of input are scanned — identifiers that matter
+/// overwhelmingly appear early, and this bounds worst-case cost.
+const SCAN_CAP_BYTES: usize = 256 * 1024;
+/// Candidate token length bounds (after trimming surrounding punctuation).
+const MIN_TOKEN_LEN: usize = 3;
+const MAX_TOKEN_LEN: usize = 120;
+/// Hard cap on unique candidates collected before ranking — bounds the
+/// O(n²) substring-collapse pass on pathological inputs.
+const MAX_CANDIDATES: usize = 512;
+
+/// Characters that terminate a candidate token. `-` and `.` are NOT
+/// delimiters — UUIDs, ticket codes, and versions contain them.
+fn is_delim(c: char) -> bool {
+    c.is_whitespace()
+        || matches!(
+            c,
+            ',' | ';' | '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>' | '"' | '\'' | '`' | '='
+                | ':'
+        )
+}
+
+/// Punctuation trimmed from both ends of a raw token (sentence-final dots,
+/// bullet markers, issue-number hashes). None of the identifier classes can
+/// legitimately start or end with these.
+fn is_trim(c: char) -> bool {
+    matches!(c, '.' | '!' | '?' | '*' | '#' | '~' | '|' | '/' | '\\' | '-' | '+')
+}
+
+/// UUID: 8-4-4-4-12 hex groups separated by dashes (case-insensitive hex).
+fn is_uuid(tok: &str) -> bool {
+    let b = tok.as_bytes();
+    if b.len() != 36 {
+        return false;
+    }
+    for (i, &c) in b.iter().enumerate() {
+        match i {
+            8 | 13 | 18 | 23 => {
+                if c != b'-' {
+                    return false;
+                }
+            }
+            _ => {
+                if !c.is_ascii_hexdigit() {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+/// Hex / git-SHA token: 7–40 lowercase hex chars with at least one digit.
+/// The digit requirement rejects English words that happen to be all-hex
+/// letters ("deadbeef", "cafebabe" pass hex but carry no digit... they do
+/// carry none — exactly the false positives this rule exists to drop).
+fn is_hex_id(tok: &str) -> bool {
+    let len = tok.len();
+    if !(7..=40).contains(&len) {
+        return false;
+    }
+    let mut has_digit = false;
+    for c in tok.chars() {
+        match c {
+            '0'..='9' => has_digit = true,
+            'a'..='f' => {}
+            _ => return false,
+        }
+    }
+    has_digit
+}
+
+/// Ticket code: 2–10 uppercase ASCII letters, a dash, then 1+ digits
+/// (e.g. PROJ-1482, AB-123).
+fn is_ticket(tok: &str) -> bool {
+    let Some(dash) = tok.find('-') else {
+        return false;
+    };
+    let (prefix, rest) = (&tok[..dash], &tok[dash + 1..]);
+    (2..=10).contains(&prefix.len())
+        && prefix.chars().all(|c| c.is_ascii_uppercase())
+        && !rest.is_empty()
+        && rest.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Version string: optional leading `v`/`V`, then 2+ dot-separated numeric
+/// components (e.g. 1.34.6, v2.0.1). One component ("v2") is too ambiguous.
+fn is_version(tok: &str) -> bool {
+    let body = tok.strip_prefix('v').or_else(|| tok.strip_prefix('V')).unwrap_or(tok);
+    let mut components = 0usize;
+    for part in body.split('.') {
+        if part.is_empty() || !part.chars().all(|c| c.is_ascii_digit()) {
+            return false;
+        }
+        components += 1;
+    }
+    components >= 2
+}
+
+/// Classify a trimmed token into a priority tier, or None if it is not a
+/// precision-critical identifier. Tiers: 0 = opaque ids (hex/UUID),
+/// 1 = ticket codes, 2 = versions / large integers.
+fn classify(tok: &str) -> Option<u8> {
+    if is_uuid(tok) {
+        return Some(0);
+    }
+    // All-digit tokens are large integers, never hex ids — check first so a
+    // 7-digit number lands in tier 2 rather than masquerading as a SHA.
+    if tok.chars().all(|c| c.is_ascii_digit()) {
+        return if tok.len() >= 6 { Some(2) } else { None };
+    }
+    if is_hex_id(tok) {
+        return Some(0);
+    }
+    if is_ticket(tok) {
+        return Some(1);
+    }
+    if is_version(tok) {
+        return Some(2);
+    }
+    None
+}
+
+/// Extract a deterministic, budget-capped list of precision-critical
+/// identifiers from `text`. Output order: (tier asc, length desc, lex asc).
+/// Exact duplicates are dropped; a candidate that is a substring of another
+/// kept candidate is dropped (the most specific token wins). Stops when
+/// either MAX_FACTS or the 256-char joined budget would be exceeded.
+pub fn extract(text: &str) -> Vec<String> {
+    // Cap the scan at 256 KiB, backing off to a char boundary.
+    let scan = if text.len() > SCAN_CAP_BYTES {
+        let mut end = SCAN_CAP_BYTES;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        &text[..end]
+    } else {
+        text
+    };
+
+    // Pass 1: tokenize, trim, classify, dedup exact duplicates.
+    let mut seen: HashSet<&str> = HashSet::new();
+    let mut cands: Vec<(u8, &str)> = Vec::new();
+    'scan: for raw in scan.split(is_delim) {
+        let tok = raw.trim_matches(is_trim);
+        if tok.len() < MIN_TOKEN_LEN || tok.len() > MAX_TOKEN_LEN {
+            continue;
+        }
+        if let Some(tier) = classify(tok) {
+            if seen.insert(tok) {
+                cands.push((tier, tok));
+                if cands.len() >= MAX_CANDIDATES {
+                    break 'scan;
+                }
+            }
+        }
+    }
+
+    // High-cardinality guard: versions / large integers that appear in bulk
+    // are almost always generated sequences (per-crate versions in a build
+    // log, loop counters), not precision-critical identifiers. If tier 2
+    // alone yields more distinct candidates than the whole factsheet can
+    // carry, drop the tier rather than fill the budget with noise. Opaque
+    // ids (hex/UUID) and ticket codes stay — those are worth carrying even
+    // in bulk.
+    if cands.iter().filter(|&&(t, _)| t == 2).count() > MAX_FACTS {
+        cands.retain(|&(t, _)| t != 2);
+    }
+
+    // Pass 2: substring collapse. Visit longest-first (lex tiebreak keeps it
+    // deterministic) and drop any candidate contained in one already kept.
+    let mut order: Vec<usize> = (0..cands.len()).collect();
+    order.sort_by(|&a, &b| {
+        cands[b]
+            .1
+            .len()
+            .cmp(&cands[a].1.len())
+            .then_with(|| cands[a].1.cmp(cands[b].1))
+    });
+    let mut kept: Vec<(u8, &str)> = Vec::new();
+    for i in order {
+        let (tier, tok) = cands[i];
+        if !kept.iter().any(|&(_, k)| k.contains(tok)) {
+            kept.push((tier, tok));
+        }
+    }
+
+    // Pass 3: deterministic final order, then budget.
+    kept.sort_by(|a, b| {
+        a.0.cmp(&b.0)
+            .then_with(|| b.1.len().cmp(&a.1.len()))
+            .then_with(|| a.1.cmp(b.1))
+    });
+
+    let mut out: Vec<String> = Vec::new();
+    let mut joined_len = 0usize;
+    for (_, tok) in kept {
+        if out.len() >= MAX_FACTS {
+            break;
+        }
+        // Count as if joined with a single-char separator.
+        let add = tok.len() + usize::from(!out.is_empty());
+        if joined_len + add > MAX_JOINED_LEN {
+            break;
+        }
+        joined_len += add;
+        out.push(tok.to_string());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_git_sha() {
+        let facts = extract("commit a1347daf9b2c41e0 pushed to main");
+        assert_eq!(facts, vec!["a1347daf9b2c41e0".to_string()]);
+    }
+
+    #[test]
+    fn extracts_uuid() {
+        let facts = extract("request id 550e8400-e29b-41d4-a716-446655440000 failed");
+        assert_eq!(facts, vec!["550e8400-e29b-41d4-a716-446655440000".to_string()]);
+    }
+
+    #[test]
+    fn extracts_version_and_ticket_and_large_int() {
+        let facts = extract("released v1.34.6 for PROJ-1482 build 20260710");
+        assert!(facts.contains(&"v1.34.6".to_string()));
+        assert!(facts.contains(&"PROJ-1482".to_string()));
+        assert!(facts.contains(&"20260710".to_string()));
+        // Tier order: ticket (1) before version/number (2).
+        let ticket_pos = facts.iter().position(|f| f == "PROJ-1482").unwrap();
+        let ver_pos = facts.iter().position(|f| f == "v1.34.6").unwrap();
+        assert!(ticket_pos < ver_pos);
+    }
+
+    #[test]
+    fn hex_requires_a_digit() {
+        // "deadbeef" is all hex letters but has no digit → rejected.
+        assert!(extract("value deadbeef here").is_empty());
+        assert_eq!(extract("value deadbee7 here"), vec!["deadbee7".to_string()]);
+    }
+
+    #[test]
+    fn dedups_exact_duplicates() {
+        let facts = extract("sha a1347daf9 then a1347daf9 again a1347daf9");
+        assert_eq!(facts, vec!["a1347daf9".to_string()]);
+    }
+
+    #[test]
+    fn substring_collapse_keeps_most_specific() {
+        // Short SHA is a prefix of the full SHA → only the full one survives.
+        let facts = extract("short a1347daf9 full a1347daf9b2c41e0aa55");
+        assert_eq!(facts, vec!["a1347daf9b2c41e0aa55".to_string()]);
+    }
+
+    #[test]
+    fn deterministic_across_runs() {
+        let input = "PROJ-1 v1.2.3 550e8400-e29b-41d4-a716-446655440000 \
+                     a1347daf9 123456789 AB-123 v2.0.1";
+        assert_eq!(extract(input), extract(input));
+    }
+
+    #[test]
+    fn caps_at_max_facts() {
+        // 30 distinct short hex ids (7 chars each fit well under the char
+        // budget) → exactly MAX_FACTS survive.
+        let input: String = (0..30).map(|i| format!("abc{:04} ", i)).collect();
+        let facts = extract(&input);
+        assert_eq!(facts.len(), MAX_FACTS);
+    }
+
+    #[test]
+    fn caps_joined_length() {
+        // Long ticket numbers: each fact is ~40 chars, so the 256-char joined
+        // budget cuts off well before MAX_FACTS.
+        let input: String = (0..16)
+            .map(|i| format!("ABCDEF-{:034} ", i))
+            .collect();
+        let facts = extract(&input);
+        assert!(facts.len() < MAX_FACTS);
+        let joined = facts.join(" ");
+        assert!(joined.len() <= 256, "joined {} chars", joined.len());
+    }
+
+    #[test]
+    fn trims_surrounding_punctuation() {
+        let facts = extract("see (v1.34.6). and [PROJ-99] plus \"a1347daf9\",");
+        assert!(facts.contains(&"v1.34.6".to_string()));
+        assert!(facts.contains(&"PROJ-99".to_string()));
+        assert!(facts.contains(&"a1347daf9".to_string()));
+    }
+
+    #[test]
+    fn all_digit_token_is_large_int_not_hex() {
+        // 7 digits satisfies the hex shape but must land in tier 2, after a
+        // real hex id in the final ordering.
+        let facts = extract("1234567 and abc1234");
+        assert_eq!(
+            facts,
+            vec!["abc1234".to_string(), "1234567".to_string()]
+        );
+    }
+
+    #[test]
+    fn rejects_small_numbers_and_plain_words() {
+        // 5 digits < large-int floor; "v3" has one component; plain words and
+        // small numbers never classify.
+        assert!(extract("12345 words only here v3 line 42").is_empty());
+    }
+
+    #[test]
+    fn bulk_versions_are_noise_but_opaque_ids_survive() {
+        // >MAX_FACTS distinct versions (a build log pattern) → tier 2 is
+        // dropped wholesale; a lone SHA in the same text still comes through.
+        let mut input: String = (0..30).map(|i| format!("v0.1.{} ", i)).collect();
+        input.push_str("commit a1347daf9");
+        assert_eq!(extract(&input), vec!["a1347daf9".to_string()]);
+        // At or under the cap, versions are kept.
+        let few: String = (0..3).map(|i| format!("v0.1.{} ", i)).collect();
+        assert_eq!(extract(&few).len(), 3);
+    }
+
+    #[test]
+    fn empty_input_empty_vec() {
+        assert!(extract("").is_empty());
+        assert!(extract("   \n\t ").is_empty());
+    }
+
+    #[test]
+    fn scan_capped_at_256kib() {
+        // Identifier placed past the cap is not scanned.
+        let mut big = " ".repeat(SCAN_CAP_BYTES + 10);
+        big.push_str(" a1347daf9 ");
+        assert!(extract(&big).is_empty());
+    }
+}

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod factsheet;
 pub mod hash;
 pub mod intensity;
 pub mod redundancy;

--- a/src/context/summarize.rs
+++ b/src/context/summarize.rs
@@ -1,5 +1,6 @@
 use crate::commands::wrap;
 use crate::config::Config;
+use crate::context::factsheet;
 use crate::json_util;
 
 /// Which output shape to use for the dense summary.
@@ -148,9 +149,26 @@ fn apply_prose(lines: Vec<String>, cmd: &str) -> Vec<String> {
     }
 
     let tail_n = TAIL_KEEP.min(total);
-    out.push(format!("tail_preserved={}", tail_n));
-
     let tail_start = total.saturating_sub(tail_n);
+
+    // R1 factsheet: exact identifiers (SHAs, UUIDs, versions, tickets, big
+    // numbers) in the dropped region would otherwise vanish — the tail is
+    // preserved verbatim so only lines before it need rescue. Cap the facts
+    // so the whole summary stays within the ≤40-line bound.
+    let dropped = lines[..tail_start].join("\n");
+    let facts = factsheet::extract(&dropped);
+    if !facts.is_empty() {
+        // room = 40 − lines so far − "ids_preserved:" − "tail_preserved=" − tail
+        let room = 40usize.saturating_sub(out.len() + 2 + tail_n);
+        if room > 0 {
+            out.push("ids_preserved:".to_string());
+            for f in facts.iter().take(room) {
+                out.push(format!("  - {}", f));
+            }
+        }
+    }
+
+    out.push(format!("tail_preserved={}", tail_n));
     for line in lines.into_iter().skip(tail_start) {
         out.push(line);
     }
@@ -194,12 +212,24 @@ fn apply_structured(lines: Vec<String>, cmd: &str) -> Vec<String> {
 
     let test_json = json_util::escape_str(&test);
 
+    // R1 factsheet: identifiers from the dropped region (before the tail),
+    // empty array when none. Same rationale as the Prose ids_preserved block.
+    let ids_json = {
+        let dropped = lines[..tail_start].join("\n");
+        let items: Vec<String> = factsheet::extract(&dropped)
+            .iter()
+            .map(|f| format!("\"{}\"", json_util::escape_str(f)))
+            .collect();
+        format!("[{}]", items.join(","))
+    };
+
     let json_line = format!(
-        "{{\"squeez\":\"summary\",\"cmd\":\"{}\",\"total\":{},\"files\":{},\"errors\":{},\"test\":\"{}\",\"tail\":{}}}",
+        "{{\"squeez\":\"summary\",\"cmd\":\"{}\",\"total\":{},\"files\":{},\"errors\":{},\"ids\":{},\"test\":\"{}\",\"tail\":{}}}",
         json_util::escape_str(&cmd_short),
         total,
         files_json,
         errors_json,
+        ids_json,
         test_json,
         tail_n,
     );
@@ -319,6 +349,27 @@ mod tests {
         let joined = out.join("\n");
         assert!(joined.contains("top_files"));
         assert!(joined.contains("src/main.rs"));
+    }
+
+    #[test]
+    fn summary_carries_ids_from_dropped_head() {
+        // SHA + UUID live in the head, far from the preserved tail — the
+        // factsheet must rescue them in both output shapes.
+        let mut lines: Vec<String> = vec![
+            "commit a1347daf9b2c41e0 built".to_string(),
+            "trace 550e8400-e29b-41d4-a716-446655440000 ok".to_string(),
+        ];
+        lines.extend((0..598).map(|i| format!("noise {}", i)));
+
+        let prose = apply_with_format(lines.clone(), "cmd", SummaryFormat::Prose).join("\n");
+        assert!(prose.contains("ids_preserved:"));
+        assert!(prose.contains("  - a1347daf9b2c41e0"));
+        assert!(prose.contains("  - 550e8400-e29b-41d4-a716-446655440000"));
+
+        let structured = apply_with_format(lines, "cmd", SummaryFormat::Structured);
+        assert!(structured[0].contains(
+            "\"ids\":[\"550e8400-e29b-41d4-a716-446655440000\",\"a1347daf9b2c41e0\"]"
+        ));
     }
 
     #[test]

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -50,6 +50,109 @@ pub fn estimate(s: &str) -> usize {
     }
 }
 
+// ── Content-class calibrated density (R2) ──────────────────────────────────
+//
+// pxpipe measured real tokenizer density on production tool output:
+// dense payloads (JSON/code/diffs, N=391) run ~1.91 chars/token, while
+// English prose runs ~3.5-3.7 chars/token. A flat divisor is wrong in both
+// directions, so `classify` fingerprints the payload coarsely and
+// `estimate_classed` picks a calibrated divisor per class.
+
+/// Content class of a payload, used to pick a calibrated chars/token density.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentClass {
+    Dense,
+    Prose,
+    Mixed,
+}
+
+/// Bytes of `s` that `classify` inspects. Density is stable across a payload,
+/// so the head is enough — no need to rescan a multi-MB capture.
+const CLASSIFY_SAMPLE_BYTES: usize = 64 * 1024;
+/// Punctuation/symbol share of non-whitespace chars at or above which content
+/// is Dense. pxpipe's dense corpus (JSON/code/diffs, ~1.91 chars/token) runs
+/// ≥ ~18% ASCII punctuation.
+const DENSE_PUNCT_RATIO: f64 = 0.18;
+/// Share at or below which content is Prose — English prose (~3.5-3.7
+/// chars/token in the same calibration) rarely exceeds ~8% punctuation.
+const PROSE_PUNCT_RATIO: f64 = 0.08;
+/// Calibrated divisor for Dense: pxpipe's measured 1.91 rounded to a
+/// conservative 2.0.
+const DENSE_CHARS_PER_TOKEN: f64 = 2.0;
+/// Calibrated divisor for Prose (pxpipe prose upper bound).
+const PROSE_CHARS_PER_TOKEN: f64 = 3.7;
+
+/// Coarsely classify `s` by tokenizer density: punctuation share plus a
+/// line-shape check (JSON/diff/table lines start with `{ " + - |` or carry
+/// `=>` / `::` / `==`).
+pub fn classify(s: &str) -> ContentClass {
+    let mut end = s.len().min(CLASSIFY_SAMPLE_BYTES);
+    while end < s.len() && !s.is_char_boundary(end) {
+        end += 1;
+    }
+    let sample = &s[..end];
+
+    let mut punct = 0usize;
+    let mut nonws = 0usize;
+    for c in sample.chars() {
+        if c.is_whitespace() {
+            continue;
+        }
+        nonws += 1;
+        if c.is_ascii() && !c.is_ascii_alphanumeric() {
+            punct += 1;
+        }
+    }
+    if nonws == 0 {
+        return ContentClass::Mixed;
+    }
+
+    // Structural shape: majority of non-empty lines look like JSON/diff/table.
+    let mut structural = 0usize;
+    let mut nonempty = 0usize;
+    for line in sample.lines() {
+        let t = line.trim_start();
+        if t.is_empty() {
+            continue;
+        }
+        nonempty += 1;
+        if matches!(t.as_bytes()[0], b'{' | b'"' | b'+' | b'-' | b'|')
+            || t.contains("=>")
+            || t.contains("::")
+            || t.contains("==")
+        {
+            structural += 1;
+        }
+    }
+    let looks_structured = structural * 2 > nonempty;
+
+    let ratio = punct as f64 / nonws as f64;
+    if ratio >= DENSE_PUNCT_RATIO || looks_structured {
+        ContentClass::Dense
+    } else if ratio <= PROSE_PUNCT_RATIO {
+        ContentClass::Prose
+    } else {
+        ContentClass::Mixed
+    }
+}
+
+/// Estimate tokens in `s` using the content-class calibrated densities:
+/// Dense → chars/2.0, Prose → chars/3.7, Mixed → the char-class `estimate`.
+/// `scale` applies like `estimate_scaled`; the non-empty floor of 1 holds.
+pub fn estimate_classed(s: &str, scale: f32) -> usize {
+    let base = match classify(s) {
+        ContentClass::Dense => (s.chars().count() as f64 / DENSE_CHARS_PER_TOKEN).ceil() as usize,
+        ContentClass::Prose => (s.chars().count() as f64 / PROSE_CHARS_PER_TOKEN).ceil() as usize,
+        ContentClass::Mixed => estimate(s),
+    };
+    let scaled = ((base as f64) * scale as f64).ceil() as usize;
+    if scaled == 0 && !s.is_empty() {
+        1
+    } else {
+        scaled
+    }
+}
+
 /// Estimate tokens in `s`, scaled by a model's tokenizer density factor.
 ///
 /// `scale = 1.0` returns `estimate(s)` unchanged (legacy). Values > 1.0 model
@@ -135,5 +238,42 @@ mod tests {
     #[test]
     fn scaled_empty_is_zero() {
         assert_eq!(estimate_scaled("", 1.3), 0);
+    }
+
+    #[test]
+    fn json_classifies_dense_and_beats_chars_over_four() {
+        let json = r#"{"name":"squeez","version":"1.34.6","deps":{"libc":"0.2"},"flags":[true,false]}"#;
+        assert_eq!(classify(json), ContentClass::Dense);
+        assert!(
+            estimate_classed(json, 1.0) > json.chars().count() / 4,
+            "dense JSON should exceed the chars/4 rule"
+        );
+    }
+
+    #[test]
+    fn english_prose_classifies_prose() {
+        let prose = "the quick brown fox jumps over the lazy dog and then trots quietly home";
+        assert_eq!(classify(prose), ContentClass::Prose);
+    }
+
+    #[test]
+    fn mixed_agent_output_falls_back_to_estimate() {
+        // Prose with sprinkled paths/versions: punct ratio between the Prose
+        // and Dense thresholds, no structural line shape.
+        let mixed = "Compiling squeez v1.34.6 (/Users/me/squeez)\nFinished dev profile in 2.41s";
+        assert_eq!(classify(mixed), ContentClass::Mixed);
+        assert_eq!(estimate_classed(mixed, 1.0), estimate(mixed));
+    }
+
+    #[test]
+    fn classed_scale_above_one_counts_more() {
+        let prose = "the quick brown fox jumps over the lazy dog and then trots quietly home";
+        assert!(estimate_classed(prose, 1.3) > estimate_classed(prose, 1.0));
+    }
+
+    #[test]
+    fn classed_empty_is_zero() {
+        assert_eq!(estimate_classed("", 1.0), 0);
+        assert_eq!(estimate_classed("", 1.3), 0);
     }
 }

--- a/tests/test_config_tunables.rs
+++ b/tests/test_config_tunables.rs
@@ -52,6 +52,27 @@ fn invalid_values_fall_back_to_defaults() {
 }
 
 #[test]
+fn class_density_and_net_win_defaults() {
+    let c = Config::default();
+    assert!(c.class_density);
+    assert_eq!(c.net_win_min_tokens, 24);
+}
+
+#[test]
+fn class_density_parses_from_ini() {
+    let c = Config::from_str("class_density = false");
+    assert!(!c.class_density);
+}
+
+#[test]
+fn net_win_min_tokens_parses_from_ini() {
+    let c = Config::from_str("net_win_min_tokens = 0");
+    assert_eq!(c.net_win_min_tokens, 0);
+    let c = Config::from_str("net_win_min_tokens = 40");
+    assert_eq!(c.net_win_min_tokens, 40);
+}
+
+#[test]
 fn tunables_propagate_to_session_context() {
     use squeez::context::cache::SessionContext;
     let mut cfg = Config::default();

--- a/tests/test_efficiency_proof.rs
+++ b/tests/test_efficiency_proof.rs
@@ -1,4 +1,6 @@
-use squeez::commands::benchmark::{efficiency_to_json, run_efficiency_proof};
+use squeez::commands::benchmark::{
+    efficiency_to_json, run_efficiency_proof, EfficiencyResult, CACHE_READ_RATE, CACHE_WRITE_RATE,
+};
 
 #[test]
 fn efficiency_proof_returns_five_cases() {
@@ -43,8 +45,8 @@ fn efficiency_json_envelope_is_valid() {
     let json = efficiency_to_json(&results);
 
     assert!(
-        json.contains("\"schema_version\":1"),
-        "JSON missing schema_version:1\ngot: {}",
+        json.contains("\"schema_version\":2"),
+        "JSON missing schema_version:2\ngot: {}",
         &json[..json.len().min(300)]
     );
     assert!(
@@ -66,6 +68,70 @@ fn efficiency_json_envelope_is_valid() {
     for feature in &["US-001", "US-003", "US-004"] {
         assert!(json.contains(feature), "JSON missing feature: {}", feature);
     }
+
+    for field in &[
+        "\"cold_baseline_eff\":",
+        "\"cold_compressed_eff\":",
+        "\"warm_baseline_eff\":",
+        "\"warm_compressed_eff\":",
+        "\"net_saving_cold\":",
+        "\"net_saving_warm\":",
+    ] {
+        assert!(json.contains(field), "JSON missing cache-aware field: {}", field);
+    }
+}
+
+#[test]
+fn cache_aware_effective_costs_are_consistent() {
+    let results = run_efficiency_proof();
+    let eps = 1e-9;
+    for r in &results {
+        assert!(
+            (r.cold_baseline_eff - r.baseline_tokens as f64 * CACHE_WRITE_RATE).abs() < eps,
+            "{}: cold_baseline_eff {} != baseline {} × {}",
+            r.label, r.cold_baseline_eff, r.baseline_tokens, CACHE_WRITE_RATE
+        );
+        assert!(
+            (r.cold_compressed_eff - r.compressed_tokens as f64 * CACHE_WRITE_RATE).abs() < eps,
+            "{}: cold_compressed_eff {} != compressed {} × {}",
+            r.label, r.cold_compressed_eff, r.compressed_tokens, CACHE_WRITE_RATE
+        );
+        assert!(
+            (r.warm_baseline_eff - r.baseline_tokens as f64 * CACHE_READ_RATE).abs() < eps,
+            "{}: warm_baseline_eff {} != baseline {} × {}",
+            r.label, r.warm_baseline_eff, r.baseline_tokens, CACHE_READ_RATE
+        );
+        assert!(
+            (r.warm_compressed_eff - r.compressed_tokens as f64 * CACHE_READ_RATE).abs() < eps,
+            "{}: warm_compressed_eff {} != compressed {} × {}",
+            r.label, r.warm_compressed_eff, r.compressed_tokens, CACHE_READ_RATE
+        );
+        // compressed ≤ baseline ⇒ saving ≥ 0 in both cache states
+        if r.compressed_tokens <= r.baseline_tokens {
+            assert!(r.cold_baseline_eff - r.cold_compressed_eff >= 0.0, "{}: negative cold saving", r.label);
+            assert!(r.warm_baseline_eff - r.warm_compressed_eff >= 0.0, "{}: negative warm saving", r.label);
+        }
+    }
+}
+
+#[test]
+fn cache_aware_json_represents_negative_savings() {
+    // Compressed > baseline (compression made it bigger): savings must go
+    // negative — not be floored — and survive JSON serialization.
+    let r = EfficiencyResult::new("negative_case", "US-001", 100, 200, -100.0, 10.0);
+    assert!(!r.passes);
+    assert!(r.cold_baseline_eff - r.cold_compressed_eff < 0.0);
+    assert!(r.warm_baseline_eff - r.warm_compressed_eff < 0.0);
+
+    let json = efficiency_to_json(&[r]);
+    assert!(
+        json.contains("\"net_saving_cold\":-125.00"),
+        "JSON missing negative cold saving: {}", json
+    );
+    assert!(
+        json.contains("\"net_saving_warm\":-10.00"),
+        "JSON missing negative warm saving: {}", json
+    );
 }
 
 #[test]

--- a/tests/test_factsheet.rs
+++ b/tests/test_factsheet.rs
@@ -1,0 +1,102 @@
+// Integration tests for the R1 factsheet: deterministic extraction of
+// precision-critical identifiers (git SHAs, UUIDs, versions, ticket codes,
+// large integers) and their preservation when summarize.rs collapses a large
+// output — the dropped head region must not silently lose exact ids.
+
+use squeez::context::factsheet::{extract, MAX_FACTS};
+use squeez::context::summarize::{apply_with_format, SummaryFormat};
+
+#[test]
+fn extracts_all_identifier_classes() {
+    let text = "deploy v1.34.6 commit a1347daf9b2c41e0 for PROJ-1482 \
+                trace 550e8400-e29b-41d4-a716-446655440000 build 20260710";
+    let facts = extract(text);
+    assert!(facts.contains(&"a1347daf9b2c41e0".to_string()));
+    assert!(facts.contains(&"550e8400-e29b-41d4-a716-446655440000".to_string()));
+    assert!(facts.contains(&"v1.34.6".to_string()));
+    assert!(facts.contains(&"PROJ-1482".to_string()));
+    assert!(facts.contains(&"20260710".to_string()));
+}
+
+#[test]
+fn output_is_deterministic_and_tier_ordered() {
+    let text = "v2.0.1 PROJ-7 abc1234def 550e8400-e29b-41d4-a716-446655440000";
+    let a = extract(text);
+    let b = extract(text);
+    assert_eq!(a, b);
+    // Tier 0 (UUID, hex) first, then ticket, then version.
+    assert_eq!(
+        a,
+        vec![
+            "550e8400-e29b-41d4-a716-446655440000".to_string(),
+            "abc1234def".to_string(),
+            "PROJ-7".to_string(),
+            "v2.0.1".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn budgets_are_enforced() {
+    // Many distinct ids → never more than MAX_FACTS, never over 256 joined chars.
+    let text: String = (0..100).map(|i| format!("abcd{:05} ", i)).collect();
+    let facts = extract(&text);
+    assert!(facts.len() <= MAX_FACTS);
+    assert!(facts.join(" ").len() <= 256);
+}
+
+#[test]
+fn prose_summary_preserves_ids_from_dropped_head() {
+    // 600-line output: SHA + UUID in the head (dropped region), noise after.
+    let mut lines: Vec<String> = vec![
+        "pushed commit a1347daf9b2c41e0aa55 to origin".to_string(),
+        "session 550e8400-e29b-41d4-a716-446655440000 started".to_string(),
+    ];
+    lines.extend((0..598).map(|i| format!("compiling unit {}", i)));
+
+    let out = apply_with_format(lines, "cargo build", SummaryFormat::Prose);
+    let joined = out.join("\n");
+    assert!(joined.contains("ids_preserved:"), "missing ids_preserved section:\n{}", joined);
+    assert!(joined.contains("a1347daf9b2c41e0aa55"));
+    assert!(joined.contains("550e8400-e29b-41d4-a716-446655440000"));
+    // The ≤40-line bound still holds with the factsheet included.
+    assert!(out.len() <= 40, "got {} lines", out.len());
+}
+
+#[test]
+fn structured_summary_carries_ids_array() {
+    let mut lines: Vec<String> = vec![
+        "commit a1347daf9b2c41e0aa55".to_string(),
+        "ticket PROJ-1482 resolved".to_string(),
+    ];
+    lines.extend((0..598).map(|i| format!("step {}", i)));
+
+    let out = apply_with_format(lines, "make", SummaryFormat::Structured);
+    assert!(out[0].contains("\"ids\":[\"a1347daf9b2c41e0aa55\",\"PROJ-1482\"]"), "{}", out[0]);
+}
+
+#[test]
+fn structured_summary_ids_empty_when_none() {
+    let lines: Vec<String> = (0..600).map(|i| format!("plain text {}", i)).collect();
+    let out = apply_with_format(lines, "make", SummaryFormat::Structured);
+    assert!(out[0].contains("\"ids\":[]"), "{}", out[0]);
+}
+
+#[test]
+fn prose_summary_omits_section_when_no_ids() {
+    let lines: Vec<String> = (0..600).map(|i| format!("plain text {}", i)).collect();
+    let out = apply_with_format(lines, "make", SummaryFormat::Prose);
+    assert!(!out.join("\n").contains("ids_preserved:"));
+}
+
+#[test]
+fn ids_in_tail_only_are_not_duplicated_into_factsheet() {
+    // Identifier appears only in the preserved tail → it survives verbatim
+    // there, so the factsheet must stay empty.
+    let mut lines: Vec<String> = (0..599).map(|i| format!("quiet {}", i)).collect();
+    lines.push("done at commit a1347daf9b2c41e0aa55".to_string());
+    let out = apply_with_format(lines, "make", SummaryFormat::Prose);
+    let joined = out.join("\n");
+    assert!(!joined.contains("ids_preserved:"));
+    assert!(joined.contains("a1347daf9b2c41e0aa55")); // still present via tail
+}


### PR DESCRIPTION
Closes #183

Implements the four techniques identified in the pxpipe analysis (see issue). All zero-dep, stdlib only.

## R1 — Factsheet identifier preservation (`src/context/factsheet.rs`)
Deterministic, budget-capped (16 facts / 256 chars) extraction of exact identifiers (git SHAs/hex, UUIDs, ticket codes, versions, large ints) from the region a dense summary drops. Wired into both Prose (`ids_preserved:`) and Structured (`"ids":[...]`) shapes. High-cardinality version/counter noise is dropped wholesale; opaque ids survive even in bulk.

## R2 — Content-class calibrated density (`src/tokens.rs`)
`classify()` buckets output as Dense/Prose/Mixed; `estimate_classed()` applies chars/2.0 (pxpipe measured 1.91 on dense production tool output, N=391), chars/3.7 for prose, existing char-class estimate for mixed. On by default (`class_density`), flat legacy path preserved via config.

## R3 — Cache-aware effective accounting (`src/commands/benchmark.rs`)
Efficiency proof reports effective costs under list-price ratios (input ×1.0, cache write ×1.25, cache read ×0.1, output ×5) applied identically to both sides under the same cache state — the caching discount can never be miscounted as savings. schema_version 2, negatives representable.

## R4 — Net-win gate (`src/commands/wrap.rs`)
The `# squeez` header costs ~15-25 tokens; when compression saves less than `net_win_min_tokens` (default 24) the call is a net loss → verbatim passthrough, header suppressed, zero savings recorded. Redundancy hits exempt; warning lines still print.

## Verification
- Full suite: **77 test binaries, all green, 0 failed** (isolated HOME; the only local failure mode is environmental — live `config.ini` with `enabled=false`).
- `cargo build --release` clean; `benchmark --efficiency-proof` prints new WARM-SAVE column + cache-aware footer, all floors pass.
- New tests: 15 inline factsheet units + 8 integration (`test_factsheet.rs`), 6 tokens units, 3 config tunables, efficiency-proof suite extended to 6 incl. negative-savings JSON representation.

Also bumps version to 1.35.0.