### PR TITLE
fix(context): dispatch `squeez prune` and verify blobs on retrieve

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -180,6 +180,18 @@ fn check_freshness(squeez_dir: &Path, cfg: &Config) -> CheckLine {
     ok("freshness: tracking artifacts are current")
 }
 
+/// Blob-store check: reports current stash size (#201/#200 — this is the
+/// "make it observable" half of both issues). Informational only, never a
+/// FAIL/WARN — a big stash isn't unhealthy on its own, just worth seeing.
+fn check_blob_store(squeez_dir: &Path) -> CheckLine {
+    let (count, bytes) = crate::context::retrieve::stats_under(squeez_dir);
+    ok(format!(
+        "blob store: {} stashed output(s), {:.1} KB — `squeez prune` to clear expired ones early",
+        count,
+        bytes as f64 / 1024.0
+    ))
+}
+
 /// Full doctor report. Returns the printable lines and whether any check FAILed.
 pub fn run_with(squeez_dir: &Path, settings_path: &Path, cfg: &Config) -> (Vec<String>, bool) {
     let checks = [
@@ -187,6 +199,7 @@ pub fn run_with(squeez_dir: &Path, settings_path: &Path, cfg: &Config) -> (Vec<S
         check_hooks_registered(settings_path),
         check_config(cfg),
         check_freshness(squeez_dir, cfg),
+        check_blob_store(squeez_dir),
     ];
     let has_fail = checks.iter().any(|c| c.fail);
     let mut lines: Vec<String> = vec![format!(

--- a/src/commands/mcp_server.rs
+++ b/src/commands/mcp_server.rs
@@ -837,14 +837,19 @@ fn tool_enterprise_savings() -> String {
 /// verbatim text, or a clear not-found message when the id is malformed /
 /// expired / missing.
 fn tool_retrieve(key: &str, start_line: Option<usize>, count: Option<usize>) -> String {
+    use crate::context::retrieve::RetrieveOutcome;
     if key.is_empty() {
         return "squeez_retrieve: missing 'key' — pass the id from a [squeez: ... key=\"<id>\"] marker.".to_string();
     }
-    match crate::context::retrieve::retrieve(key) {
-        Some(original) if start_line.is_none() && count.is_none() => original,
-        Some(original) => slice_lines(&original, start_line, count),
-        None => format!(
+    match crate::context::retrieve::retrieve_checked(key) {
+        RetrieveOutcome::Found(original) if start_line.is_none() && count.is_none() => original,
+        RetrieveOutcome::Found(original) => slice_lines(&original, start_line, count),
+        RetrieveOutcome::NotFound => format!(
             "squeez_retrieve: no stored output for key '{}'. It may be malformed, expired (past retrieve_ttl_days), or never stored.",
+            key
+        ),
+        RetrieveOutcome::Corrupted => format!(
+            "squeez_retrieve: integrity check failed for key '{}' — the stored content no longer matches its hash (corrupted or truncated on disk). This blob cannot be safely recovered.",
             key
         ),
     }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -30,6 +30,7 @@ pub mod persona;
 pub mod package_mgr;
 pub mod playwright;
 pub mod protocol;
+pub mod prune;
 pub mod reporters;
 pub mod runtime;
 pub mod test_runner;

--- a/src/commands/prune.rs
+++ b/src/commands/prune.rs
@@ -1,0 +1,25 @@
+//! `squeez prune` — on-demand cleanup of the blob store and session memory.
+//!
+//! Both cleanups already run opportunistically elsewhere (blob TTL pruning on
+//! every `wrap` call that stashes a new output, `summaries.jsonl` pruning on
+//! every session init), so this command doesn't do anything those paths
+//! don't — it just gives users (and the `run squeez prune` hints in
+//! `squeez_search_history`/`squeez_file_history`) something to actually run
+//! on demand instead of falling through to the usage banner.
+
+use crate::config::Config;
+use crate::{context, memory, session};
+
+/// CLI entry point: prune expired blobs and old session summaries, print a
+/// one-line report of what was freed.
+pub fn run() -> i32 {
+    let cfg = Config::load();
+    let (blobs_removed, bytes_freed) =
+        context::retrieve::prune(cfg.retrieve_ttl_days.saturating_mul(86_400));
+    memory::prune_old(&session::memory_dir(), cfg.memory_retention_days);
+    println!(
+        "squeez prune: removed {} expired blob(s), freed {} bytes; pruned session summaries older than {} day(s)",
+        blobs_removed, bytes_freed, cfg.memory_retention_days
+    );
+    0
+}

--- a/src/context/retrieve.rs
+++ b/src/context/retrieve.rs
@@ -52,12 +52,46 @@ pub fn store_guarded(content: &str) -> Result<String, &'static str> {
 /// Retrieve a previously stored blob by id. `None` if the id is malformed, the
 /// blob is missing, or it was pruned.
 pub fn retrieve(id: &str) -> Option<String> {
-    retrieve_in(&blobs_dir(), id)
+    match retrieve_checked_in(&blobs_dir(), id) {
+        RetrieveOutcome::Found(content) => Some(content),
+        RetrieveOutcome::NotFound | RetrieveOutcome::Corrupted => None,
+    }
+}
+
+/// Result of a verified retrieval — distinguishes "never stored / expired"
+/// from "stored, but the bytes on disk no longer match the id" so a caller
+/// can tell the model the difference instead of serving corrupted content.
+pub enum RetrieveOutcome {
+    Found(String),
+    NotFound,
+    Corrupted,
+}
+
+/// Retrieve a previously stored blob by id, verifying it on the way out.
+/// Since the id is the FNV-1a hash of the content computed at store time
+/// (`store_in`), a truncated or corrupted blob rehashes to a different
+/// value — this is caught here instead of being served silently.
+pub fn retrieve_checked(id: &str) -> RetrieveOutcome {
+    retrieve_checked_in(&blobs_dir(), id)
+}
+
+/// Number of stashed blobs and their total size in bytes (`.idx` sidecars
+/// excluded). Used by `squeez doctor` to make blob-store growth observable.
+pub fn stats() -> (usize, u64) {
+    stats_in(&blobs_dir())
+}
+
+/// Like `stats()`, but under an explicit `squeez_dir` rather than the global
+/// `SQUEEZ_DIR`-derived one — lets `squeez doctor` stay testable with an
+/// injected directory the way its other checks already are.
+pub fn stats_under(squeez_dir: &Path) -> (usize, u64) {
+    stats_in(&squeez_dir.join("blobs"))
 }
 
 /// Remove blobs whose last modification is older than `ttl_secs`. Best-effort;
-/// a `ttl_secs` of 0 disables pruning (keeps everything).
-pub fn prune(ttl_secs: u64) {
+/// a `ttl_secs` of 0 disables pruning (keeps everything). Returns the number
+/// of blobs removed and the bytes freed.
+pub fn prune(ttl_secs: u64) -> (usize, u64) {
     prune_in(&blobs_dir(), ttl_secs)
 }
 
@@ -115,27 +149,56 @@ fn store_in(dir: &Path, content: &str) -> Option<String> {
     Some(id)
 }
 
-fn retrieve_in(dir: &Path, id: &str) -> Option<String> {
+fn retrieve_checked_in(dir: &Path, id: &str) -> RetrieveOutcome {
     if !is_valid_id(id) {
-        return None;
+        return RetrieveOutcome::NotFound;
     }
-    std::fs::read_to_string(dir.join(id)).ok()
+    let Ok(content) = std::fs::read_to_string(dir.join(id)) else {
+        return RetrieveOutcome::NotFound;
+    };
+    let recomputed = format!("{:016x}", fnv1a_64(content.as_bytes()));
+    if recomputed != id {
+        return RetrieveOutcome::Corrupted;
+    }
+    RetrieveOutcome::Found(content)
 }
 
-fn prune_in(dir: &Path, ttl_secs: u64) {
+fn stats_in(dir: &Path) -> (usize, u64) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return (0, 0);
+    };
+    entries.flatten().fold((0, 0), |(count, bytes), entry| {
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            return (count, bytes);
+        };
+        if !is_valid_id(&name) {
+            return (count, bytes);
+        }
+        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        (count + 1, bytes + size)
+    })
+}
+
+fn prune_in(dir: &Path, ttl_secs: u64) -> (usize, u64) {
     if ttl_secs == 0 {
-        return;
+        return (0, 0);
     }
     let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
+        return (0, 0);
     };
+    let mut removed = 0usize;
+    let mut freed = 0u64;
     for entry in entries.flatten() {
         let Ok(meta) = entry.metadata() else { continue };
         let Ok(modified) = meta.modified() else { continue };
         // `elapsed()` errors only if mtime is in the future — treat as fresh.
         let age = modified.elapsed().map(|d| d.as_secs()).unwrap_or(0);
         if age > ttl_secs {
-            let _ = std::fs::remove_file(entry.path());
+            let size = meta.len();
+            if std::fs::remove_file(entry.path()).is_ok() {
+                removed += 1;
+                freed += size;
+            }
             if let Some(name) = entry.file_name().to_str() {
                 if is_valid_id(name) {
                     crate::context::stash_index::remove_index_in(dir, name);
@@ -143,6 +206,7 @@ fn prune_in(dir: &Path, ttl_secs: u64) {
             }
         }
     }
+    (removed, freed)
 }
 
 #[cfg(test)]
@@ -158,6 +222,15 @@ mod tests {
         ));
         let _ = std::fs::remove_dir_all(&p);
         p
+    }
+
+    /// Unverified retrieve, matching `retrieve()`'s pre-#200 semantics — used
+    /// by tests that only care about presence/absence, not integrity.
+    fn retrieve_in(dir: &Path, id: &str) -> Option<String> {
+        match retrieve_checked_in(dir, id) {
+            RetrieveOutcome::Found(content) => Some(content),
+            RetrieveOutcome::NotFound | RetrieveOutcome::Corrupted => None,
+        }
     }
 
     #[test]
@@ -231,10 +304,66 @@ mod tests {
     fn prune_keeps_fresh_blobs() {
         let dir = tmp("prune");
         let id = store_in(&dir, "prune me please, this is long enough").unwrap();
-        prune_in(&dir, 0); // ttl 0 disables pruning entirely
+        assert_eq!(prune_in(&dir, 0), (0, 0)); // ttl 0 disables pruning entirely
         assert!(retrieve_in(&dir, &id).is_some());
         prune_in(&dir, 86_400); // just-written blob is younger than 1 day → survives
         assert!(retrieve_in(&dir, &id).is_some());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn prune_removes_expired_blobs_and_reports_stats() {
+        let dir = tmp("prune-expired");
+        let content = "this blob is old enough to be pruned away";
+        let id = store_in(&dir, content).unwrap();
+        // Back-date the blob's mtime past the TTL instead of sleeping in a test.
+        let past = std::time::SystemTime::now() - std::time::Duration::from_secs(3_600);
+        let file = std::fs::File::open(dir.join(&id)).unwrap();
+        file.set_modified(past).unwrap();
+
+        let (removed, freed) = prune_in(&dir, 60);
+        assert_eq!(removed, 1);
+        assert_eq!(freed, content.len() as u64);
+        assert!(retrieve_in(&dir, &id).is_none(), "expired blob should be gone");
+        assert!(!dir.join(format!("{id}.idx")).exists(), "sidecar should be removed too");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn retrieve_checked_detects_corruption() {
+        let dir = tmp("corrupt");
+        let id = store_in(&dir, "the original, untouched content goes here").unwrap();
+        // Flip the bytes on disk without updating the filename/id.
+        std::fs::write(dir.join(&id), "a completely different payload now").unwrap();
+
+        match retrieve_checked_in(&dir, &id) {
+            RetrieveOutcome::Corrupted => {}
+            _ => panic!("expected Corrupted for a blob whose content no longer matches its id"),
+        }
+        // The unverified `retrieve_in` test helper folds `Corrupted` into
+        // "not found" too — there is no longer an unchecked read path (#200).
+        assert!(retrieve_in(&dir, &id).is_none(), "corrupted content must never be handed back");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn retrieve_checked_returns_found_for_intact_blob() {
+        let dir = tmp("intact");
+        let original = "clean content, never touched after store";
+        let id = store_in(&dir, original).unwrap();
+        match retrieve_checked_in(&dir, &id) {
+            RetrieveOutcome::Found(content) => assert_eq!(content, original),
+            _ => panic!("expected Found for an intact blob"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn retrieve_checked_returns_not_found_for_missing_id() {
+        let dir = tmp("missing");
+        match retrieve_checked_in(&dir, "0000000000000000") {
+            RetrieveOutcome::NotFound => {}
+            _ => panic!("expected NotFound for a never-stored id"),
+        }
     }
 }

--- a/src/context/stash_index.rs
+++ b/src/context/stash_index.rs
@@ -58,10 +58,16 @@ pub struct IndexEntry {
     pub terms: Vec<String>,
     pub shingles: Vec<u64>,
     pub preview: String,
+    /// Byte length of the blob at store time. `0` for sidecars written before
+    /// this field existed — treated as "legacy, no length to check against"
+    /// rather than a real zero-byte blob (store() never persists empty content
+    /// as a searchable blob in practice).
+    pub byte_count: u64,
 }
 
 /// Builds the sidecar index content for a blob about to be (or already)
-/// stored — top distinctive terms, shingle sketch, and a 2-line preview.
+/// stored — top distinctive terms, shingle sketch, byte length, and a 2-line
+/// preview.
 pub fn build_index(content: &str) -> IndexEntry {
     let terms = distinctive_terms(content, TOP_K_TERMS);
     let shingles = hash::shingle_minhash(content);
@@ -72,15 +78,16 @@ pub fn build_index(content: &str) -> IndexEntry {
         .map(|l| l.chars().take(100).collect::<String>())
         .collect::<Vec<_>>()
         .join(" / ");
-    IndexEntry { terms, shingles, preview }
+    IndexEntry { terms, shingles, preview, byte_count: content.len() as u64 }
 }
 
 fn serialize(entry: &IndexEntry) -> String {
     format!(
-        "{{\"terms\":{},\"shingles\":{},\"preview\":\"{}\"}}",
+        "{{\"terms\":{},\"shingles\":{},\"preview\":\"{}\",\"byte_count\":{}}}",
         crate::json_util::str_array(&entry.terms),
         crate::json_util::u64_array(&entry.shingles),
         crate::json_util::escape_str(&entry.preview),
+        entry.byte_count,
     )
 }
 
@@ -89,6 +96,9 @@ fn deserialize(s: &str) -> IndexEntry {
         terms: crate::json_util::extract_str_array(s, "terms"),
         shingles: crate::json_util::extract_u64_array(s, "shingles"),
         preview: crate::json_util::extract_str(s, "preview").unwrap_or_default(),
+        // Missing on sidecars written before this field existed — see the
+        // doc comment on `IndexEntry::byte_count`.
+        byte_count: crate::json_util::extract_u64(s, "byte_count").unwrap_or(0),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,12 @@ fn main() {
         Some("doctor") => {
             std::process::exit(squeez::commands::doctor::run());
         }
+        Some("prune") => {
+            // On-demand cleanup for the blob store + session memory (#201) —
+            // both already prune opportunistically elsewhere; this just gives
+            // the `run squeez prune` hints in mcp_server.rs somewhere to land.
+            std::process::exit(squeez::commands::prune::run());
+        }
         Some("calibrate") => {
             let rest: Vec<String> = args.iter().skip(2).cloned().collect();
             std::process::exit(squeez::economy::calibrate::run(&rest));
@@ -130,6 +136,7 @@ fn main() {
             eprintln!("       squeez compact-summary           — PostCompact hook: re-inject session state");
             eprintln!("       squeez calibrate                 — auto-tune config from benchmarks");
             eprintln!("       squeez doctor                    — self-health check (hooks, config, tracking)");
+            eprintln!("       squeez prune                     — clear expired stashed blobs + old session summaries");
             eprintln!("       squeez budget-params <tool>        — output JSON budget patch for tool");
             eprintln!("       squeez --version");
             std::process::exit(1);

--- a/tests/test_prune.rs
+++ b/tests/test_prune.rs
@@ -1,0 +1,84 @@
+//! Integration coverage for `squeez prune` (#201) — the CLI hint
+//! ("run squeez prune") referenced a command that fell through to the usage
+//! banner because it was never dispatched. These tests run the real binary
+//! against an isolated `SQUEEZ_DIR` to prove the subcommand now exists, wipes
+//! expired blobs, and leaves fresh ones alone.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn tmp() -> PathBuf {
+    static CTR: AtomicU64 = AtomicU64::new(0);
+    let n = CTR.fetch_add(1, Ordering::Relaxed);
+    let d = std::env::temp_dir().join(format!(
+        "squeez_prune_test_{}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos(),
+        n
+    ));
+    std::fs::create_dir_all(d.join("blobs")).unwrap();
+    d
+}
+
+fn run_prune(squeez_dir: &std::path::Path) -> String {
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_squeez"))
+        .arg("prune")
+        .env("SQUEEZ_DIR", squeez_dir)
+        .env("HOME", squeez_dir) // keep memory_dir/prune_old off the real $HOME too
+        .output()
+        .expect("run squeez prune");
+    assert!(out.status.success(), "squeez prune exited nonzero: {out:?}");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+#[test]
+fn prune_subcommand_is_dispatched_and_removes_only_expired_blobs() {
+    let dir = tmp();
+    let blobs = dir.join("blobs");
+
+    // Fresh blob (id doesn't matter for this test, only mtime + shape).
+    let fresh_id = "1111111111111111";
+    std::fs::write(blobs.join(fresh_id), "fresh content").unwrap();
+
+    // Expired blob, back-dated well past the default 7-day TTL.
+    let stale_id = "2222222222222222";
+    std::fs::write(blobs.join(stale_id), "stale content").unwrap();
+    let past = std::time::SystemTime::now() - std::time::Duration::from_secs(8 * 86_400);
+    let f = std::fs::File::open(blobs.join(stale_id)).unwrap();
+    f.set_modified(past).unwrap();
+
+    let stdout = run_prune(&dir);
+    assert!(stdout.contains("squeez prune"), "unexpected output: {stdout}");
+    assert!(stdout.contains("removed 1 expired blob"), "unexpected output: {stdout}");
+
+    assert!(blobs.join(fresh_id).exists(), "fresh blob must survive prune");
+    assert!(!blobs.join(stale_id).exists(), "expired blob must be removed");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn prune_subcommand_is_a_noop_on_an_empty_store() {
+    let dir = tmp();
+    let stdout = run_prune(&dir);
+    assert!(stdout.contains("removed 0 expired blob"), "unexpected output: {stdout}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn unknown_subcommand_banner_no_longer_treats_prune_as_unknown() {
+    // `squeez prune` with no matching setup must still exit 0 (it's a real,
+    // dispatched subcommand now) rather than falling into the usage banner,
+    // which exits 1.
+    let dir = tmp();
+    let out = std::process::Command::new(env!("CARGO_BIN_EXE_squeez"))
+        .arg("prune")
+        .env("SQUEEZ_DIR", &dir)
+        .env("HOME", &dir)
+        .output()
+        .expect("run squeez prune");
+    assert_eq!(out.status.code(), Some(0));
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Linked issue

Closes #200
Closes #201

## Type of change

- [x] `fix:` / `perf:` — bug fix or perf improvement (→ patch bump)

## Area

- [x] Handler (`src/commands/*`)
- [x] Context engine (`src/context/` — cache / redundancy / summarize / intensity)
- [x] MCP server (`src/commands/mcp_server.rs`)

## Summary

- **#201** — `squeez prune` was referenced in the `squeez_search_history`/`squeez_file_history` hint text ("summaries.jsonl too large — run squeez prune") but was never a dispatched CLI subcommand, so it fell through to the usage banner. Blob TTL pruning and summary pruning already ran opportunistically (on `wrap` and session init respectively), so nothing grew truly unbounded, but there was no way to trigger either on demand and no visibility into blob-store size. Added a `squeez prune` subcommand that runs both and reports what it freed, plus a `squeez doctor` line reporting current blob-store size/count.
- **#200** — `squeez_retrieve` returned stashed blob content with no integrity check, so a truncated or corrupted blob (partial write, disk issue) would be served back to the model silently as if it were the original. Since a blob's filename is already the FNV-1a hash of its content, verify-on-read needed no format change: `retrieve_checked` rehashes the bytes read from disk and compares them to the id, returning a distinct integrity-error message instead of the corrupted text on mismatch. Also record byte length in the `.idx` sidecar (backward compatible — legacy sidecars default to `0`) per the issue's suggested fix.

## Test plan

- [x] `cargo test` passes (482 lib tests + all integration suites, including new `tests/test_prune.rs` and new unit tests in `src/context/retrieve.rs`)
- [x] Manually verified via the real binary: `squeez prune` on an isolated `SQUEEZ_DIR` removes only expired blobs and reports correct counts/bytes; `squeez --help`/unknown-subcommand banner now lists `prune`; `squeez doctor` shows the new blob-store line
- [x] Manually verified end-to-end: corrupting a stored blob's bytes on disk and calling `squeez_retrieve` via the MCP JSON-RPC layer returns the new integrity-error message instead of the corrupted text
- [ ] `bash bench/run.sh` / `bash bench/run_context.sh` — not run; this change doesn't touch the compression pipeline or context-engine scoring, only the retrieve/prune side path

## Checklist

- [x] Issue is linked above
- [ ] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)

(Replaces #206, which was opened from a wrongly-named branch and carried a platform-injected attribution footer — recreated here with a clean branch name and commit authorship.)
