### PR TITLE
fix(economy): soften context-critical alert when the real window is unproven

### DIFF
--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -821,27 +821,38 @@ fn record_bash_event(
         };
         if critical {
             current.state_warned = true;
-            Some(format!(
-                "🚨 squeez: context critical ({}%) — save state before clearing:\n\
-                 \n\
-                 Write `.claude/session_state.md` with:\n\
-                 ## Current Objective\n\
-                 <what you're solving now>\n\
-                 ## Files Read\n\
-                 <paths + what was learned>\n\
-                 ## Decisions Taken\n\
-                 <why approach X not Y>\n\
-                 ## Next Steps\n\
-                 <immediate plan>\n\
-                 \n\
-                 Then run `/clear` to reset context (or `/compact [describe focus area]` for a focused summary).{}",
-                pct.min(100),
-                if crate::context::intensity::window_is_assumed(config, ctx.real_ctx_window) {
-                    crate::context::intensity::ASSUMED_WINDOW_NOTE
-                } else {
-                    ""
-                },
-            ))
+            if crate::context::intensity::window_is_assumed(config, ctx.real_ctx_window) {
+                // The host never proved this session's real window, so `pct` may
+                // be off by 5x (200K assumed vs. an actual 1M model — issue
+                // #199). Telling the user to /clear on that unproven number risks
+                // discarding a session with 800K of real headroom left, so this
+                // stays informational instead of an imperative "critical" alarm.
+                Some(format!(
+                    "ℹ️  squeez: {}% of an assumed 200K window ({}K tokens) — the \
+                     host doesn't report the real context window, so this may be a \
+                     false alarm on a larger-context model.{}",
+                    pct.min(100),
+                    effective_used / 1000,
+                    crate::context::intensity::ASSUMED_WINDOW_NOTE,
+                ))
+            } else {
+                Some(format!(
+                    "🚨 squeez: context critical ({}%) — save state before clearing:\n\
+                     \n\
+                     Write `.claude/session_state.md` with:\n\
+                     ## Current Objective\n\
+                     <what you're solving now>\n\
+                     ## Files Read\n\
+                     <paths + what was learned>\n\
+                     ## Decisions Taken\n\
+                     <why approach X not Y>\n\
+                     ## Next Steps\n\
+                     <immediate plan>\n\
+                     \n\
+                     Then run `/clear` to reset context (or `/compact [describe focus area]` for a focused summary).",
+                    pct.min(100),
+                ))
+            }
         } else {
             None
         }


### PR DESCRIPTION
## Linked issue

Closes #204

## Type of change

- [x] `fix:` / `perf:` -- bug fix or perf improvement (-> patch bump)

## Area

- [ ] Handler (`src/commands/*`)
- [ ] Compression pipeline (`src/strategies/` -- dedup / grouping / truncation / smart_filter)
- [ ] Context engine (`src/context/` -- cache / redundancy / summarize / intensity)
- [ ] MCP server (`src/commands/mcp_server.rs`)
- [ ] CI / release / tooling
- [ ] Docs

## Summary

- When `window_is_assumed()` holds (the host never proved the real context window -- #199), the critical-pressure alert in `wrap.rs` is now informational instead of an imperative "🚨 critical, save state, /clear" warning.
- The proven-window branch (pinned `context_window_tokens`, or a `real_ctx_window` already observed above the 200K floor) keeps the original imperative alert unchanged.
- No test asserted the exact alert text before this change (verified via grep across `tests/`), so no existing test needed updating; behavior is otherwise config/threshold-identical.

## Test plan

- [x] `cargo test` passes (478/479; the 1 pre-existing failure, `showcase_names_resolve_to_real_scenarios`, reproduces identically on main without this change -- unrelated `find_binary()`/fixture gate on Windows)
- [ ] `bash bench/run.sh`
- [ ] `bash bench/run_context.sh`

## Checklist

- [x] Issue is linked above
- [ ] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)