### PR TITLE
fix(context): never destructively summarize Read tool output

### DIFF
--- a/src/commands/compress_output.rs
+++ b/src/commands/compress_output.rs
@@ -246,12 +246,17 @@ pub fn compute_rewrite(raw: &str, tool: &str, sessions_dir: &Path, cfg: &Config)
     }
 
     // Large benign outputs get summarized (Skill is handled earlier via the
-    // session-long dedup store and never reaches here). MCP results are
-    // dedup-only: they are structured payloads (JSON, DOM snapshots) that the
-    // log-oriented summarizer would corrupt, so they participate in the
-    // redundancy check above but are never summarized (audit item 2 — track
-    // and dedupe MCP traffic, leave first-sight content intact).
-    let rewritten = if !is_mcp && context::summarize::should_apply_for_tool(&lines, cfg, tool) {
+    // session-long dedup store and never reaches here). MCP results and Read
+    // are dedup-only, never summarized: both carry structured, non-repetitive
+    // payloads (JSON, DOM snapshots, source files) the log-oriented summarizer
+    // would corrupt. Read shares MCP's failure mode: `is_benign` does raw
+    // substring matching for "error"/"failed"/"panic", which fires on ordinary
+    // source code that merely mentions those words, collapsing the relaxed
+    // threshold and handing the summarizer a source file — it then keeps a
+    // tail slice plus incidental keyword hits and drops the rest, which is
+    // exactly the content needed to reason about or Edit the file.
+    let is_structured_payload = is_mcp || tool == "Read";
+    let rewritten = if !is_structured_payload && context::summarize::should_apply_for_tool(&lines, cfg, tool) {
         let summary = context::summarize::apply(lines.clone(), tool);
         if summary.len() < lines.len() {
             Some(summary.join("\n"))
@@ -744,12 +749,13 @@ mod tests {
     }
 
     #[test]
-    fn read_uses_lower_summarize_threshold() {
+    fn read_is_never_summarized_even_with_error_marker() {
+        // Read is a structured payload (source/config/data), not log output —
+        // see the is_structured_payload comment above. A stray "error:" line
+        // (e.g. a comment, a string literal) must not trigger the dense
+        // log summarizer regardless of line count or threshold.
         let dir = tmp();
         let cfg = Config::default();
-        // Build 200 benign lines: passes global 300 default but triggers
-        // Read-specific 150 default (×2 benign = 300; so we need >300 for benign).
-        // Use error markers to ensure non-benign path (threshold = base = 150).
         let mut lines = Vec::with_capacity(200);
         lines.push("error: synthetic".to_string());
         for i in 1..200 {
@@ -762,8 +768,8 @@ mod tests {
         );
         let rewrite = compute_rewrite(&json, "Read", &dir, &cfg);
         assert!(
-            rewrite.is_some(),
-            "Read with 200 lines + error marker should trigger summarize at threshold 150"
+            rewrite.is_none(),
+            "Read must never be replaced by the dense summarizer"
         );
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,10 +101,12 @@ pub struct Config {
     /// `squeez_handler_stats` can surface under/over-performers. Default: true.
     pub handler_stats_enabled: bool,
     // ── PostToolUse compression for Read/Edit/Write (gap fix) ────────────────
-    /// Override `summarize_threshold_lines` when the tool is Read. Default 150.
-    /// Many code files are 80-300 lines and never triggered the global default
-    /// of 300, leaving them uncompressed. Set to 0 to fall back to the global
-    /// `summarize_threshold_lines`.
+    /// Override `summarize_threshold_lines` when the tool is Read. Currently
+    /// inert: `compress_output.rs` exempts Read from destructive summarization
+    /// entirely (source files are structured content, not log output — see
+    /// the `is_structured_payload` comment there). Kept for `should_apply_for_tool`
+    /// callers that do want a Read-specific override. Set to 0 to fall back to
+    /// the global `summarize_threshold_lines`.
     pub read_summarize_threshold_lines: usize,
     /// Byte-size trigger for summarize, independent of line count. A single-line
     /// 50 KB JSON blob (e.g. `az`/`curl` output) has `lines.len() == 1` and slips

--- a/tests/test_compress_output.rs
+++ b/tests/test_compress_output.rs
@@ -159,12 +159,14 @@ fn large_output_is_summarized() {
 
     // Use enough lines that the summarizer (≤40 lines out) is definitely shorter.
     // Include an error marker so is_benign() returns false (no benign multiplier).
+    // Tool is Grep, not Read: Read is exempt from summarization (see
+    // large_read_output_is_never_summarized below).
     let mut lines: Vec<String> = (0..80).map(|i| format!("build output line {i}: compiled ok")).collect();
     lines.push("error: build failed with 1 error".to_string());
     let content = lines.join("\n");
     let json = make_json(&content);
 
-    let result = compute_rewrite(&json, "Read", &dir, &cfg);
+    let result = compute_rewrite(&json, "Grep", &dir, &cfg);
     assert!(
         result.is_some(),
         "output exceeding summarize_threshold_lines should be summarized"
@@ -174,6 +176,35 @@ fn large_output_is_summarized() {
     assert!(
         summary_lines < 81,
         "summary ({summary_lines} lines) should be shorter than original (81 lines)"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn large_read_output_is_never_summarized() {
+    // Regression test: source code Read output must never be replaced by the
+    // dense log summarizer. Real source files routinely mention "error",
+    // "failed", "panic" as ordinary code/comments (this crate's own
+    // is_benign() is a prime example) — that used to flip is_benign() to
+    // false, collapse the relaxed threshold, and hand the summarizer a
+    // source file, which kept only a tail slice and discarded the rest of
+    // the file the model needed to reason about or Edit.
+    let dir = tmp();
+    let mut cfg = cfg();
+    cfg.summarize_threshold_lines = 10;
+    cfg.read_summarize_threshold_lines = 5;
+
+    let mut lines: Vec<String> = (0..80)
+        .map(|i| format!("fn helper_{i}() {{ /* unique source line {i} */ }}"))
+        .collect();
+    lines.push("// handles the \"failed\" and \"panic\" error paths".to_string());
+    let content = lines.join("\n");
+    let json = make_json(&content);
+
+    let result = compute_rewrite(&json, "Read", &dir, &cfg);
+    assert!(
+        result.is_none(),
+        "Read output must pass through untouched, not be summarized"
     );
     let _ = std::fs::remove_dir_all(&dir);
 }


### PR DESCRIPTION
## Linked issue

Closes #202

## Type of change

- [x] `fix:` / `perf:` -- bug fix or perf improvement (-> patch bump)

## Area

- [x] Context engine (`src/context/` -- cache / redundancy / summarize / intensity)
- [ ] Handler (`src/commands/*`)
- [ ] Compression pipeline (`src/strategies/` -- dedup / grouping / truncation / smart_filter)
- [ ] MCP server (`src/commands/mcp_server.rs`)
- [ ] CI / release / tooling
- [ ] Docs

## Summary

- `Read` output no longer goes through `context::summarize::apply` (the dense log-summarizer); it now gets the same dedup-only treatment already applied to MCP results.
- Root cause: `is_benign()` false-positives on ordinary source code that mentions "error"/"failed"/"panic", and even when classified benign, the summarizer's tail+metadata shape is wrong for source files (drops the middle, which is the actual content).
- Updated the one existing unit test that asserted the old (buggy) behavior, and added a regression test (`large_read_output_is_never_summarized` / `read_is_never_summarized_even_with_error_marker`) reproducing the exact false-positive.

## Test plan

- [x] `cargo test` passes (478/479; the 1 pre-existing failure, `showcase_names_resolve_to_real_scenarios`, reproduces identically on main without this change -- unrelated `find_binary()`/fixture gate on Windows)
- [ ] `bash bench/run.sh`
- [ ] `bash bench/run_context.sh`

## Checklist

- [x] Issue is linked above
- [ ] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)