### PR TITLE
fix(json): escape all JSON control characters in escape_str

### DIFF
--- a/src/json_util.rs
+++ b/src/json_util.rs
@@ -97,11 +97,16 @@ pub fn extract_str_array(json: &str, key: &str) -> Vec<String> {
 }
 
 /// Escape a string for inclusion in a JSON string value (not quoted).
+///
+/// Produces valid JSON string contents for arbitrary UTF-8, including every
+/// C0 control character. Escaping `\t` (and the rest of `U+0000..U+001F`) is
+/// not cosmetic: MCP responses are assembled by hand in
+/// [`crate::commands::mcp_server`], so an unescaped tab in a retrieved blob
+/// made the whole JSON-RPC frame unparseable for the client (issue #210).
 pub fn escape_str(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "")
+    let mut out = String::with_capacity(s.len());
+    escape_strict(s, &mut out);
+    out
 }
 
 /// Serialize a string slice as a JSON array of strings.
@@ -472,9 +477,9 @@ impl JsonValue {
     }
 }
 
-/// Strict JSON string escaping — unlike [`escape_str`], which is lossy (it
-/// drops `\r`) and tuned for one-line log records, this preserves every input
-/// byte so user settings files round-trip unchanged.
+/// Strict JSON string escaping, written into an existing buffer. Preserves
+/// every input byte so user settings files round-trip unchanged; [`escape_str`]
+/// is the allocating form.
 fn escape_strict(s: &str, out: &mut String) {
     for ch in s.chars() {
         match ch {

--- a/tests/test_json_util.rs
+++ b/tests/test_json_util.rs
@@ -71,3 +71,50 @@ fn test_str_array_empty() {
     let json = squeez::json_util::str_array(&[]);
     assert_eq!(json, "[]");
 }
+
+// ── Regression: control characters must not leak into JSON strings (#210) ──
+//
+// MCP responses are assembled by hand, so a literal tab inside a retrieved
+// blob used to travel straight into the JSON-RPC frame and the client
+// rejected the whole response with "Invalid control character at:".
+
+#[test]
+fn test_escape_str_tab() {
+    assert_eq!(squeez::json_util::escape_str("a\tb"), "a\\tb");
+}
+
+#[test]
+fn test_escape_str_all_named_escapes() {
+    assert_eq!(
+        squeez::json_util::escape_str("\u{8}\t\n\u{c}\r\"\\"),
+        "\\b\\t\\n\\f\\r\\\"\\\\"
+    );
+}
+
+#[test]
+fn test_escape_str_carriage_return_is_preserved_not_dropped() {
+    // Previously `\r` was silently deleted, which corrupted CRLF payloads.
+    assert_eq!(squeez::json_util::escape_str("a\r\nb"), "a\\r\\nb");
+}
+
+#[test]
+fn test_escape_str_other_control_chars_use_u_escape() {
+    assert_eq!(squeez::json_util::escape_str("\0"), "\\u0000");
+    assert_eq!(squeez::json_util::escape_str("\u{1}\u{1f}"), "\\u0001\\u001f");
+}
+
+#[test]
+fn test_escape_str_leaves_printable_and_unicode_alone() {
+    let s = "ok — café 日本語 {}[]";
+    assert_eq!(squeez::json_util::escape_str(s), s);
+}
+
+#[test]
+fn test_escaped_control_chars_reparse_as_json() {
+    // The end-to-end property the bug violated: whatever escape_str emits must
+    // survive a round-trip through the parser as the ORIGINAL bytes.
+    let raw = "fn main() {\n\tlet x = \"q\";\r\n}\u{7}\0";
+    let doc = format!("{{\"text\":\"{}\"}}", squeez::json_util::escape_str(raw));
+    let parsed = squeez::json_util::parse_value(&doc).expect("escaped payload must parse");
+    assert_eq!(parsed.get_str("text"), raw);
+}

--- a/tests/test_mcp_server.rs
+++ b/tests/test_mcp_server.rs
@@ -174,3 +174,48 @@ fn session_efficiency_exposes_overhead_tokens() {
     // net_saved = tokens_saved(200) - overhead_tokens(777) = -577
     assert!(resp.contains("-577"), "missing signed net_saved: {}", resp);
 }
+
+/// Regression for #210: a stashed blob containing tab indentation used to be
+/// spliced into the JSON-RPC frame with the tab still literal, and the MCP
+/// client rejected the whole response ("Invalid control character at:").
+/// This is the reporter's exact repro, driven through the public dispatcher.
+#[test]
+fn retrieve_response_with_control_chars_is_valid_json() {
+    let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = std::env::temp_dir().join(format!("squeez-mcp-ctrl-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let prev = std::env::var("SQUEEZ_DIR").ok();
+    std::env::set_var("SQUEEZ_DIR", &dir);
+
+    let original = "fn main() {\n\tlet s = \"tab\\tinside\";\r\n}\u{7}";
+    let key = squeez::context::retrieve::store(original).expect("blob must store");
+    let req = format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"tools/call\",\
+\"params\":{{\"name\":\"squeez_retrieve\",\"arguments\":{{\"key\":\"{}\"}}}}}}",
+        key
+    );
+    let resp = handle_request(&req).expect("must respond");
+
+    match prev {
+        Some(v) => std::env::set_var("SQUEEZ_DIR", v),
+        None => std::env::remove_var("SQUEEZ_DIR"),
+    }
+    std::fs::remove_dir_all(&dir).ok();
+
+    assert_jsonrpc_response(&resp, "42");
+    assert!(
+        !resp.contains('\t'),
+        "raw tab leaked into the JSON-RPC frame: {:?}",
+        resp
+    );
+    let parsed = squeez::json_util::parse_value(&resp)
+        .unwrap_or_else(|| panic!("response must be parseable JSON: {:?}", resp));
+    let text = parsed
+        .get("result")
+        .and_then(|r| r.get("content"))
+        .map(|c| c.as_arr())
+        .and_then(|a| a.first())
+        .map(|e| e.get_str("text"))
+        .expect("result.content[0].text");
+    assert_eq!(text, original, "blob must round-trip byte-for-byte");
+}


### PR DESCRIPTION
Closes #210

Reported by @inarmar — thanks for the precise diagnosis, including the exact
line and the unit-level reproduction. Both landed almost verbatim.

## The bug

`json_util::escape_str` handled backslash, quote and newline, and *deleted*
carriage returns. Every other C0 control character — a tab, most of the time —
went through untouched:

```rust
pub fn escape_str(s: &str) -> String {
    s.replace('\\', "\\\\")
        .replace('"', "\\\"")
        .replace('\n', "\\n")
        .replace('\r', "")          // dropped, not escaped
}
```

MCP responses are assembled by hand in `mcp_server::text_result_response`, so a
stashed blob indented with tabs put a literal tab inside a JSON string and the
client rejected the whole JSON-RPC frame:

```text
Invalid control character at: line 1 column ...
```

`squeez_retrieve` was therefore unusable for any tab-indented source file, even
though the stored blob was byte-identical and passed the #200 integrity check —
the failure is at the serialization boundary, downstream of it.

## The fix

`json_util` already carried a correct strict escaper (`escape_strict`) used for
settings round-trips. Rather than add a third escaping path, the two are
collapsed: `escape_str` is now the allocating form of `escape_strict`. One
implementation, not a correct one plus a lossy one.

Behaviour change worth calling out: `\r` is now escaped as `\r` instead of
being deleted. No caller relied on the deletion, and it stops CRLF payloads
from being silently corrupted in the session JSONL as well.

The zero-dependency constraint rules out the "use a real serializer"
alternative from the issue, so the hand-written path is made correct instead.

## Proof

Six new tests, all of which **fail against the previous implementation**:

```
$ git stash -- src/json_util.rs && cargo test --test test_json_util --test test_mcp_server
test result: FAILED. 11 passed; 5 failed;   # tests/test_json_util.rs
test result: FAILED. 0 passed; 1 failed;    # tests/test_mcp_server.rs
```

With the fix, and the full suite:

```
$ cargo test --test test_json_util --test test_mcp_server
test result: ok. 16 passed; 0 failed;
test result: ok. 12 passed; 0 failed;

$ cargo test
1150 passed; 0 failed   (exit 0)
```

Coverage: `\t` `\b` `\f` `\r` NUL and the `U+0001..U+001F` range, printable and
non-ASCII text left untouched, plus the reporter's end-to-end repro — store a
blob containing a tab, call `squeez_retrieve` through `handle_request`, assert
the response reparses as JSON and the text round-trips byte-for-byte.
