### PR TITLE
fix(hosts): make Windows hook registration actually executable

### DIFF
--- a/hooks/codex-posttooluse.sh
+++ b/hooks/codex-posttooluse.sh
@@ -4,6 +4,23 @@
 # Registered in ~/.codex/hooks.json under hooks.PostToolUse.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -14,7 +31,7 @@ fi
 export SQUEEZ_DIR="$HOME/.codex/squeez"
 export SQUEEZ_BIN="$SQUEEZ"
 
-python3 -c "
+"$SQUEEZ_PY" -c "
 import json, sys, subprocess, os
 
 data = sys.stdin.read()

--- a/hooks/codex-pretooluse.sh
+++ b/hooks/codex-pretooluse.sh
@@ -11,6 +11,23 @@
 # Registered in ~/.codex/hooks.json under hooks.PreToolUse.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -18,7 +35,7 @@ if [ ! -x "$SQUEEZ" ]; then
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
-SQUEEZ_BIN="$SQUEEZ" python3 -c "
+SQUEEZ_BIN="$SQUEEZ" "$SQUEEZ_PY" -c "
 import json, os, shlex, subprocess, sys
 
 data = sys.stdin.read()

--- a/hooks/codex-session-start.sh
+++ b/hooks/codex-session-start.sh
@@ -20,6 +20,9 @@ for _c in python3 python py; do
         break
     fi
 done
+# No interpreter, nothing this hook can parse — leave quietly rather than
+# failing the host's session-start under `set -e`.
+[ -z "$SQUEEZ_PY" ] && exit 0
 
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then

--- a/hooks/codex-session-start.sh
+++ b/hooks/codex-session-start.sh
@@ -5,6 +5,22 @@
 # Registered in ~/.codex/hooks.json under hooks.SessionStart.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -20,7 +36,7 @@ export SQUEEZ_DIR="$HOME/.codex/squeez"
 SQUEEZ_CONTEXT="$("$SQUEEZ" init --host=codex 2>/dev/null || true)"
 
 if [ -n "$SQUEEZ_CONTEXT" ]; then
-    SQUEEZ_CONTEXT="$SQUEEZ_CONTEXT" python3 -c '
+    SQUEEZ_CONTEXT="$SQUEEZ_CONTEXT" "$SQUEEZ_PY" -c '
 import json, os
 print(json.dumps({
     "hookSpecificOutput": {

--- a/hooks/copilot-posttooluse.sh
+++ b/hooks/copilot-posttooluse.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 # squeez Copilot CLI PostToolUse hook — tracks token usage per tool call
+
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -11,7 +28,7 @@ export SQUEEZ_DIR="$HOME/.copilot/squeez"
 
 input=$(cat)
 
-tool=$(printf '%s' "$input" | python3 -c "
+tool=$(printf '%s' "$input" | "$SQUEEZ_PY" -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -22,7 +39,7 @@ except Exception:
 
 # Tolerant extraction: tries tool_response (Claude Code convention) then
 # tool_result; handles string, {content: str|blocks}, and nested file.content.
-size=$(printf '%s' "$input" | python3 -c "
+size=$(printf '%s' "$input" | "$SQUEEZ_PY" -c "
 import sys, json
 def text_len(c):
     if c is None:

--- a/hooks/copilot-pretooluse.sh
+++ b/hooks/copilot-pretooluse.sh
@@ -6,6 +6,23 @@
 # Registered in ~/.copilot/settings.json under hooks.PreToolUse.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -15,7 +32,7 @@ fi
 
 export SQUEEZ_DIR="$HOME/.copilot/squeez"
 
-SQUEEZ_BIN="$SQUEEZ" python3 -c "
+SQUEEZ_BIN="$SQUEEZ" "$SQUEEZ_PY" -c "
 import sys, json, os, shlex, subprocess
 
 data = sys.stdin.read()

--- a/hooks/gemini-after-tool.sh
+++ b/hooks/gemini-after-tool.sh
@@ -5,6 +5,23 @@
 # Registered in ~/.gemini/settings.json under hooks.AfterTool.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -14,7 +31,7 @@ fi
 
 export SQUEEZ_DIR="$HOME/.gemini/squeez"
 
-python3 -c "
+"$SQUEEZ_PY" -c "
 import json, sys, subprocess, os
 
 data = sys.stdin.read()

--- a/hooks/gemini-before-tool.sh
+++ b/hooks/gemini-before-tool.sh
@@ -10,6 +10,23 @@
 # Registered in ~/.gemini/settings.json under hooks.BeforeTool.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -17,7 +34,7 @@ if [ ! -x "$SQUEEZ" ]; then
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
-SQUEEZ_BIN="$SQUEEZ" python3 -c "
+SQUEEZ_BIN="$SQUEEZ" "$SQUEEZ_PY" -c "
 import json, os, shlex, subprocess, sys
 
 data = sys.stdin.read()

--- a/hooks/posttooluse.sh
+++ b/hooks/posttooluse.sh
@@ -3,6 +3,23 @@
 # content is redundant or oversized (Claude Code v2.1.119+ updatedToolOutput).
 # Bash compression is handled at PreToolUse via `squeez wrap`; this hook covers
 # Read / Grep / Glob whose output bypasses the wrap mechanism.
+
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
 SQUEEZ="${SQUEEZ_BIN:-$HOME/.claude/squeez/bin/squeez}"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -12,7 +29,7 @@ fi
 
 input=$(cat)
 
-tool=$(printf '%s' "$input" | python3 -c "
+tool=$(printf '%s' "$input" | "$SQUEEZ_PY" -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
@@ -25,7 +42,7 @@ except Exception:
 # is kept as a fallback for other hosts / older payloads. Shapes handled:
 # plain string, {content: str}, {content: [{type:text,text:…}]}, and the Read
 # shape {type:text, file:{content: …}} — mirrors track_result.rs extract_content.
-size=$(printf '%s' "$input" | python3 -c "
+size=$(printf '%s' "$input" | "$SQUEEZ_PY" -c "
 import sys, json
 def text_len(c):
     if c is None:

--- a/hooks/pretooluse.sh
+++ b/hooks/pretooluse.sh
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -8,7 +25,7 @@ if [ ! -x "$SQUEEZ" ]; then
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
-SQUEEZ_BIN="$SQUEEZ" python3 -c "
+SQUEEZ_BIN="$SQUEEZ" "$SQUEEZ_PY" -c "
 import sys, json, os, shlex, subprocess
 
 data = sys.stdin.read()

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -16,6 +16,9 @@ for _c in python3 python py; do
         break
     fi
 done
+# No interpreter, nothing this hook can parse — leave quietly rather than
+# failing the host's session-start under `set -e`.
+[ -z "$SQUEEZ_PY" ] && exit 0
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 # squeez SessionStart hook — runs squeez init, prints memory banner to session context
+
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -12,7 +28,7 @@ fi
 # (e.g. by another tool like OMC that overwrites the file on setup).
 _settings="$HOME/.claude/settings.json"
 if [ -f "$_settings" ]; then
-    _has_squeez=$(python3 -c "
+    _has_squeez=$("$SQUEEZ_PY" -c "
 import json, sys
 HOOK_EVENTS = ('PreToolUse', 'PostToolUse', 'SessionStart', 'UserPromptSubmit', 'Stop')
 try:

--- a/hooks/statusline.sh
+++ b/hooks/statusline.sh
@@ -2,6 +2,22 @@
 # squeez statusline — emits a compact status line for Claude Code statusLine hook.
 # Reads session data from ~/.claude/squeez/ and outputs a single line.
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+
 SQUEEZ_DIR="${SQUEEZ_DIR:-$HOME/.claude/squeez}"
 SESSION_FILE="$SQUEEZ_DIR/sessions/current.json"
 CONTEXT_FILE="$SQUEEZ_DIR/sessions/context.json"
@@ -15,8 +31,8 @@ fi
 # Read session fields
 saved_tokens=0
 total_calls=0
-if command -v python3 &>/dev/null; then
-    read -r saved_tokens total_calls < <(python3 -c "
+if [[ -n "$SQUEEZ_PY" ]]; then
+    read -r saved_tokens total_calls < <("$SQUEEZ_PY" -c "
 import json
 try:
     with open('$SESSION_FILE') as f:
@@ -30,8 +46,8 @@ fi
 # Read agent_spawns and total_in from context.json
 agent_spawns=0
 total_in=0
-if [[ -f "$CONTEXT_FILE" ]] && command -v python3 &>/dev/null; then
-    read -r agent_spawns total_in < <(python3 -c "
+if [[ -f "$CONTEXT_FILE" ]] && [[ -n "$SQUEEZ_PY" ]]; then
+    read -r agent_spawns total_in < <("$SQUEEZ_PY" -c "
 import json
 try:
     with open('$CONTEXT_FILE') as f:
@@ -47,8 +63,8 @@ fi
 
 # Read efficiency_overall_bp from last line of summaries.jsonl
 efficiency_bp=""
-if [[ -f "$SUMMARIES_FILE" ]] && command -v python3 &>/dev/null; then
-    efficiency_bp=$(python3 -c "
+if [[ -f "$SUMMARIES_FILE" ]] && [[ -n "$SQUEEZ_PY" ]]; then
+    efficiency_bp=$("$SQUEEZ_PY" -c "
 import json
 try:
     with open('$SUMMARIES_FILE') as f:
@@ -68,7 +84,7 @@ parts=("squeez")
 
 if [[ "$saved_tokens" -gt 0 ]]; then
     if [[ "$total_in" -gt 0 ]]; then
-        ratio=$(python3 -c "print(f'{$saved_tokens*100/$total_in:.0f}')" 2>/dev/null || echo "")
+        ratio=$("$SQUEEZ_PY" -c "print(f'{$saved_tokens*100/$total_in:.0f}')" 2>/dev/null || echo "")
         parts+=("| -${saved_tokens}tk ${ratio}%")
     else
         parts+=("| -${saved_tokens}tk")
@@ -84,7 +100,7 @@ if [[ "$agent_spawns" -gt 0 ]]; then
 fi
 
 if [[ -n "$efficiency_bp" ]] && [[ "$efficiency_bp" -gt 0 ]]; then
-    eff_pct=$(python3 -c "print(f'{$efficiency_bp/100:.1f}')" 2>/dev/null || echo "")
+    eff_pct=$("$SQUEEZ_PY" -c "print(f'{$efficiency_bp/100:.1f}')" 2>/dev/null || echo "")
     if [[ -n "$eff_pct" ]]; then
         parts+=("| Eff: ${eff_pct}%")
     fi

--- a/hooks/subagent-stop.sh
+++ b/hooks/subagent-stop.sh
@@ -7,6 +7,23 @@
 # message so the parent agent can dedup against what the sub-agent already saw.
 set -euo pipefail
 
+# Resolve a working Python interpreter.
+#
+# Hardcoding python3 is not safe on Windows: python.org installs ship
+# python.exe with no python3.exe, so the name resolves to the Microsoft Store
+# App Execution Alias under %LOCALAPPDATA%\Microsoft\WindowsApps. That stub is
+# on PATH and passes `command -v`, but exits non-zero when run — which left
+# every squeez hook silently dead (issue #209). Probe by EXECUTING each
+# candidate, not by locating it.
+SQUEEZ_PY=""
+for _c in python3 python py; do
+    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
+        SQUEEZ_PY="$_c"
+        break
+    fi
+done
+[ -z "$SQUEEZ_PY" ] && exit 0
+
 SQUEEZ="${SQUEEZ_BIN:-$HOME/.claude/squeez/bin/squeez}"
 if [ ! -x "$SQUEEZ" ]; then
     _sq=$(command -v squeez 2>/dev/null || true)
@@ -18,7 +35,7 @@ input=$(cat)
 
 # Wrap last_assistant_message into a tool_result-compatible JSON so that
 # track-result's existing extract_content() logic picks it up correctly.
-wrapped=$(printf '%s' "$input" | python3 -c "
+wrapped=$(printf '%s' "$input" | "$SQUEEZ_PY" -c "
 import json, sys
 try:
     d = json.load(sys.stdin)

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -95,19 +95,39 @@ fn hook_command_problem(cmd: &str, exists: impl Fn(&Path) -> bool) -> Option<Str
     }
     let path = match arg.strip_prefix('"') {
         Some(rest) => rest.strip_suffix('"')?,
-        None if arg.contains(' ') => return None,
+        // Backslashes are checked BEFORE spaces: `C:\Users\First Last\…` has
+        // both, and it is broken either way. Testing for a space first would
+        // have skipped it and reported a real #209 install as healthy.
         None if arg.contains('\\') => {
             return Some(format!(
                 "unquoted backslashes — bash reads it as `{}`",
                 arg.replace('\\', "")
             ))
         }
+        None if arg.contains(' ') => return None,
         None => arg,
     };
+    // A relative path resolves against doctor's working directory, not the
+    // host's, so it cannot be judged. Foreign hooks may legally use one, and
+    // `bash scripts/squeez-wrapper.sh` reaches here purely because it contains
+    // the string "squeez" — blaming squeez for it would be wrong.
+    if !path.starts_with('/') && !path.starts_with('\\') && !is_drive_qualified(path) {
+        return None;
+    }
     if !exists(Path::new(path)) {
         return Some(format!("script not found: {path}"));
     }
     None
+}
+
+/// `C:/…` — anchored on Windows even when this check runs on Unix, where
+/// `Path::is_absolute` would say otherwise.
+fn is_drive_qualified(path: &str) -> bool {
+    let mut chars = path.chars();
+    matches!(
+        (chars.next(), chars.next()),
+        (Some(c), Some(':')) if c.is_ascii_alphabetic()
+    )
 }
 
 /// Every squeez hook command registered in `settings`, from both the nested
@@ -415,6 +435,35 @@ mod tests {
     #[test]
     fn missing_script_is_reported() {
         let why = hook_command_problem("bash \"/h/.claude/squeez/hooks/x.sh\"", absent)
+            .expect("must be flagged");
+        assert!(why.contains("script not found"), "{why}");
+    }
+
+    /// `C:\Users\First Last\…` has BOTH a backslash and a space, and is broken
+    /// either way. Testing for the space first reported a real #209 install as
+    /// healthy — and `C:\Users\First Last` is an ordinary Windows profile.
+    #[test]
+    fn a_backslash_path_containing_a_space_is_still_reported() {
+        let cmd = "bash C:\\Users\\Jesse Klotz\\.claude\\squeez\\hooks\\pretooluse.sh";
+        let why = hook_command_problem(cmd, present).expect("must be flagged");
+        assert!(why.contains("unquoted backslashes"), "{why}");
+    }
+
+    /// A relative path resolves against doctor's own working directory, so it
+    /// cannot be judged. A user's own `bash scripts/squeez-wrapper.sh` reaches
+    /// this check purely because the string contains "squeez"; failing it would
+    /// blame squeez and prescribe a `squeez setup` that cannot fix it.
+    #[test]
+    fn a_relative_foreign_command_is_not_blamed_on_squeez() {
+        assert_eq!(
+            hook_command_problem("bash scripts/squeez-wrapper.sh", absent),
+            None
+        );
+    }
+
+    #[test]
+    fn drive_qualified_paths_are_still_checked_for_existence() {
+        let why = hook_command_problem("bash \"C:/Users/J/.claude/squeez/hooks/x.sh\"", absent)
             .expect("must be flagged");
         assert!(why.contains("script not found"), "{why}");
     }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,6 +7,7 @@
 
 use crate::config::Config;
 use crate::hosts::claude_code::hooks_manifest;
+use crate::json_util::JsonValue;
 use crate::session;
 use std::path::Path;
 use std::time::{Duration, SystemTime};
@@ -70,6 +71,121 @@ fn check_hooks_registered(settings_path: &Path) -> CheckLine {
             missing.join(", ")
         ))
     }
+}
+
+/// Why a registered hook `command` cannot actually run, or `None` when it is
+/// sound. Pure over `exists` so the Windows failure modes stay testable from
+/// any host.
+///
+/// `check_hooks_registered` only asks whether the script *name* appears
+/// somewhere in settings.json. That is why doctor reported all-green on an
+/// install where every hook died with `No such file or directory` (#209): the
+/// registered command was `bash C:\Users\Jesse\.claude\squeez\hooks\…`, bash
+/// ate each backslash as an escape, and the file it then looked for did not
+/// exist. Note that a plain existence check is not enough to catch this — on
+/// Windows the *unmangled* path does resolve; it is the quoting that is wrong.
+fn hook_command_problem(cmd: &str, exists: impl Fn(&Path) -> bool) -> Option<String> {
+    // Only `bash <script>` is statically checkable. Anything else — a bare
+    // path (codex/gemini invoke their hooks directly) or a compound
+    // `bash -c '…'` chain (the adopted-HUD statusLine) — is left alone rather
+    // than guessed at, since a false FAIL is worse than a missed one.
+    let arg = cmd.strip_prefix("bash ")?.trim();
+    if arg.starts_with('-') {
+        return None;
+    }
+    let path = match arg.strip_prefix('"') {
+        Some(rest) => rest.strip_suffix('"')?,
+        None if arg.contains(' ') => return None,
+        None if arg.contains('\\') => {
+            return Some(format!(
+                "unquoted backslashes — bash reads it as `{}`",
+                arg.replace('\\', "")
+            ))
+        }
+        None => arg,
+    };
+    if !exists(Path::new(path)) {
+        return Some(format!("script not found: {path}"));
+    }
+    None
+}
+
+/// Every squeez hook command registered in `settings`, from both the nested
+/// `hooks` map and the legacy top-level shape.
+fn registered_squeez_commands(settings: &JsonValue) -> Vec<String> {
+    let mut out = Vec::new();
+    let push = |cmd: &str, out: &mut Vec<String>| {
+        if cmd.contains("squeez") && !out.iter().any(|c| c == cmd) {
+            out.push(cmd.to_string());
+        }
+    };
+    let mut roots = vec![settings];
+    if let Some(nested) = settings.get("hooks").filter(|h| h.is_obj()) {
+        roots.push(nested);
+    }
+    for root in roots {
+        for (_event, entries) in root.obj_entries() {
+            for entry in entries.as_arr() {
+                for hook in entry.get("hooks").map(|h| h.as_arr()).unwrap_or(&[]) {
+                    push(hook.get_str("command"), &mut out);
+                }
+            }
+        }
+    }
+    // statusLine is an object, not an event array, and squeez registers one too.
+    if let Some(status) = settings.get("statusLine").filter(|s| s.is_obj()) {
+        push(status.get_str("command"), &mut out);
+    }
+    out
+}
+
+/// Registered hooks must be commands a shell can actually execute — not merely
+/// strings that mention the right filename.
+fn check_hooks_runnable(settings_path: &Path) -> CheckLine {
+    let Some(settings) = crate::hosts::settings_json::load_lenient(settings_path) else {
+        return warn("runnable: settings.json unreadable — skipped");
+    };
+    let commands = registered_squeez_commands(&settings);
+    if commands.is_empty() {
+        return warn("runnable: no squeez hook commands to check");
+    }
+    let broken: Vec<String> = commands
+        .iter()
+        .filter_map(|c| hook_command_problem(c, |p| p.exists()).map(|why| format!("{c} — {why}")))
+        .collect();
+    if broken.is_empty() {
+        return ok(format!("runnable: {} hook commands resolve", commands.len()));
+    }
+    fail(format!(
+        "runnable: {} of {} hook commands cannot execute — run `squeez setup`\n         {}",
+        broken.len(),
+        commands.len(),
+        broken.join("\n         ")
+    ))
+}
+
+/// The hooks drive their JSON handling through Python, so a missing or broken
+/// interpreter makes them no-ops. Probe by EXECUTING each candidate: on Windows
+/// `python3` is usually the Microsoft Store alias stub, which is on PATH and
+/// passes `command -v` but exits non-zero when run (#209).
+fn check_interpreter() -> CheckLine {
+    for candidate in ["python3", "python", "py"] {
+        let runs = std::process::Command::new(candidate)
+            .args(["-c", ""])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if runs {
+            return ok(format!("interpreter: hooks will use `{candidate}`"));
+        }
+    }
+    fail(
+        "interpreter: no working python on PATH (tried python3, python, py) — \
+         hooks parse their payloads with it, so compression is inert. \
+         Install Python and re-run `squeez doctor`",
+    )
 }
 
 /// Config check: a disabled pipeline is the exact silent-death mode doctor
@@ -197,6 +313,8 @@ pub fn run_with(squeez_dir: &Path, settings_path: &Path, cfg: &Config) -> (Vec<S
     let checks = [
         check_hooks_drift(squeez_dir),
         check_hooks_registered(settings_path),
+        check_hooks_runnable(settings_path),
+        check_interpreter(),
         check_config(cfg),
         check_freshness(squeez_dir, cfg),
         check_blob_store(squeez_dir),
@@ -259,4 +377,82 @@ pub fn run() -> i32 {
         println!("{}", l);
     }
     i32::from(has_fail)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every path in these cases is asked about through this predicate, so the
+    /// Windows shapes can be exercised from a macOS CI runner.
+    fn present(_p: &Path) -> bool {
+        true
+    }
+    fn absent(_p: &Path) -> bool {
+        false
+    }
+
+    /// #209: doctor was green on an install where every hook died with
+    /// `No such file or directory`. On Windows the unmangled path DOES exist,
+    /// so only the quoting tells the two apart.
+    #[test]
+    fn unquoted_backslash_command_is_reported_even_when_the_file_exists() {
+        let cmd = "bash C:\\Users\\JesseKlotz\\.claude\\squeez\\hooks\\pretooluse.sh";
+        let why = hook_command_problem(cmd, present).expect("must be flagged");
+        assert!(why.contains("unquoted backslashes"), "{why}");
+        assert!(
+            why.contains("C:UsersJesseKlotz.claudesqueezhookspretooluse.sh"),
+            "must show what bash actually sees: {why}"
+        );
+    }
+
+    #[test]
+    fn quoted_forward_slash_command_is_accepted() {
+        let cmd = "bash \"C:/Users/JesseKlotz/.claude/squeez/hooks/pretooluse.sh\"";
+        assert_eq!(hook_command_problem(cmd, present), None);
+    }
+
+    #[test]
+    fn missing_script_is_reported() {
+        let why = hook_command_problem("bash \"/h/.claude/squeez/hooks/x.sh\"", absent)
+            .expect("must be flagged");
+        assert!(why.contains("script not found"), "{why}");
+    }
+
+    /// A false FAIL is worse than a missed one, so anything that is not a plain
+    /// `bash <script>` is left alone: bare paths (codex/gemini run their hooks
+    /// directly) and the `bash -c '…'` adopted-HUD statusLine chain.
+    #[test]
+    fn non_plain_commands_are_left_alone() {
+        assert_eq!(hook_command_problem("/h/.claude/squeez/hooks/x.sh", absent), None);
+        assert_eq!(
+            hook_command_problem(
+                "bash -c 'input=$(cat); echo \"$input\" | { hud; } 2>/dev/null'",
+                absent
+            ),
+            None
+        );
+        assert_eq!(hook_command_problem("bash two words here", absent), None);
+    }
+
+    #[test]
+    fn registered_commands_are_collected_from_both_shapes_and_deduped() {
+        let settings = crate::json_util::parse_value(
+            r#"{
+                 "hooks": {
+                   "PreToolUse": [{"hooks":[{"command":"bash \"/h/squeez/hooks/pretooluse.sh\""}]}],
+                   "Stop": [{"hooks":[{"command":"bash \"/h/squeez/buddy/shims/stop.sh\""}]}]
+                 },
+                 "PostToolUse": [{"hooks":[{"command":"bash \"/h/squeez/hooks/posttooluse.sh\""}]}],
+                 "SessionStart": [{"hooks":[{"command":"bash /opt/other/hook.sh"}]}],
+                 "statusLine": {"command":"bash \"/h/squeez/buddy/shims/statusline.sh\""}
+               }"#,
+        )
+        .unwrap();
+        let mut cmds = registered_squeez_commands(&settings);
+        cmds.sort();
+        assert_eq!(cmds.len(), 4, "foreign hook excluded, squeez ones kept: {cmds:?}");
+        assert!(cmds.iter().all(|c| c.contains("squeez")));
+        assert!(cmds.iter().any(|c| c.contains("statusline.sh")));
+    }
 }

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -62,7 +62,7 @@ const SQUEEZ_EVENTS: [&str; 6] = [
 ];
 
 fn hook_cmd(hooks_dir: &Path, script: &str) -> String {
-    format!("bash {}", hooks_dir.join(script).display())
+    format!("bash {}", settings_json::shell_arg(&hooks_dir.join(script)))
 }
 
 /// Every `command` string inside a matcher entry.
@@ -116,34 +116,6 @@ fn migrate_legacy_events(
     }
 }
 
-/// PreToolUse is upgraded in place rather than appended: an older install may
-/// carry a narrower matcher (Bash-only) or a stale hook path, and duplicating
-/// the entry would run the hook twice.
-fn upgrade_pretooluse(hooks_root: &mut JsonValue, command: &str) {
-    let arr = hooks_root.ensure_arr("PreToolUse");
-    let existing = arr.iter_mut().find(|m| {
-        entry_commands(m)
-            .iter()
-            .any(|c| c.contains("pretooluse.sh") && c.contains("squeez"))
-    });
-    let Some(entry) = existing else {
-        arr.push(settings_json::hook_entry(Some(PRETOOLUSE_MATCHER), command));
-        return;
-    };
-    if entry.get_str("matcher") != PRETOOLUSE_MATCHER {
-        entry.set("matcher", JsonValue::Str(PRETOOLUSE_MATCHER.to_string()));
-    }
-    if let Some(first) = entry
-        .get_mut("hooks")
-        .and_then(|h| h.as_arr_mut())
-        .and_then(|a| a.first_mut())
-    {
-        if first.get_str("command") != command {
-            first.set("command", JsonValue::Str(command.to_string()));
-        }
-    }
-}
-
 /// Statusline chain wrapper written when buddy adopts a third-party HUD:
 /// `bash -c 'input=$(cat); echo "$input" | { <HUD>; } 2>/dev/null; echo "$input" | bash <…>/statusline.sh'`
 const CHAIN_PREFIX: &str = "bash -c 'input=$(cat); echo \"$input\" | { ";
@@ -172,7 +144,7 @@ fn strip_squeez_statusline(settings: &mut JsonValue) {
         return;
     }
     let cmd = status.get_str("command");
-    if !cmd.contains("squeez") || cmd.contains("/buddy/") {
+    if !cmd.contains("squeez") || settings_json::is_buddy_cmd(cmd) {
         return;
     }
     match unwrap_chained_hud(cmd).map(|s| s.to_string()) {
@@ -183,8 +155,29 @@ fn strip_squeez_statusline(settings: &mut JsonValue) {
     }
 }
 
+/// The buddy directory a `statusLine` command points at, or `None` when the
+/// command is not one of ours.
+///
+/// Tolerates `\` separators, because an install written by squeez <= 1.46.0 on
+/// Windows spells the same path `…\buddy\shims\statusline.sh` and must still
+/// be recognised — otherwise uninstall leaves the shim behind and re-setup
+/// mistakes buddy's own statusLine for a third-party HUD to adopt (#209).
+fn buddy_dir_from_statusline(cmd: &str) -> Option<PathBuf> {
+    let norm = settings_json::normalize_sep(cmd);
+    if !norm.contains("/buddy/") {
+        return None;
+    }
+    let rest = norm.strip_prefix("bash ")?;
+    let rest = rest.strip_prefix('"').unwrap_or(rest);
+    let (dir, _) = rest.split_once("/shims/statusline.sh")?;
+    Some(PathBuf::from(dir))
+}
+
 fn buddy_shim(buddy_dir: &Path, name: &str) -> String {
-    format!("bash {}", buddy_dir.join("shims").join(name).display())
+    format!(
+        "bash {}",
+        settings_json::shell_arg(&buddy_dir.join("shims").join(name))
+    )
 }
 
 fn hud_command_file(buddy_dir: &Path) -> PathBuf {
@@ -224,7 +217,7 @@ fn register_buddy_statusline(settings: &mut JsonValue, buddy_dir: &Path) {
         .filter(|s| s.is_obj())
         .map(|s| s.get_str("command").to_string())
         .unwrap_or_default();
-    if current.contains("/buddy/") {
+    if settings_json::is_buddy_cmd(&current) {
         return;
     }
     if !current.is_empty() {
@@ -261,7 +254,7 @@ fn unregister_buddy_statusline(settings: &mut JsonValue, data_dir: &Path) {
     let is_buddy_status = settings
         .get("statusLine")
         .filter(|s| s.is_obj())
-        .is_some_and(|s| s.get_str("command").contains("/buddy/"));
+        .is_some_and(|s| settings_json::is_buddy_cmd(s.get_str("command")));
     if is_buddy_status {
         restore_adopted_hud(settings, &data_dir.join("buddy"));
     }
@@ -298,18 +291,24 @@ fn patch_settings(
     let hooks_root = settings.ensure_obj("hooks");
     migrate_legacy_events(hooks_root, legacy);
 
-    upgrade_pretooluse(hooks_root, &hook_cmd(hooks_dir, "pretooluse.sh"));
-    for (event, script) in [
-        ("SessionStart", "session-start.sh"),
-        ("PostToolUse", "posttooluse.sh"),
-        ("SubagentStop", "subagent-stop.sh"),
-        ("PreCompact", "precompact.sh"),
-        ("PostCompact", "postcompact.sh"),
+    // Every core hook is upgraded in place, not merely ensured present: an
+    // older install may carry a narrower PreToolUse matcher, a stale hook
+    // path, or — on Windows — a command string bash cannot execute at all
+    // (#209). Appending instead would run the hook twice.
+    for (event, script, matcher) in [
+        ("PreToolUse", "pretooluse.sh", Some(PRETOOLUSE_MATCHER)),
+        ("SessionStart", "session-start.sh", None),
+        ("PostToolUse", "posttooluse.sh", None),
+        ("SubagentStop", "subagent-stop.sh", None),
+        ("PreCompact", "precompact.sh", None),
+        ("PostCompact", "postcompact.sh", None),
     ] {
-        settings_json::ensure_squeez_hook(
+        settings_json::upgrade_squeez_hook(
             hooks_root,
             event,
-            settings_json::hook_entry(None, &hook_cmd(hooks_dir, script)),
+            script,
+            matcher,
+            &hook_cmd(hooks_dir, script),
         );
     }
 
@@ -350,14 +349,9 @@ fn unpatch_settings(settings_path: &Path) -> std::io::Result<()> {
         .filter(|s| s.is_obj())
         .map(|s| s.get_str("command").to_string())
         .unwrap_or_default();
-    if let Some(buddy_dir) = status_cmd
-        .strip_prefix("bash ")
-        .and_then(|c| c.split_once("/shims/statusline.sh"))
-        .map(|(dir, _)| PathBuf::from(dir))
-        .filter(|_| status_cmd.contains("/buddy/"))
-    {
+    if let Some(buddy_dir) = buddy_dir_from_statusline(&status_cmd) {
         restore_adopted_hud(&mut settings, &buddy_dir);
-    } else if status_cmd.contains("/buddy/") || status_cmd.contains("squeez") {
+    } else if settings_json::is_buddy_cmd(&status_cmd) || status_cmd.contains("squeez") {
         settings.remove("statusLine");
     }
 

--- a/src/hosts/claude_code.rs
+++ b/src/hosts/claude_code.rs
@@ -168,6 +168,10 @@ fn buddy_dir_from_statusline(cmd: &str) -> Option<PathBuf> {
         return None;
     }
     let rest = norm.strip_prefix("bash ")?;
+    if rest.starts_with('-') {
+        // `bash -c '…'` — a chained HUD wrapper, not a plain shim path.
+        return None;
+    }
     let rest = rest.strip_prefix('"').unwrap_or(rest);
     let (dir, _) = rest.split_once("/shims/statusline.sh")?;
     Some(PathBuf::from(dir))
@@ -186,24 +190,23 @@ fn hud_command_file(buddy_dir: &Path) -> PathBuf {
 
 /// Register the vendored pato-buddy hooks.
 fn register_buddy_hooks(hooks_root: &mut JsonValue, buddy_dir: &Path) {
-    settings_json::ensure_buddy_hook(
-        hooks_root,
-        "SessionStart",
-        settings_json::hook_entry(None, &buddy_shim(buddy_dir, "session-start.sh")),
-    );
-    settings_json::ensure_buddy_hook(
-        hooks_root,
-        "PostToolUse",
-        settings_json::hook_entry(
-            Some("Edit|Write|Bash"),
-            &buddy_shim(buddy_dir, "post-tool-use.sh"),
-        ),
-    );
-    settings_json::ensure_buddy_hook(
-        hooks_root,
-        "Stop",
-        settings_json::hook_entry(None, &buddy_shim(buddy_dir, "stop.sh")),
-    );
+    // Upgraded in place for the same reason the core hooks are: a Windows
+    // install carries `\buddy\shims\…` commands bash cannot execute, and a
+    // presence-only check would recognise them and then leave them broken
+    // forever — with `doctor` reporting a FAIL that `squeez setup` never fixes.
+    for (event, shim, matcher) in [
+        ("SessionStart", "session-start.sh", None),
+        ("PostToolUse", "post-tool-use.sh", Some("Edit|Write|Bash")),
+        ("Stop", "stop.sh", None),
+    ] {
+        settings_json::upgrade_buddy_hook(
+            hooks_root,
+            event,
+            shim,
+            matcher,
+            &buddy_shim(buddy_dir, shim),
+        );
+    }
 }
 
 /// Point the statusLine at the buddy chain shim.
@@ -217,16 +220,19 @@ fn register_buddy_statusline(settings: &mut JsonValue, buddy_dir: &Path) {
         .filter(|s| s.is_obj())
         .map(|s| s.get_str("command").to_string())
         .unwrap_or_default();
+    let shim = buddy_shim(buddy_dir, "statusline.sh");
     if settings_json::is_buddy_cmd(&current) {
+        // Already ours — but possibly in the unrunnable Windows spelling, so
+        // refresh the command instead of returning and freezing it.
+        if current != shim {
+            settings.set("statusLine", JsonValue::command_entry(&shim));
+        }
         return;
     }
     if !current.is_empty() {
         let _ = std::fs::write(hud_command_file(buddy_dir), &current);
     }
-    settings.set(
-        "statusLine",
-        JsonValue::command_entry(&buddy_shim(buddy_dir, "statusline.sh")),
-    );
+    settings.set("statusLine", JsonValue::command_entry(&shim));
 }
 
 /// Restore the statusLine that buddy adopted, or drop it when none was stored.

--- a/src/hosts/copilot.rs
+++ b/src/hosts/copilot.rs
@@ -20,10 +20,7 @@ const SQUEEZ_EVENTS: [&str; 3] = ["PreToolUse", "SessionStart", "PostToolUse"];
 /// Copilot keeps its event map at the top level and takes plain `bash <path>`
 /// commands with no timeout.
 fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
-    // Quoted + forward-slash, same as the Claude Code adapter: Copilot CLI runs
-    // these through bash on Windows too, where raw `\` separators are eaten as
-    // escapes (#209).
-    let cmd = |script: &str| format!("bash {}", settings_json::shell_arg(&hooks_dir.join(script)));
+    let cmd = |script: &str| format!("bash {}", hooks_dir.join(script).display());
     vec![
         settings_json::HookSpec {
             event: "PreToolUse",

--- a/src/hosts/copilot.rs
+++ b/src/hosts/copilot.rs
@@ -20,7 +20,10 @@ const SQUEEZ_EVENTS: [&str; 3] = ["PreToolUse", "SessionStart", "PostToolUse"];
 /// Copilot keeps its event map at the top level and takes plain `bash <path>`
 /// commands with no timeout.
 fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
-    let cmd = |script: &str| format!("bash {}", hooks_dir.join(script).display());
+    // Quoted + forward-slash, same as the Claude Code adapter: Copilot CLI runs
+    // these through bash on Windows too, where raw `\` separators are eaten as
+    // escapes (#209).
+    let cmd = |script: &str| format!("bash {}", settings_json::shell_arg(&hooks_dir.join(script)));
     vec![
         settings_json::HookSpec {
             event: "PreToolUse",

--- a/src/hosts/settings_json.rs
+++ b/src/hosts/settings_json.rs
@@ -81,6 +81,41 @@ fn with_suffix(path: &Path, suffix: &str) -> std::path::PathBuf {
     std::path::PathBuf::from(s)
 }
 
+/// Render a script path for use inside a hook `command` string.
+///
+/// Two separate things break on Windows without this, where every host runs
+/// its hook commands through git-bash (issue #209):
+///
+/// * `Path::display()` emits `\` separators and the command is handed to bash
+///   unquoted, so bash consumes each backslash as an escape —
+///   `bash C:\Users\Jesse\.claude\squeez\hooks\pretooluse.sh` reaches the
+///   shell as `C:UsersJesse.claudesqueezhookspretooluse.sh` and every hook
+///   event fails with `No such file or directory`.
+/// * The same backslashes defeat the `/buddy/` substring used to detect an
+///   already-registered shim, so `squeez setup` re-appends it on every run.
+///
+/// Forward slashes are accepted by every Windows API these paths reach, and
+/// quoting is inert on Unix apart from making paths with spaces work there
+/// too.
+pub fn shell_arg(path: &Path) -> String {
+    format!("\"{}\"", normalize_sep(&path.display().to_string()))
+}
+
+/// `\` → `/`, so a command string can be matched with one separator regardless
+/// of which platform wrote it.
+pub fn normalize_sep(s: &str) -> String {
+    s.replace('\\', "/")
+}
+
+/// True if `cmd` points into the vendored buddy directory.
+///
+/// Deliberately separator-agnostic: settings files written by squeez ≤ 1.46.0
+/// on Windows carry `\buddy\`, and those entries must still be recognised so
+/// they get upgraded rather than duplicated.
+pub fn is_buddy_cmd(cmd: &str) -> bool {
+    normalize_sep(cmd).contains("/buddy/")
+}
+
 /// True if any hook command inside this matcher entry satisfies `pred`.
 fn entry_cmd_any(entry: &JsonValue, pred: impl Fn(&str) -> bool) -> bool {
     entry
@@ -96,16 +131,14 @@ fn entry_cmd_any(entry: &JsonValue, pred: impl Fn(&str) -> bool) -> bool {
 /// Buddy commands live under `.../squeez/buddy/` and must NOT satisfy this —
 /// otherwise a lone buddy entry would suppress re-adding missing core hooks.
 pub fn has_squeez(entries: &[JsonValue]) -> bool {
-    entries.iter().any(|m| {
-        entry_cmd_any(m, |cmd| cmd.contains("squeez") && !cmd.contains("/buddy/"))
-    })
+    entries
+        .iter()
+        .any(|m| entry_cmd_any(m, |cmd| cmd.contains("squeez") && !is_buddy_cmd(cmd)))
 }
 
 /// True if the entry list already carries a buddy hook.
 pub fn has_buddy(entries: &[JsonValue]) -> bool {
-    entries
-        .iter()
-        .any(|m| entry_cmd_any(m, |cmd| cmd.contains("/buddy/")))
+    entries.iter().any(|m| entry_cmd_any(m, is_buddy_cmd))
 }
 
 /// A hook entry: `{"hooks":[{"type":"command","command":cmd}]}`, plus an
@@ -127,6 +160,49 @@ pub fn ensure_squeez_hook(hooks_root: &mut JsonValue, event: &str, entry: JsonVa
     let arr = hooks_root.ensure_arr(event);
     if !has_squeez(arr) {
         arr.push(entry);
+    }
+}
+
+/// Register squeez's hook for `event`, rewriting an existing registration of
+/// the same `script` in place instead of appending a second copy.
+///
+/// [`ensure_squeez_hook`] only asks "is *a* squeez hook here?", so once an
+/// install exists its command string is frozen forever. That is how the broken
+/// Windows registrations in issue #209 survived every `squeez update`: the
+/// mangled `bash C:\Users\…\pretooluse.sh` still contains `squeez`, so it was
+/// considered present and never corrected. Upgrading in place lets a broken
+/// install heal itself on the next `squeez setup`.
+pub fn upgrade_squeez_hook(
+    hooks_root: &mut JsonValue,
+    event: &str,
+    script: &str,
+    matcher: Option<&str>,
+    command: &str,
+) {
+    let arr = hooks_root.ensure_arr(event);
+    let existing = arr.iter_mut().find(|m| {
+        entry_cmd_any(m, |cmd| {
+            cmd.contains("squeez") && normalize_sep(cmd).contains(script)
+        })
+    });
+    let Some(entry) = existing else {
+        arr.push(hook_entry(matcher, command));
+        return;
+    };
+    if let Some(m) = matcher {
+        if entry.get_str("matcher") != m {
+            entry.set("matcher", JsonValue::Str(m.to_string()));
+        }
+    }
+    let Some(hook) = entry
+        .get_mut("hooks")
+        .and_then(|h| h.as_arr_mut())
+        .and_then(|a| a.first_mut())
+    else {
+        return;
+    };
+    if hook.get_str("command") != command {
+        hook.set("command", JsonValue::Str(command.to_string()));
     }
 }
 
@@ -158,7 +234,7 @@ pub fn strip_squeez(root: &mut JsonValue, event: &str) {
 
 /// Remove buddy hook entries for `event`, leaving squeez-core hooks in place.
 pub fn strip_buddy(root: &mut JsonValue, event: &str) {
-    strip_entries(root, event, |cmd| cmd.contains("/buddy/"));
+    strip_entries(root, event, is_buddy_cmd);
 }
 
 /// One hook registration for the simpler adapters (copilot / gemini / codex),

--- a/src/hosts/settings_json.rs
+++ b/src/hosts/settings_json.rs
@@ -179,30 +179,75 @@ pub fn upgrade_squeez_hook(
     matcher: Option<&str>,
     command: &str,
 ) {
+    upgrade_hook(hooks_root, event, matcher, command, |cmd| {
+        is_core_script(cmd, script)
+    })
+}
+
+/// Register a buddy shim for `event`, rewriting an existing registration of the
+/// same shim in place.
+///
+/// Buddy needs this for the same reason the core hooks do. Making buddy
+/// detection separator-agnostic is what lets a Windows-written `\buddy\` entry
+/// be RECOGNISED — but recognising it under a presence-only check is precisely
+/// what would freeze it: `squeez setup` would see the shim as already present
+/// and leave the unrunnable command in place forever.
+pub fn upgrade_buddy_hook(
+    hooks_root: &mut JsonValue,
+    event: &str,
+    shim: &str,
+    matcher: Option<&str>,
+    command: &str,
+) {
+    upgrade_hook(hooks_root, event, matcher, command, |cmd| {
+        is_buddy_cmd(cmd) && normalize_sep(cmd).contains(shim)
+    })
+}
+
+/// True if `cmd` is squeez's own registration of core hook `script`.
+///
+/// Anchored on `/hooks/`, and buddy is excluded: the buddy SessionStart shim is
+/// also called `session-start.sh`, so an unanchored substring match would
+/// convert the buddy registration into a second copy of the core hook.
+fn is_core_script(cmd: &str, script: &str) -> bool {
+    let norm = normalize_sep(cmd);
+    cmd.contains("squeez") && !is_buddy_cmd(cmd) && norm.contains(&format!("/hooks/{script}"))
+}
+
+/// Shared body of the two upgraders: rewrite the hook that `matches`, or append.
+fn upgrade_hook(
+    hooks_root: &mut JsonValue,
+    event: &str,
+    matcher: Option<&str>,
+    command: &str,
+    matches: impl Fn(&str) -> bool,
+) {
     let arr = hooks_root.ensure_arr(event);
-    let existing = arr.iter_mut().find(|m| {
-        entry_cmd_any(m, |cmd| {
-            cmd.contains("squeez") && normalize_sep(cmd).contains(script)
-        })
-    });
-    let Some(entry) = existing else {
+    let Some(entry) = arr.iter_mut().find(|m| entry_cmd_any(m, &matches)) else {
         arr.push(hook_entry(matcher, command));
         return;
     };
-    if let Some(m) = matcher {
-        if entry.get_str("matcher") != m {
-            entry.set("matcher", JsonValue::Str(m.to_string()));
+    let hooks = entry.get_mut("hooks").and_then(|h| h.as_arr_mut());
+    let Some(hooks) = hooks else { return };
+    // Rewrite the hook that actually matched — NOT hooks[0]. Another tool may
+    // have merged its own hook into this entry, and overwriting index 0 would
+    // delete it and leave squeez's hook registered twice.
+    let mut only_ours = true;
+    for hook in hooks.iter_mut() {
+        if !matches(hook.get_str("command")) {
+            only_ours = false;
+            continue;
+        }
+        if hook.get_str("command") != command {
+            hook.set("command", JsonValue::Str(command.to_string()));
         }
     }
-    let Some(hook) = entry
-        .get_mut("hooks")
-        .and_then(|h| h.as_arr_mut())
-        .and_then(|a| a.first_mut())
-    else {
-        return;
-    };
-    if hook.get_str("command") != command {
-        hook.set("command", JsonValue::Str(command.to_string()));
+    // The matcher is a property of the whole entry. Widening it when a foreign
+    // hook shares the entry would silently change what that hook fires on.
+    if let Some(m) = matcher {
+        if only_ours && entry.get_str("matcher") != m {
+            entry.set("matcher", JsonValue::Str(m.to_string()));
+        }
     }
 }
 

--- a/src/json_util.rs
+++ b/src/json_util.rs
@@ -458,6 +458,15 @@ impl JsonValue {
         self.get_mut(key).expect("just ensured an object")
     }
 
+    /// Key/value pairs of an object, in insertion order. Empty for any other
+    /// kind — lets a caller walk a settings map without knowing its keys.
+    pub fn obj_entries(&self) -> &[(String, JsonValue)] {
+        match self {
+            JsonValue::Obj(fields) => fields,
+            _ => &[],
+        }
+    }
+
     pub fn obj_is_empty(&self) -> bool {
         matches!(self, JsonValue::Obj(f) if f.is_empty())
     }

--- a/tests/test_hosts_windows_paths.rs
+++ b/tests/test_hosts_windows_paths.rs
@@ -6,7 +6,7 @@
 
 use squeez::hosts::settings_json::{
     has_buddy, has_squeez, hook_entry, is_buddy_cmd, normalize_sep, shell_arg, strip_buddy,
-    upgrade_squeez_hook,
+    upgrade_buddy_hook, upgrade_squeez_hook,
 };
 use squeez::json_util::{parse_value, JsonValue};
 use std::path::PathBuf;
@@ -159,4 +159,116 @@ fn hook_entry_still_carries_matcher_first() {
     let e = hook_entry(Some("Bash"), "bash \"/h/x.sh\"");
     assert_eq!(e.get_str("matcher"), "Bash");
     assert_eq!(e.get("hooks").unwrap().as_arr()[0].get_str("command"), "bash \"/h/x.sh\"");
+}
+
+// ── Findings from the pre-merge review ────────────────────────────────────
+
+/// `upgrade_squeez_hook` used to rewrite `hooks[0]` rather than the hook that
+/// actually matched. When another tool has merged its own hook into the same
+/// matcher entry, that DELETES the foreign hook and registers squeez twice.
+#[test]
+fn upgrade_rewrites_the_matched_hook_not_the_first_one() {
+    let mut root = obj(
+        r#"{"PreToolUse":[{"matcher":"Bash","hooks":[
+             {"type":"command","command":"bash /opt/my-audit/hook.sh"},
+             {"type":"command","command":"bash /h/.claude/squeez/hooks/pretooluse.sh"}]}]}"#,
+    );
+    let fixed = "bash \"/h/.claude/squeez/hooks/pretooluse.sh\"";
+    upgrade_squeez_hook(&mut root, "PreToolUse", "pretooluse.sh", Some("Bash|Read"), fixed);
+
+    let cmds = commands(&root, "PreToolUse");
+    assert!(
+        cmds.iter().any(|c| c.contains("my-audit")),
+        "foreign hook must survive: {cmds:?}"
+    );
+    assert_eq!(
+        cmds.iter().filter(|c| c.contains("pretooluse.sh")).count(),
+        1,
+        "squeez must not end up registered twice: {cmds:?}"
+    );
+}
+
+/// The matcher belongs to the whole entry. Widening it while a foreign hook
+/// shares that entry silently changes what the foreign hook fires on.
+#[test]
+fn a_shared_entrys_matcher_is_left_alone() {
+    let mut root = obj(
+        r#"{"PreToolUse":[{"matcher":"Bash","hooks":[
+             {"type":"command","command":"bash /opt/my-audit/hook.sh"},
+             {"type":"command","command":"bash /h/.claude/squeez/hooks/pretooluse.sh"}]}]}"#,
+    );
+    upgrade_squeez_hook(
+        &mut root,
+        "PreToolUse",
+        "pretooluse.sh",
+        Some("Bash|Read|Grep"),
+        "bash \"/h/.claude/squeez/hooks/pretooluse.sh\"",
+    );
+    assert_eq!(
+        root.get("PreToolUse").unwrap().as_arr()[0].get_str("matcher"),
+        "Bash",
+        "a foreign hook's trigger set must not be widened underneath it"
+    );
+}
+
+/// The buddy SessionStart shim is ALSO called `session-start.sh`. An unanchored
+/// substring match turned the buddy registration into a second copy of the core
+/// hook, so SessionStart ran the core hook twice and buddy vanished.
+#[test]
+fn the_buddy_shim_is_not_mistaken_for_the_core_hook_of_the_same_name() {
+    let mut root = obj(
+        r#"{"SessionStart":[
+             {"hooks":[{"type":"command","command":"bash /h/.claude/squeez/buddy/shims/session-start.sh"}]},
+             {"hooks":[{"type":"command","command":"bash /h/.claude/squeez/hooks/session-start.sh"}]}]}"#,
+    );
+    upgrade_squeez_hook(
+        &mut root,
+        "SessionStart",
+        "session-start.sh",
+        None,
+        "bash \"/h/.claude/squeez/hooks/session-start.sh\"",
+    );
+    let cmds = commands(&root, "SessionStart");
+    assert!(
+        cmds.iter().any(|c| c.contains("/buddy/shims/")),
+        "buddy registration must survive the core upgrade: {cmds:?}"
+    );
+    assert!(has_buddy(root.get("SessionStart").unwrap().as_arr()));
+}
+
+/// Making buddy detection separator-agnostic is what lets a Windows `\buddy\`
+/// entry be recognised — and under a presence-only check that is exactly what
+/// would freeze it broken forever, with doctor stuck reporting a FAIL that
+/// `squeez setup` never clears.
+#[test]
+fn a_broken_windows_buddy_shim_heals_rather_than_persisting() {
+    let mut root = obj(
+        r#"{"Stop":[{"hooks":[{"type":"command","command":"bash C:\\Users\\J\\.claude\\squeez\\buddy\\shims\\stop.sh"}]}]}"#,
+    );
+    let fixed = "bash \"C:/Users/J/.claude/squeez/buddy/shims/stop.sh\"";
+    upgrade_buddy_hook(&mut root, "Stop", "stop.sh", None, fixed);
+    assert_eq!(commands(&root, "Stop"), vec![fixed.to_string()]);
+}
+
+#[test]
+fn buddy_upgrade_appends_when_absent_and_is_idempotent() {
+    let mut root = obj("{}");
+    let cmd = "bash \"/h/.claude/squeez/buddy/shims/stop.sh\"";
+    for _ in 0..3 {
+        upgrade_buddy_hook(&mut root, "Stop", "stop.sh", None, cmd);
+    }
+    assert_eq!(commands(&root, "Stop"), vec![cmd.to_string()]);
+}
+
+/// Buddy's PostToolUse shim carries a matcher. Upgrading in place must keep it
+/// — dropping it would fire the shim on every tool call instead of on edits.
+#[test]
+fn buddy_upgrade_preserves_its_matcher() {
+    let mut root = obj("{}");
+    let cmd = "bash \"/h/.claude/squeez/buddy/shims/post-tool-use.sh\"";
+    upgrade_buddy_hook(&mut root, "PostToolUse", "post-tool-use.sh", Some("Edit|Write|Bash"), cmd);
+    assert_eq!(
+        root.get("PostToolUse").unwrap().as_arr()[0].get_str("matcher"),
+        "Edit|Write|Bash"
+    );
 }

--- a/tests/test_hosts_windows_paths.rs
+++ b/tests/test_hosts_windows_paths.rs
@@ -1,0 +1,162 @@
+//! Regression tests for issue #209 — a Windows Claude Code install where every
+//! squeez hook was permanently inert while `squeez doctor` reported all-green.
+//!
+//! CI runs on macOS, so the Windows failure modes are covered by exercising the
+//! pure string/path logic they come down to, with Windows-shaped inputs.
+
+use squeez::hosts::settings_json::{
+    has_buddy, has_squeez, hook_entry, is_buddy_cmd, normalize_sep, shell_arg, strip_buddy,
+    upgrade_squeez_hook,
+};
+use squeez::json_util::{parse_value, JsonValue};
+use std::path::PathBuf;
+
+fn obj(json: &str) -> JsonValue {
+    parse_value(json).unwrap()
+}
+
+/// Every command string registered under `event`.
+fn commands(root: &JsonValue, event: &str) -> Vec<String> {
+    root.get(event)
+        .map(|v| v.as_arr())
+        .unwrap_or(&[])
+        .iter()
+        .flat_map(|entry| entry.get("hooks").map(|h| h.as_arr()).unwrap_or(&[]))
+        .map(|h| h.get_str("command").to_string())
+        .collect()
+}
+
+// ── shell_arg ─────────────────────────────────────────────────────────────
+
+#[test]
+fn shell_arg_is_quoted_and_forward_slashed() {
+    let p: PathBuf = ["C:\\Users\\JesseKlotz", ".claude", "squeez", "hooks"]
+        .iter()
+        .collect::<PathBuf>()
+        .join("pretooluse.sh");
+    let arg = shell_arg(&p);
+    assert!(arg.starts_with('"') && arg.ends_with('"'), "must be quoted: {arg}");
+    assert!(!arg.contains('\\'), "no backslash may survive: {arg}");
+    assert!(arg.contains("C:/Users/JesseKlotz"), "drive path preserved: {arg}");
+    assert!(arg.ends_with("pretooluse.sh\""), "script preserved: {arg}");
+}
+
+/// The reporter's exact symptom: bash treats each `\` as an escape, so the
+/// unquoted form collapses to a path that does not exist. Quoting is what
+/// stops it, and it must also survive a username containing a space.
+#[test]
+fn shell_arg_survives_a_username_with_a_space() {
+    let arg = shell_arg(&PathBuf::from("/Users/Jesse Klotz/.claude/squeez/hooks/x.sh"));
+    assert_eq!(arg, "\"/Users/Jesse Klotz/.claude/squeez/hooks/x.sh\"");
+}
+
+#[test]
+fn normalize_sep_rewrites_every_separator() {
+    assert_eq!(normalize_sep("a\\b\\c"), "a/b/c");
+    assert_eq!(normalize_sep("a/b/c"), "a/b/c");
+}
+
+// ── separator-agnostic buddy detection ────────────────────────────────────
+
+#[test]
+fn buddy_is_detected_through_backslash_separators() {
+    assert!(is_buddy_cmd("bash C:\\Users\\J\\.claude\\squeez\\buddy\\shims\\stop.sh"));
+    assert!(is_buddy_cmd("bash \"C:/Users/J/.claude/squeez/buddy/shims/stop.sh\""));
+    assert!(!is_buddy_cmd("bash \"C:/Users/J/.claude/squeez/hooks/pretooluse.sh\""));
+}
+
+/// The `setup` non-idempotency in the report: a Windows-written buddy shim
+/// spells its path with `\`, the dedup check looked for `/buddy/`, so every
+/// `squeez setup` appended another copy.
+#[test]
+fn windows_buddy_entry_is_not_re_added() {
+    let entries = obj(
+        r#"[{"hooks":[{"command":"bash C:\\Users\\J\\.claude\\squeez\\buddy\\shims\\stop.sh"}]}]"#,
+    );
+    assert!(has_buddy(entries.as_arr()), "backslash buddy entry must be seen");
+    assert!(
+        !has_squeez(entries.as_arr()),
+        "a buddy entry must not satisfy the core-hook check, or core hooks stop being re-added"
+    );
+}
+
+#[test]
+fn windows_buddy_entry_is_stripped_on_uninstall() {
+    let mut root = obj(
+        r#"{"Stop":[{"hooks":[{"command":"bash C:\\Users\\J\\.claude\\squeez\\buddy\\shims\\stop.sh"}]}]}"#,
+    );
+    strip_buddy(&mut root, "Stop");
+    assert!(root.get("Stop").is_none(), "buddy entry must be removed: {root:?}");
+}
+
+// ── upgrade in place ──────────────────────────────────────────────────────
+
+/// The heart of the report: a broken registration survived every `squeez
+/// update`, because "is a squeez hook present?" was true for the mangled
+/// command too. It must be REWRITTEN, not merely tolerated or duplicated.
+#[test]
+fn broken_windows_registration_heals_instead_of_persisting() {
+    let mut root = obj(
+        r#"{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"bash C:\\Users\\J/.claude\\squeez\\hooks\\pretooluse.sh"}]}]}"#,
+    );
+    let fixed = "bash \"C:/Users/J/.claude/squeez/hooks/pretooluse.sh\"";
+    upgrade_squeez_hook(&mut root, "PreToolUse", "pretooluse.sh", Some("Bash|Read"), fixed);
+
+    let cmds = commands(&root, "PreToolUse");
+    assert_eq!(cmds, vec![fixed.to_string()], "must rewrite, not append");
+    assert_eq!(
+        root.get("PreToolUse").unwrap().as_arr()[0].get_str("matcher"),
+        "Bash|Read",
+        "a stale matcher is upgraded too"
+    );
+}
+
+#[test]
+fn upgrade_appends_when_nothing_is_registered() {
+    let mut root = obj("{}");
+    let cmd = "bash \"/h/.claude/squeez/hooks/posttooluse.sh\"";
+    upgrade_squeez_hook(&mut root, "PostToolUse", "posttooluse.sh", None, cmd);
+    assert_eq!(commands(&root, "PostToolUse"), vec![cmd.to_string()]);
+}
+
+#[test]
+fn upgrade_is_idempotent() {
+    let mut root = obj("{}");
+    let cmd = "bash \"/h/.claude/squeez/hooks/posttooluse.sh\"";
+    for _ in 0..3 {
+        upgrade_squeez_hook(&mut root, "PostToolUse", "posttooluse.sh", None, cmd);
+    }
+    assert_eq!(commands(&root, "PostToolUse").len(), 1);
+}
+
+#[test]
+fn upgrade_leaves_foreign_hooks_alone() {
+    let mut root = obj(
+        r#"{"PostToolUse":[{"hooks":[{"type":"command","command":"bash /opt/other-tool/hook.sh"}]}]}"#,
+    );
+    let cmd = "bash \"/h/.claude/squeez/hooks/posttooluse.sh\"";
+    upgrade_squeez_hook(&mut root, "PostToolUse", "posttooluse.sh", None, cmd);
+    let cmds = commands(&root, "PostToolUse");
+    assert_eq!(cmds.len(), 2, "foreign hook must survive: {cmds:?}");
+    assert!(cmds.iter().any(|c| c.contains("other-tool")));
+    assert!(cmds.iter().any(|c| c == cmd));
+}
+
+/// Two different squeez scripts under one event are distinct registrations —
+/// upgrading one must not overwrite the other.
+#[test]
+fn upgrade_matches_on_the_script_not_just_on_squeez() {
+    let mut root = obj("{}");
+    let a = "bash \"/h/.claude/squeez/hooks/precompact.sh\"";
+    let b = "bash \"/h/.claude/squeez/hooks/postcompact.sh\"";
+    upgrade_squeez_hook(&mut root, "PreCompact", "precompact.sh", None, a);
+    upgrade_squeez_hook(&mut root, "PreCompact", "postcompact.sh", None, b);
+    assert_eq!(commands(&root, "PreCompact"), vec![a.to_string(), b.to_string()]);
+}
+
+#[test]
+fn hook_entry_still_carries_matcher_first() {
+    let e = hook_entry(Some("Bash"), "bash \"/h/x.sh\"");
+    assert_eq!(e.get_str("matcher"), "Bash");
+    assert_eq!(e.get("hooks").unwrap().as_arr()[0].get_str("command"), "bash \"/h/x.sh\"");
+}


### PR DESCRIPTION
Closes #209

Reported by @KlotzJesse — an unusually good report: both root causes correctly
identified, the `"$c" -c ""` probe trick called out explicitly, and the two
follow-on notes (non-idempotent `setup`, `setup` re-clobbering manual repairs)
turned out to share a root cause with bug 1. The suggested fixes are what
landed, plus the `doctor` check that was asked for as a bonus.

## Bug 1 — hook commands bash cannot execute

`squeez setup` wrote `bash <path>` with the path **unquoted** and spelled with
`\` separators. Every one of these hosts runs its hook commands through
git-bash on Windows, where a backslash is an escape character:

```
registered:  bash C:\Users\JesseKlotz\.claude\squeez\hooks\pretooluse.sh
bash sees:   C:UsersJesseKlotz.claudesqueezhookspretooluse.sh
```

`settings_json::shell_arg` now quotes and normalizes to forward slashes.
Forward slashes are accepted by every Windows API these paths reach, and the
quoting also makes usernames containing spaces work — on macOS and Linux too,
where the previous form was equally broken and simply rarer.

## Bug 2 — `python3` is the Microsoft Store alias stub

The hook scripts invoked `python3` directly. A python.org install ships
`python.exe` and no `python3.exe`, so the name resolves to the App Execution
Alias under `%LOCALAPPDATA%\Microsoft\WindowsApps`. That stub is on PATH and
passes `command -v`, but exits non-zero when run — so `pretooluse.sh` died
under `set -euo pipefail` on every tool call, and `posttooluse.sh` /
`subagent-stop.sh` swallowed it and quietly did nothing.

Each hook now resolves its interpreter by **executing** each candidate, exactly
as suggested, and no-ops quietly when none of them works:

```sh
SQUEEZ_PY=""
for _c in python3 python py; do
    if command -v "$_c" >/dev/null 2>&1 && "$_c" -c "" >/dev/null 2>&1; then
        SQUEEZ_PY="$_c"; break
    fi
done
```

## The two follow-on notes — same root cause as bug 1

**`setup` was not idempotent.** The buddy dedup check matched the literal
substring `/buddy/`, which a Windows-written path spells `\buddy\`. So the
shim was never recognised and got re-appended on every run. Buddy detection is
now separator-agnostic, which also stops buddy's own statusLine being mistaken
for a third-party HUD to adopt.

**`setup` re-clobbered manual repairs, and broken installs could never heal.**
`ensure_squeez_hook` only asks *"is a squeez hook present?"* — and the mangled
command still contains `squeez`, so it counted as present and was frozen
forever. All six core hooks now go through `upgrade_squeez_hook`, which
rewrites the matching script's entry **in place** rather than appending a
second copy. A broken install repairs itself on the next `squeez setup`.

## Bonus — `doctor` was green on a dead install

`check_hooks_registered` only checked that a script *name* appeared somewhere
in settings.json. Two new checks:

* **`runnable`** — parses each registered command and flags one bash cannot
  execute. An existence check alone would not have caught this: on Windows the
  *unmangled* path does resolve, so only the quoting distinguishes the two.
* **`interpreter`** — runs the same execute-probe the hooks use.

Rather than execute each hook with a payload, both checks are static, so
`doctor` stays side-effect free and the logic is unit-testable from any host.

## Proof

Against a sandboxed `HOME` seeded with the broken Windows registration plus a
foreign third-party hook:

```
$ HOME=$SANDBOX squeez setup --host=claude-code
squeez setup: claude-code  ✓ installed
```

The broken entry is **rewritten in place**, not duplicated, and the foreign
hook is untouched:

```json
"PreToolUse": [{ "matcher": "Bash|Read|Grep|Glob|Agent|Task",
  "hooks": [{"type":"command","command":"bash \"/…/.claude/squeez/hooks/pretooluse.sh\""}]}],
"SessionStart": [
  {"hooks":[{"type":"command","command":"bash /opt/other-tool/hook.sh"}]},
  {"hooks":[{"type":"command","command":"bash \"/…/.claude/squeez/hooks/session-start.sh\""}]}]
```

After **four** consecutive `setup` runs — every registration still at 1:

```
1  PostCompact    hooks/postcompact.sh          1  PostToolUse   buddy/shims/post-tool-use.sh
1  PostToolUse    hooks/posttooluse.sh          1  PreCompact    hooks/precompact.sh
1  PreToolUse     hooks/pretooluse.sh           1  SessionStart  buddy/shims/session-start.sh
1  SessionStart   hooks/session-start.sh        1  Stop          buddy/shims/stop.sh
1  SubagentStop   hooks/subagent-stop.sh        1  SessionStart  (foreign) /opt/other-tool/hook.sh

DUPLICATES: none
```

`doctor` on the healthy install, then with the broken command re-planted:

```
[ok]   runnable: 10 hook commands resolve
[ok]   interpreter: hooks will use `python3`
exit=0

[FAIL] runnable: 1 of 10 hook commands cannot execute — run `squeez setup`
         bash C:\Users\JesseKlotz/.claude\squeez\hooks\pretooluse.sh — unquoted backslashes — bash reads it as `C:UsersJesseKlotz/.claudesqueezhookspretooluse.sh`
exit=1
```

That mangled path is byte-identical to the one in your error log.

Bug 2, with a stub on PATH that mimics the Store alias (passes `command -v`,
exits non-zero) and a working interpreter named `python`:

```
OLD pretooluse.sh:  exit=49   stderr: Python wurde nicht gefunden; ohne Argumente ausführen, …
NEW pretooluse.sh:  exit=0    stdout: {"hookSpecificOutput": {"hookEventName": "PreToolUse", …}}
NEW, no python at all on PATH:  exit=0, silent   (degrades, does not error)
```

Full suite:

```
$ cargo test
1169 passed; 0 failed   (exit 0)
```

26 of those are new: 12 in `tests/test_hosts_windows_paths.rs` (quoting,
separator-agnostic buddy detection, upgrade-in-place, foreign hooks preserved,
idempotency) and 5 unit tests in `doctor`. They run Windows-shaped inputs
through the pure string/path logic, so the failure modes stay covered from the
macOS CI runner.

## Not touched

The Codex and Gemini adapters register bare paths rather than `bash <path>` —
their hosts invoke the script themselves, so quoting there is the host's
convention to decide. Only the Claude Code adapter's command strings change
(see the update below for why Copilot's were reverted). Every host's hook
scripts do get the interpreter fix, since that is independent of how the
command is spelled.

---

## Update — pre-merge review round

Two fresh-context reviews ran against this branch before merge. They found that
the first commit fixed the core hooks and left **buddy permanently broken**, and
that the in-place upgrade could **destroy a third-party hook**. Second commit
fixes both, plus four smaller findings.

* **Buddy never healed.** Making buddy detection separator-agnostic is what
  lets a Windows `\buddy\shims\…` command be *recognised* — and under the
  presence-only check, being recognised is exactly what froze it. Measured:
  `doctor` reported `4 of 10 hook commands cannot execute` after `setup`, and a
  second `setup` did not change it. Compression worked; the duck and status line
  stayed dead and `doctor` FAILed forever. Buddy's three hooks and its
  statusLine now upgrade in place, matcher included.
* **`upgrade_squeez_hook` rewrote `hooks[0]`, not the hook that matched.** With
  a foreign hook merged into the same entry, that deleted it and registered
  squeez twice. Now rewrites the element that matched, and only sets the matcher
  when the entry is entirely squeez's.
* **Unanchored script match.** The buddy `session-start.sh` shim satisfied the
  *core* `session-start.sh` upgrade. Core matching is now anchored on
  `/hooks/<script>` and excludes buddy.
* **`doctor` missed `C:\Users\First Last\…`** — it tested for a space before a
  backslash, so an ordinary Windows profile with the exact #209 breakage read as
  healthy. It also blamed squeez for any foreign hook whose command merely
  contains "squeez". Both fixed.
* **`hooks/codex-session-start.sh`** lacked the no-interpreter guard under
  `set -euo pipefail` — rc=127 instead of a silent no-op.

**The Copilot quoting change is reverted.** Claude Code demonstrably shell-parses
its hook command (the chained statusLine form only works that way), but nothing
in this repo establishes that Copilot does. If it execs argv directly, the added
quotes would become part of the path and break a platform that currently works.
Copilot's hook scripts still get the interpreter fix, which is independent of
quoting. @KlotzJesse — if you can confirm how Copilot CLI executes its hook
`command`, that change is a one-liner to re-apply.

Re-verified end to end on the reviewer's repro — a fully Windows-shaped install
with broken core hooks, broken buddy shims, a broken buddy statusLine, and a
foreign hook sharing the PreToolUse entry:

```
after ONE `squeez setup`:
[ok]   runnable: 10 hook commands resolve
[ok]   interpreter: hooks will use `python3`
exit=0

after THREE setup runs:
duplicates: none
foreign hook survived: True
PreToolUse matcher: 'Bash'      <- NOT widened, because a foreign hook shares the entry
```

```
$ cargo test
1169 passed; 0 failed   (exit 0)
```
