### PR TITLE
fix(doctor): treat wrapped Bash accounting as alive in freshness check

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -103,7 +103,36 @@ fn newest_session(sessions: &Path) -> Option<SystemTime> {
     newest
 }
 
-/// True if any of the newest session logs carries a nonzero tokens_est —
+/// Nonzero unsigned integer value for `key` in a JSONL record line.
+fn nonzero_field(line: &str, key: &str) -> bool {
+    line.split(&format!("\"{}\":", key))
+        .skip(1)
+        .filter_map(|rest| {
+            rest.trim_start()
+                .split(|c: char| !c.is_ascii_digit())
+                .next()?
+                .parse::<u64>()
+                .ok()
+        })
+        .any(|v| v > 0)
+}
+
+/// True if a session-log line proves accounting is still running.
+///
+/// Two record shapes count: the PostToolUse `track` record (`tokens_est`) and
+/// the `squeez wrap` record (`type:"bash"` with `in_tk`/`out_tk`). Bash output
+/// is compressed at PreToolUse, so its PostToolUse `track` record is always
+/// `tokens_est:0` — a session of purely wrapped Bash calls has live accounting
+/// but no nonzero `tokens_est` anywhere.
+fn accounting_alive_line(line: &str) -> bool {
+    if nonzero_field(line, "tokens_est") {
+        return true;
+    }
+    line.contains("\"type\":\"bash\"")
+        && (nonzero_field(line, "in_tk") || nonzero_field(line, "out_tk"))
+}
+
+/// True if any of the newest session logs shows live token accounting —
 /// distinguishes "accounting alive" from the all-zeros drift outage.
 fn tokens_est_alive(sessions: &Path) -> bool {
     let mut files: Vec<(SystemTime, std::path::PathBuf)> = std::fs::read_dir(sessions)
@@ -119,20 +148,7 @@ fn tokens_est_alive(sessions: &Path) -> bool {
         .collect();
     files.sort_by(|a, b| b.0.cmp(&a.0));
     files.iter().take(2).any(|(_, p)| {
-        std::fs::read_to_string(p).is_ok_and(|s| {
-            s.lines().any(|l| {
-                l.split("\"tokens_est\":")
-                    .nth(1)
-                    .and_then(|rest| {
-                        rest.trim_start()
-                            .split(|c: char| !c.is_ascii_digit())
-                            .next()?
-                            .parse::<u64>()
-                            .ok()
-                    })
-                    .is_some_and(|v| v > 0)
-            })
-        })
+        std::fs::read_to_string(p).is_ok_and(|s| s.lines().any(accounting_alive_line))
     })
 }
 

--- a/tests/test_doctor.rs
+++ b/tests/test_doctor.rs
@@ -147,6 +147,48 @@ fn zeroed_tokens_est_warns_tracking_dead() {
     let _ = std::fs::remove_dir_all(&dir);
 }
 
+/// Bash output is compressed at PreToolUse, so its PostToolUse `track` record
+/// is always `tokens_est:0`. A session of purely wrapped Bash calls still has
+/// live accounting via the `type:"bash"` wrap record and must not warn.
+#[test]
+fn wrapped_bash_records_count_as_live_accounting() {
+    let dir = tmp();
+    let settings = healthy_install(&dir);
+    std::fs::write(
+        dir.join("sessions").join("2026-07-20-13.jsonl"),
+        "{\"type\":\"bash\",\"cmd\":\"ls\",\"in_tk\":98,\"out_tk\":98,\"ts\":1}\n\
+         {\"type\":\"tool\",\"tool\":\"Bash\",\"tokens_est\":0,\"ts\":2}\n",
+    )
+    .unwrap();
+    let (lines, has_fail) = doctor::run_with(&dir, &settings, &Config::default());
+    assert!(!has_fail, "got: {lines:?}");
+    assert!(
+        lines.iter().any(|l| l.starts_with("[ok]") && l.contains("freshness")),
+        "wrapped Bash accounting must read as alive: {lines:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// A wrap record whose in_tk/out_tk are both zero is not proof of life —
+/// the genuine "pipeline dead" warning must survive.
+#[test]
+fn zeroed_bash_wrap_record_still_warns() {
+    let dir = tmp();
+    let settings = healthy_install(&dir);
+    std::fs::write(
+        dir.join("sessions").join("2026-07-20-13.jsonl"),
+        "{\"type\":\"bash\",\"cmd\":\"ls\",\"in_tk\":0,\"out_tk\":0,\"ts\":1}\n\
+         {\"type\":\"tool\",\"tool\":\"Bash\",\"tokens_est\":0,\"ts\":2}\n",
+    )
+    .unwrap();
+    let (lines, _) = doctor::run_with(&dir, &settings, &Config::default());
+    assert!(
+        lines.iter().any(|l| l.starts_with("[WARN]") && l.contains("tokens_est:0")),
+        "got: {lines:?}"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn quick_check_silent_when_healthy_and_loud_when_disabled() {
     let dir = tmp();


### PR DESCRIPTION
Fixes the false `[WARN] freshness` reported in #188.

## Problem

Bash output is compressed at PreToolUse via `squeez wrap`, so the stock PostToolUse hook records `{"type":"tool","tool":"Bash","tokens_est":0}` for it. `tokens_est_alive()` in `src/commands/doctor.rs` only searched for a nonzero `tokens_est`, so a session containing only wrapped Bash calls reliably tripped:

```text
[WARN] freshness: recent session logs have only tokens_est:0 — accounting broken (posttooluse payload extraction)
```

Accounting was in fact alive — each call had a nonzero wrap record `{"type":"bash","cmd":"…","in_tk":98,"out_tk":98}` written by `wrap.rs::record_bash_event`, and `handler_stats.json` / `context.json` both reported the nonzero Bash total.

## Fix

Freshness reads as OK when a recent session log carries **either**:

- a nonzero `tokens_est`, **or**
- a `type:"bash"` record with nonzero `in_tk` or `out_tk`

A wrap record with both counters at zero is not proof of life, so the warning still fires for a genuinely dead pipeline.

## Tests

- `wrapped_bash_records_count_as_live_accounting` — the reporter's exact log shape now reads `[ok] freshness`
- `zeroed_bash_wrap_record_still_warns` — guards the real outage signal
- Full suite: 1087 passed, 0 failed

Closes #188