### PR TITLE
feat(buddy): steepen the XP curve into an MMO-style progression

### DIFF
--- a/assets/buddy/lib/engine.js
+++ b/assets/buddy/lib/engine.js
@@ -137,9 +137,31 @@ const RANK_HEX = {
   Lendário: '#FBBF24',
 };
 
-/** Curva de XP acumulado necessário para alcançar cada um dos 15 degraus. */
+/**
+ * Curva de XP acumulado necessário para alcançar cada um dos 15 degraus.
+ *
+ * Progressão geométrica (base 150, razão ~1.55), no formato dos MMOs: cada
+ * degrau custa ~55% mais que o anterior. A curva antiga era quase linear
+ * (total 6.500) e dava para varrer os degraus em poucas sessões — Épico saía
+ * numa tarde. Aqui o total é 125.730 XP, ~19x maior, e o custo por degrau
+ * cresce de 150 XP até 44.710 XP.
+ *
+ * Efeito prático (sessão pesada ~70 XP: ~40 edits + 3 commits + 2 suítes
+ * verdes + 1 bug resolvido):
+ *
+ *   Comum II        150 XP        ~2 sessões    <- fisgada inicial rápida
+ *   Incomum I     2.170 XP       ~12 sessões
+ *   Raro I        8.810 XP       ~46 sessões
+ *   Épico I      33.560 XP      ~171 sessões
+ *   Lendário I  125.730 XP      ~639 sessões    <- endgame, não um checkpoint
+ *
+ * No topo uma ação isolada vale ~0,002% do degrau e uma sessão inteira ~0,08%,
+ * que é a escala de grind de MMO pretendida. Mexer aqui reprecifica todo o
+ * histórico: o XP acumulado não muda, só o degrau que ele compra.
+ */
 const RANK_THRESHOLDS = [
-  0, 50, 120, 220, 350, 500, 700, 950, 1250, 1650, 2150, 2800, 3700, 4900, 6500,
+  0, 150, 380, 740, 1300, 2170, 3510, 5590, 8810, 13810, 21560, 33560, 52170,
+  81020, 125730,
 ];
 
 const RANKS = RANK_COLORS.flatMap((color) =>


### PR DESCRIPTION
Closes #195.

## Problem

The rank table was close to linear and topped out at 6.500 XP. At ~70 XP for a heavy session (40 edits + 3 commits + 2 green test runs + 1 resolved bug), the whole 15-rank ladder fell in a few dozen sessions — Épico in an afternoon.

## Fix

Geometric progression, base 150, ratio ~1.55 — each rank costs ~55% more than the previous. Ladder total goes 6.500 → **125.730 XP (~19x)**, per-rank cost grows 150 → 44.710 XP.

| Degrau | XP total | Custo do degrau | Sessões pesadas |
|---|---:|---:|---:|
| Comum II | 150 | 150 | ~2 |
| Incomum I | 2.170 | 870 | ~12 |
| Raro I | 8.810 | 3.220 | ~46 |
| Épico I | 33.560 | 12.000 | ~171 |
| Lendário I | 125.730 | 44.710 | ~639 |

The fast early hook is deliberately kept (first rank still ~2 sessions) — the curve bites in the mid and late tiers, so Lendário is endgame rather than a checkpoint. At the top rank one action is ~0.002% of the rank and a full session ~0.08%.

## Deliberately unchanged

- **Accrual weights** (1/3/5/10). The pacing problem was the curve, not what an action is worth. This is the obvious next lever if it still climbs too fast.
- **Accumulated XP.** Nothing is rewritten; the same XP simply buys a lower rank now. Existing users will see their rank drop, which is the intended repricing.

## Tests

18/18 buddy JS tests, 7/7 `test_hosts_buddy` — no test asserted the old thresholds.