### PR TITLE
fix(wrap,hermes): use bash on Windows and honor HERMES_HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test
+      # CI runs on macOS, so the #[cfg(windows)] blocks are otherwise only
+      # compiled at release-tag time. Two of the bugs this project has shipped
+      # (#209, #208) lived in exactly that code. `check` does not link, so a
+      # cross-target check is enough to keep it compiling.
+      - name: Type-check the Windows-only code paths
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          cargo check --target x86_64-pc-windows-msvc --all-targets
       - name: Run buddy (vendored pato-buddy) tests
         run: node --test assets/buddy/test/*.test.js
       - name: Build release binary

--- a/README.md
+++ b/README.md
@@ -345,10 +345,14 @@ Runs a command, compresses its output, and prints a savings header:
 ```
 
 `wrap` re-executes the command through a shell: `sh -c` on Unix, and on
-Windows `bash -c` when bash is on `PATH` — every agent host writes its terminal
-commands for bash there, so re-running them under `cmd.exe` corrupts quoting,
-`$(…)`, backticks and `;`. `cmd /C` remains the fallback when no POSIX shell is
-present. Set `SQUEEZ_SHELL` to force a specific shell:
+Windows `bash -c`, then `sh -c`, when one of them resolves on `PATH` — every
+agent host writes its terminal commands for bash there, so re-running them
+under `cmd.exe` corrupts quoting, `$(…)`, backticks and `;`. `cmd /C` remains
+the fallback when no POSIX shell is present, and is also retried automatically
+if the preferred shell cannot be spawned. `%SystemRoot%\System32\bash.exe` is
+skipped: that is the WSL launcher, which would run the command inside a Linux
+distro rather than against the host filesystem. `CLAUDE_CODE_GIT_BASH_PATH` is
+honoured when set. Set `SQUEEZ_SHELL` to force a specific shell:
 
 ```bash
 SQUEEZ_SHELL="C:/Program Files/Git/bin/bash.exe" squeez wrap 'ls -la'
@@ -641,8 +645,9 @@ Plugin installed at `~/.config/opencode/plugins/squeez.js`. OpenCode auto-loads 
 ### Hermes
 
 Directory plugin installed at `$HERMES_HOME/plugins/squeez-fallback/` —
-`~/.hermes/plugins/` when `HERMES_HOME` is unset. Set `HERMES_HOME` if Hermes
-lives elsewhere (e.g. `%LOCALAPPDATA%\hermes` on Windows), otherwise
+`~/.hermes/plugins/` when `HERMES_HOME` is unset (a leading `~` is expanded).
+Set `HERMES_HOME` if Hermes lives elsewhere (e.g. `%LOCALAPPDATA%\hermes` on
+Windows), otherwise
 `squeez setup --host=hermes` will not detect it. Directory plugins are opt-in;
 enable it once with `hermes plugins enable squeez-fallback`.
 

--- a/README.md
+++ b/README.md
@@ -344,6 +344,16 @@ Runs a command, compresses its output, and prints a savings header:
 # squeez [git log] 2692→289 tokens (-89%) 0.2ms [adaptive: Ultra]
 ```
 
+`wrap` re-executes the command through a shell: `sh -c` on Unix, and on
+Windows `bash -c` when bash is on `PATH` — every agent host writes its terminal
+commands for bash there, so re-running them under `cmd.exe` corrupts quoting,
+`$(…)`, backticks and `;`. `cmd /C` remains the fallback when no POSIX shell is
+present. Set `SQUEEZ_SHELL` to force a specific shell:
+
+```bash
+SQUEEZ_SHELL="C:/Program Files/Git/bin/bash.exe" squeez wrap 'ls -la'
+```
+
 ### `squeez filter`
 
 Reads from stdin. Use for manual pipelines:
@@ -627,6 +637,14 @@ tail_preserved=20
 ### OpenCode
 
 Plugin installed at `~/.config/opencode/plugins/squeez.js`. OpenCode auto-loads plugins on startup. All Bash commands are automatically compressed via `squeez wrap`.
+
+### Hermes
+
+Directory plugin installed at `$HERMES_HOME/plugins/squeez-fallback/` —
+`~/.hermes/plugins/` when `HERMES_HOME` is unset. Set `HERMES_HOME` if Hermes
+lives elsewhere (e.g. `%LOCALAPPDATA%\hermes` on Windows), otherwise
+`squeez setup --host=hermes` will not detect it. Directory plugins are opt-in;
+enable it once with `hermes plugins enable squeez-fallback`.
 
 ### GitHub Copilot CLI
 

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,7 +1,8 @@
 """Hermes plugin adapter for squeez fallback compression.
 
 When installed via `squeez setup --host=hermes`, this plugin is dropped into
-~/.hermes/plugins/squeez-fallback/__init__.py. Hermes auto-discovers plugins
+$HERMES_HOME/plugins/squeez-fallback/__init__.py, defaulting to ~/.hermes when
+that variable is unset. Hermes auto-discovers plugins
 on session start — no config file patching needed.
 
 The plugin hooks pre_tool_call and wraps unrecognized terminal commands

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -3,6 +3,7 @@ use crate::context;
 use crate::filter;
 use crate::{json_util, session};
 use std::io::Read;
+use std::path::Path;
 use std::process::{Command, Stdio};
 #[cfg(unix)]
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -29,7 +30,7 @@ static CHILD_PID: AtomicI32 = AtomicI32::new(-1);
 fn shell_choice(
     shell_override: Option<String>,
     windows: bool,
-    on_path: impl Fn(&str) -> bool,
+    resolve: impl Fn(&str) -> Option<String>,
 ) -> (String, &'static str) {
     if let Some(shell) = shell_override.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
         let flag = if is_cmd_shell(&shell) { "/C" } else { "-c" };
@@ -39,11 +40,61 @@ fn shell_choice(
         return ("sh".to_string(), "-c");
     }
     for candidate in ["bash", "sh"] {
-        if on_path(candidate) {
-            return (candidate.to_string(), "-c");
+        if let Some(program) = resolve(candidate) {
+            return (program, "-c");
         }
     }
     ("cmd".to_string(), "/C")
+}
+
+/// `%SystemRoot%\System32\bash.exe` is the WSL launcher, not a POSIX shell for
+/// this filesystem: it runs the command inside a Linux distro where the host's
+/// drive paths and toolchain do not exist, and it errors outright when WSL is
+/// enabled with no distro installed. It also normally precedes git-bash on
+/// PATH, so picking the first `bash.exe` found would reintroduce exactly the
+/// silent-wrong-output class this change exists to remove.
+#[cfg_attr(not(windows), allow(dead_code))] // reached via resolve_shell_program on Windows; tested everywhere
+fn is_wsl_launcher(path: &str) -> bool {
+    let p = path.replace('\\', "/").to_ascii_lowercase();
+    p.ends_with("/system32/bash.exe") || p.ends_with("/sysnative/bash.exe")
+}
+
+/// First directory in `dirs` holding an executable `program`, as an absolute
+/// path. Kept pure so the Windows rules are testable from any host.
+///
+/// Two rules earn their place. Relative entries are skipped: `split_paths`
+/// yields an empty `PathBuf` for the empty segment a trailing `;` leaves
+/// behind, and joining onto it produces a RELATIVE path — which would test the
+/// agent's current repo for a file named `bash.exe`. And the resolved absolute
+/// path is returned rather than a bool, so the shell that gets spawned is the
+/// same file the probe approved.
+/// True if `dir` is anchored rather than relative to the process's current
+/// directory: POSIX-rooted, UNC/`\`-rooted, or drive-qualified.
+///
+/// `Path::is_absolute` cannot be used here — it answers for the HOST platform,
+/// so `C:/Windows` is "relative" when the check runs on Unix, which makes the
+/// Windows rules impossible to test from CI.
+#[cfg_attr(not(windows), allow(dead_code))] // reached via resolve_shell_program on Windows; tested everywhere
+fn is_rooted(dir: &str) -> bool {
+    let mut chars = dir.chars();
+    match (chars.next(), chars.next()) {
+        (Some('/'), _) | (Some('\\'), _) => true,
+        (Some(c), Some(':')) => c.is_ascii_alphabetic(),
+        _ => false,
+    }
+}
+
+#[cfg_attr(not(windows), allow(dead_code))] // reached via resolve_shell_program on Windows; tested everywhere
+fn pick_program(
+    dirs: impl Iterator<Item = std::path::PathBuf>,
+    program: &str,
+    is_file: impl Fn(&Path) -> bool,
+) -> Option<String> {
+    dirs.filter(|d| is_rooted(&d.display().to_string()))
+        .map(|d| d.join(program))
+        .map(|p| p.display().to_string())
+        .filter(|p| !is_wsl_launcher(p))
+        .find(|p| is_file(Path::new(p)))
 }
 
 /// `cmd.exe` is the only shell squeez drives with `/C`; everything else
@@ -57,21 +108,32 @@ fn is_cmd_shell(shell: &str) -> bool {
     base == "cmd" || base == "cmd.exe"
 }
 
-/// True if `program` is an executable on PATH. Only consulted on Windows, and
-/// only once per process — see [`resolved_shell`].
+/// Resolve a shell to an absolute path. Only consulted on Windows, and only
+/// once per process — see [`resolved_shell`].
+///
+/// `CLAUDE_CODE_GIT_BASH_PATH` is honoured first: when the host has already
+/// been told where git-bash lives, that is a better answer than any PATH scan.
 #[cfg(windows)]
-fn program_on_path(program: &str) -> bool {
-    let Some(paths) = std::env::var_os("PATH") else {
-        return false;
-    };
-    std::env::split_paths(&paths).any(|dir| {
-        dir.join(format!("{program}.exe")).is_file() || dir.join(program).is_file()
-    })
+fn resolve_shell_program(program: &str) -> Option<String> {
+    if program == "bash" {
+        if let Some(hinted) = std::env::var_os("CLAUDE_CODE_GIT_BASH_PATH") {
+            let p = std::path::PathBuf::from(hinted);
+            if p.is_file() {
+                return Some(p.display().to_string());
+            }
+        }
+    }
+    let paths = std::env::var_os("PATH")?;
+    // Only `.exe` — `Command::new` appends `.exe` to an extensionless program
+    // name on Windows, so an extensionless match would pass the probe and then
+    // fail to spawn.
+    let exe = format!("{program}.exe");
+    pick_program(std::env::split_paths(&paths), &exe, |p| p.is_file())
 }
 
 #[cfg(not(windows))]
-fn program_on_path(_program: &str) -> bool {
-    false
+fn resolve_shell_program(_program: &str) -> Option<String> {
+    None
 }
 
 /// `wrap` runs on every Bash tool call, so the PATH scan is done once.
@@ -81,20 +143,30 @@ fn resolved_shell() -> &'static (String, &'static str) {
         shell_choice(
             std::env::var("SQUEEZ_SHELL").ok(),
             cfg!(windows),
-            program_on_path,
+            resolve_shell_program,
         )
     })
 }
 
-/// Returns a `Command` pre-configured to run `cmd` through the shell.
-/// Unix: `sh -c <cmd>`. Windows: `bash -c <cmd>` when bash is on PATH (the
-/// de-facto agent shell there), otherwise `cmd /C <cmd>`. `SQUEEZ_SHELL`
-/// overrides the choice on every platform.
-fn shell_command(cmd: &str) -> Command {
+/// The shells `wrap` will try, in order.
+///
+/// Unix: `sh -c <cmd>`. Windows: `bash -c <cmd>` when a non-WSL bash resolves
+/// (the de-facto agent shell there), then `sh`, otherwise `cmd /C <cmd>`.
+/// `SQUEEZ_SHELL` overrides the choice on every platform.
+///
+/// The second entry exists only on Windows, and only when the first choice is
+/// not already `cmd`. Before this change Windows always used `cmd`, which is
+/// effectively guaranteed to be present; now that a POSIX shell is preferred,
+/// a shell that resolves but cannot be spawned would turn every wrapped tool
+/// call into an empty exit-1. Falling back keeps the call working — a spawn
+/// failure means nothing ran, so retrying cannot execute anything twice.
+fn shell_candidates() -> Vec<(String, &'static str)> {
     let (program, flag) = resolved_shell();
-    let mut c = Command::new(program);
-    c.args([flag, cmd]);
-    c
+    let mut out = vec![(program.clone(), *flag)];
+    if cfg!(windows) && !is_cmd_shell(program) {
+        out.push(("cmd".to_string(), "/C"));
+    }
+    out
 }
 
 /// Result of spawning and fully draining one command. `Fatal` carries the
@@ -113,22 +185,34 @@ enum SpawnOutcome {
 /// flag-forcing (E3) can call it a second time for the one-shot un-forced
 /// fallback without duplicating the spawn/drain/timeout logic.
 fn spawn_and_capture(cmd_str: &str, env_vars: &[(&str, &str)], timeout_secs: u64) -> SpawnOutcome {
-    let mut cmd = shell_command(cmd_str);
-    for (k, v) in env_vars {
-        cmd.env(k, v);
-    }
-    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        cmd.process_group(0);
-    }
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("squeez: {}", e);
-            return SpawnOutcome::Fatal(1);
+    let mut spawned = None;
+    let mut spawn_err = None;
+    for (program, flag) in shell_candidates() {
+        let mut cmd = Command::new(&program);
+        cmd.args([flag, cmd_str]);
+        for (k, v) in env_vars {
+            cmd.env(k, v);
         }
+        cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0);
+        }
+        match cmd.spawn() {
+            Ok(c) => {
+                spawned = Some(c);
+                break;
+            }
+            Err(e) => spawn_err = Some(format!("{program}: {e}")),
+        }
+    }
+    let Some(mut child) = spawned else {
+        eprintln!(
+            "squeez: {}",
+            spawn_err.unwrap_or_else(|| "no usable shell".to_string())
+        );
+        return SpawnOutcome::Fatal(1);
     };
 
     // Store PID for signal forwarding (Unix only)
@@ -804,13 +888,18 @@ fn retrieve_marker_text(orig_line_count: usize, id: &str) -> String {
 }
 
 fn passthrough(cmd: &str) -> i32 {
-    let status = shell_command(cmd)
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("squeez: {}", e);
-            std::process::exit(1);
-        });
-    status.code().unwrap_or(1)
+    let mut last_err = None;
+    for (program, flag) in shell_candidates() {
+        match Command::new(&program).args([flag, cmd]).status() {
+            Ok(status) => return status.code().unwrap_or(1),
+            Err(e) => last_err = Some(format!("{program}: {e}")),
+        }
+    }
+    eprintln!(
+        "squeez: {}",
+        last_err.unwrap_or_else(|| "no usable shell".to_string())
+    );
+    std::process::exit(1);
 }
 
 fn is_streaming(cmd: &str) -> bool {
@@ -1054,16 +1143,20 @@ fn record_bash_event(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_cmd_shell, is_net_loss, retrieve_marker_text, shell_choice};
+    use super::{
+        is_cmd_shell, is_net_loss, is_rooted, is_wsl_launcher, pick_program,
+        retrieve_marker_text, shell_choice,
+    };
+    use std::path::{Path, PathBuf};
 
     /// Nothing is on PATH — the bare-Windows case.
-    fn nothing(_: &str) -> bool {
-        false
+    fn nothing(_: &str) -> Option<String> {
+        None
     }
     /// git-bash is installed, which is the normal state on any machine running
     /// one of these agent CLIs on Windows.
-    fn has_bash(p: &str) -> bool {
-        p == "bash"
+    fn has_bash(p: &str) -> Option<String> {
+        (p == "bash").then(|| "C:/Program Files/Git/bin/bash.exe".to_string())
     }
 
     #[test]
@@ -1076,7 +1169,19 @@ mod tests {
     /// quotes, `$(…)`, backticks, `$HOME` and `;` all came out wrong — silently.
     #[test]
     fn windows_prefers_bash_when_it_is_on_path() {
-        assert_eq!(shell_choice(None, true, has_bash), ("bash".to_string(), "-c"));
+        assert_eq!(
+            shell_choice(None, true, has_bash),
+            ("C:/Program Files/Git/bin/bash.exe".to_string(), "-c")
+        );
+    }
+
+    /// The resolved ABSOLUTE path must come back, not the bare name: the shell
+    /// that gets spawned has to be the same file the probe approved.
+    #[test]
+    fn windows_returns_the_resolved_path_not_the_bare_name() {
+        let (program, _) = shell_choice(None, true, has_bash);
+        assert!(program.ends_with("bash.exe"), "{program}");
+        assert!(program.contains('/'), "must be a path, not a bare name: {program}");
     }
 
     #[test]
@@ -1087,9 +1192,62 @@ mod tests {
     #[test]
     fn windows_accepts_sh_when_bash_is_absent() {
         assert_eq!(
-            shell_choice(None, true, |p| p == "sh"),
-            ("sh".to_string(), "-c")
+            shell_choice(None, true, |p| (p == "sh").then(|| "C:/msys64/usr/bin/sh.exe".into())),
+            ("C:/msys64/usr/bin/sh.exe".to_string(), "-c")
         );
+    }
+
+    // ── PATH resolution ──────────────────────────────────────────────────
+
+    /// `%SystemRoot%\System32\bash.exe` is the WSL launcher, which runs the
+    /// command inside a Linux distro where the host's drive paths and toolchain
+    /// do not exist — silently wrong output, i.e. the exact class #208 is about.
+    /// It also normally precedes git-bash on PATH.
+    #[test]
+    fn wsl_launcher_is_recognised() {
+        assert!(is_wsl_launcher(r"C:\Windows\System32\bash.exe"));
+        assert!(is_wsl_launcher("C:/Windows/System32/bash.exe"));
+        assert!(is_wsl_launcher(r"C:\WINDOWS\SYSNATIVE\BASH.EXE"));
+        assert!(!is_wsl_launcher(r"C:\Program Files\Git\bin\bash.exe"));
+        assert!(!is_wsl_launcher("C:/msys64/usr/bin/bash.exe"));
+    }
+
+    #[test]
+    fn path_scan_skips_the_wsl_launcher_and_takes_git_bash() {
+        let dirs = [
+            PathBuf::from("C:/Windows/System32"),
+            PathBuf::from("C:/Program Files/Git/bin"),
+        ];
+        let found = pick_program(dirs.into_iter(), "bash.exe", |_| true);
+        assert_eq!(found, Some("C:/Program Files/Git/bin/bash.exe".to_string()));
+    }
+
+    /// A trailing `;` in PATH yields an EMPTY entry, and joining onto it gives
+    /// a RELATIVE path — which would probe the agent's current repo for a file
+    /// named `bash.exe` and then run it as the shell for every command.
+    #[test]
+    fn path_scan_ignores_relative_entries() {
+        let dirs = [PathBuf::from(""), PathBuf::from("relative/bin")];
+        assert_eq!(pick_program(dirs.into_iter(), "bash.exe", |_| true), None);
+    }
+
+    /// Anchoring must be judged by the Windows rules even when the check runs
+    /// on Unix, which is why `Path::is_absolute` cannot be used.
+    #[test]
+    fn rooted_covers_both_platforms_regardless_of_host() {
+        assert!(is_rooted("/usr/bin"));
+        assert!(is_rooted(r"C:\Windows\System32"));
+        assert!(is_rooted("C:/Program Files/Git/bin"));
+        assert!(is_rooted(r"\\server\share\bin"));
+        assert!(!is_rooted(""));
+        assert!(!is_rooted("relative/bin"));
+        assert!(!is_rooted("bin"));
+    }
+
+    #[test]
+    fn path_scan_returns_none_when_nothing_matches() {
+        let dirs = [PathBuf::from("C:/nowhere")];
+        assert_eq!(pick_program(dirs.into_iter(), "bash.exe", |_: &Path| false), None);
     }
 
     #[test]
@@ -1121,7 +1279,10 @@ mod tests {
     /// as "not set" rather than trying to exec an empty program name.
     #[test]
     fn a_blank_override_is_ignored() {
-        assert_eq!(shell_choice(Some("   ".into()), true, has_bash), ("bash".to_string(), "-c"));
+        assert_eq!(
+            shell_choice(Some("   ".into()), true, has_bash).0,
+            "C:/Program Files/Git/bin/bash.exe"
+        );
         assert_eq!(shell_choice(Some("".into()), false, nothing), ("sh".to_string(), "-c"));
     }
 

--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -12,22 +12,89 @@ use std::time::{Duration, Instant};
 #[cfg(unix)]
 static CHILD_PID: AtomicI32 = AtomicI32::new(-1);
 
-/// Returns a `Command` pre-configured to run `cmd` through the platform shell.
-/// Unix/Git Bash: `sh -c <cmd>`
-/// Windows native: `cmd /C <cmd>`
+/// The shell `wrap` re-executes a captured command under: program plus its
+/// "run this string" flag.
+///
+/// Pure over `on_path` so the Windows branch stays testable from any host.
+///
+/// Windows used to hardcode `cmd /C`, but every agent host squeez supports
+/// hands its terminal commands to git-bash there — so a command the agent
+/// wrote for bash got re-executed by cmd.exe and quietly came out wrong:
+/// `python -c 'print(1)'` produced empty output, `$(…)` and backticks were not
+/// expanded, `$HOME` stayed literal, and `;` was passed to the first program as
+/// an argument instead of separating statements (issue #208). Wrong-but-
+/// plausible output is worse than a loud failure, because the agent then
+/// reasons on top of it. So: prefer bash when it is there, keep `cmd` as the
+/// fallback, and let `SQUEEZ_SHELL` override both.
+fn shell_choice(
+    shell_override: Option<String>,
+    windows: bool,
+    on_path: impl Fn(&str) -> bool,
+) -> (String, &'static str) {
+    if let Some(shell) = shell_override.map(|s| s.trim().to_string()).filter(|s| !s.is_empty()) {
+        let flag = if is_cmd_shell(&shell) { "/C" } else { "-c" };
+        return (shell, flag);
+    }
+    if !windows {
+        return ("sh".to_string(), "-c");
+    }
+    for candidate in ["bash", "sh"] {
+        if on_path(candidate) {
+            return (candidate.to_string(), "-c");
+        }
+    }
+    ("cmd".to_string(), "/C")
+}
+
+/// `cmd.exe` is the only shell squeez drives with `/C`; everything else
+/// (bash, sh, zsh, dash, busybox) takes `-c`.
+fn is_cmd_shell(shell: &str) -> bool {
+    let base = shell
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(shell)
+        .to_ascii_lowercase();
+    base == "cmd" || base == "cmd.exe"
+}
+
+/// True if `program` is an executable on PATH. Only consulted on Windows, and
+/// only once per process — see [`resolved_shell`].
+#[cfg(windows)]
+fn program_on_path(program: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| {
+        dir.join(format!("{program}.exe")).is_file() || dir.join(program).is_file()
+    })
+}
+
+#[cfg(not(windows))]
+fn program_on_path(_program: &str) -> bool {
+    false
+}
+
+/// `wrap` runs on every Bash tool call, so the PATH scan is done once.
+fn resolved_shell() -> &'static (String, &'static str) {
+    static SHELL: std::sync::OnceLock<(String, &'static str)> = std::sync::OnceLock::new();
+    SHELL.get_or_init(|| {
+        shell_choice(
+            std::env::var("SQUEEZ_SHELL").ok(),
+            cfg!(windows),
+            program_on_path,
+        )
+    })
+}
+
+/// Returns a `Command` pre-configured to run `cmd` through the shell.
+/// Unix: `sh -c <cmd>`. Windows: `bash -c <cmd>` when bash is on PATH (the
+/// de-facto agent shell there), otherwise `cmd /C <cmd>`. `SQUEEZ_SHELL`
+/// overrides the choice on every platform.
 fn shell_command(cmd: &str) -> Command {
-    #[cfg(windows)]
-    {
-        let mut c = Command::new("cmd");
-        c.args(["/C", cmd]);
-        c
-    }
-    #[cfg(not(windows))]
-    {
-        let mut c = Command::new("sh");
-        c.args(["-c", cmd]);
-        c
-    }
+    let (program, flag) = resolved_shell();
+    let mut c = Command::new(program);
+    c.args([flag, cmd]);
+    c
 }
 
 /// Result of spawning and fully draining one command. `Fatal` carries the
@@ -987,7 +1054,87 @@ fn record_bash_event(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_net_loss, retrieve_marker_text};
+    use super::{is_cmd_shell, is_net_loss, retrieve_marker_text, shell_choice};
+
+    /// Nothing is on PATH — the bare-Windows case.
+    fn nothing(_: &str) -> bool {
+        false
+    }
+    /// git-bash is installed, which is the normal state on any machine running
+    /// one of these agent CLIs on Windows.
+    fn has_bash(p: &str) -> bool {
+        p == "bash"
+    }
+
+    #[test]
+    fn unix_always_uses_sh() {
+        assert_eq!(shell_choice(None, false, has_bash), ("sh".to_string(), "-c"));
+        assert_eq!(shell_choice(None, false, nothing), ("sh".to_string(), "-c"));
+    }
+
+    /// #208: cmd.exe re-executed commands the agent had written for bash, so
+    /// quotes, `$(…)`, backticks, `$HOME` and `;` all came out wrong — silently.
+    #[test]
+    fn windows_prefers_bash_when_it_is_on_path() {
+        assert_eq!(shell_choice(None, true, has_bash), ("bash".to_string(), "-c"));
+    }
+
+    #[test]
+    fn windows_falls_back_to_cmd_without_a_posix_shell() {
+        assert_eq!(shell_choice(None, true, nothing), ("cmd".to_string(), "/C"));
+    }
+
+    #[test]
+    fn windows_accepts_sh_when_bash_is_absent() {
+        assert_eq!(
+            shell_choice(None, true, |p| p == "sh"),
+            ("sh".to_string(), "-c")
+        );
+    }
+
+    #[test]
+    fn squeez_shell_overrides_every_platform() {
+        assert_eq!(
+            shell_choice(Some("zsh".into()), false, nothing),
+            ("zsh".to_string(), "-c")
+        );
+        assert_eq!(
+            shell_choice(Some("C:/Program Files/Git/bin/bash.exe".into()), true, nothing),
+            ("C:/Program Files/Git/bin/bash.exe".to_string(), "-c")
+        );
+    }
+
+    /// An override back to cmd must come with cmd's flag, not `-c`.
+    #[test]
+    fn squeez_shell_pointing_at_cmd_gets_the_cmd_flag() {
+        assert_eq!(
+            shell_choice(Some("cmd".into()), true, has_bash),
+            ("cmd".to_string(), "/C")
+        );
+        assert_eq!(
+            shell_choice(Some(r"C:\Windows\System32\cmd.exe".into()), true, has_bash).1,
+            "/C"
+        );
+    }
+
+    /// An unset variable reaches us as `Some("")` in some shells; treat blank
+    /// as "not set" rather than trying to exec an empty program name.
+    #[test]
+    fn a_blank_override_is_ignored() {
+        assert_eq!(shell_choice(Some("   ".into()), true, has_bash), ("bash".to_string(), "-c"));
+        assert_eq!(shell_choice(Some("".into()), false, nothing), ("sh".to_string(), "-c"));
+    }
+
+    #[test]
+    fn only_cmd_is_a_cmd_shell() {
+        assert!(is_cmd_shell("cmd"));
+        assert!(is_cmd_shell("CMD.EXE"));
+        assert!(is_cmd_shell(r"C:\Windows\System32\cmd.exe"));
+        assert!(!is_cmd_shell("bash"));
+        assert!(!is_cmd_shell("/bin/sh"));
+        assert!(!is_cmd_shell("C:/Program Files/Git/bin/bash.exe"));
+    }
+
 
     /// What the marker actually costs, measured the same way the gate does.
     fn marker_cost() -> usize {

--- a/src/hosts/hermes.rs
+++ b/src/hosts/hermes.rs
@@ -1,7 +1,8 @@
 //! Hermes Agent adapter.
 //!
 //! [Hermes Agent](https://github.com/NousResearch/hermes-agent) by Nous Research
-//! is a general-purpose AI agent with a plugin system at `~/.hermes/plugins/`.
+//! is a general-purpose AI agent with a plugin system at `$HERMES_HOME/plugins/`
+//! (`~/.hermes/plugins/` when the variable is unset).
 //! A directory plugin is a Python package with a `plugin.yaml` manifest plus an
 //! `__init__.py` exposing `register(ctx)`; both files are required for Hermes to
 //! discover it. Discovered plugins are opt-in and must be enabled once via
@@ -40,11 +41,26 @@ const HERMES_PLUGIN: &str = include_str!("../../plugins/hermes/__init__.py");
 /// when both `plugin.yaml` and `__init__.py` are present.
 const HERMES_MANIFEST: &str = include_str!("../../plugins/hermes/plugin.yaml");
 
+/// Split out from [`HermesAdapter::hermes_dir`] so the override is testable
+/// without mutating the process environment.
+fn hermes_dir_from(hermes_home: Option<String>, home: &str) -> PathBuf {
+    match hermes_home.map(|v| v.trim().to_string()).filter(|v| !v.is_empty()) {
+        Some(dir) => PathBuf::from(dir),
+        None => PathBuf::from(format!("{}/.hermes", home)),
+    }
+}
+
 pub struct HermesAdapter;
 
 impl HermesAdapter {
+    /// Where Hermes keeps its plugins and profiles.
+    ///
+    /// `HERMES_HOME` wins when set — a Windows install at
+    /// `%LOCALAPPDATA%\hermes` lives nowhere near `~/.hermes`, so probing only
+    /// the default made `is_installed()` false and `squeez setup --host=hermes`
+    /// silently skip a perfectly good Hermes (issue #208).
     fn hermes_dir() -> PathBuf {
-        PathBuf::from(format!("{}/.hermes", home_dir()))
+        hermes_dir_from(std::env::var("HERMES_HOME").ok(), &home_dir())
     }
 
     fn plugins_dir() -> PathBuf {
@@ -69,8 +85,9 @@ impl HostAdapter for HermesAdapter {
     }
 
     fn is_installed(&self) -> bool {
-        // Detect Hermes by checking for ~/.hermes/ with a hermes-agent subdir
-        // or a config.yaml — either indicates a real installation.
+        // Detect Hermes by checking the install root (HERMES_HOME, else
+        // ~/.hermes) for a hermes-agent subdir or a config.yaml — either
+        // indicates a real installation.
         let dir = Self::hermes_dir();
         if !dir.exists() {
             return false;
@@ -196,6 +213,23 @@ fn strip_squeez_block(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #208: a Windows Hermes at %LOCALAPPDATA%\hermes was never detected,
+    /// because only ~/.hermes was probed — so `squeez setup --host=hermes`
+    /// silently skipped a perfectly good install.
+    #[test]
+    fn hermes_home_overrides_the_default_location() {
+        assert_eq!(
+            hermes_dir_from(Some("C:/Users/J/AppData/Local/hermes".into()), "/home/j"),
+            PathBuf::from("C:/Users/J/AppData/Local/hermes")
+        );
+    }
+
+    #[test]
+    fn default_location_is_used_when_hermes_home_is_unset_or_blank() {
+        assert_eq!(hermes_dir_from(None, "/home/j"), PathBuf::from("/home/j/.hermes"));
+        assert_eq!(hermes_dir_from(Some("  ".into()), "/home/j"), PathBuf::from("/home/j/.hermes"));
+    }
 
     #[test]
     fn strip_squeez_block_inside_existing_soul_md() {

--- a/src/hosts/hermes.rs
+++ b/src/hosts/hermes.rs
@@ -43,10 +43,22 @@ const HERMES_MANIFEST: &str = include_str!("../../plugins/hermes/plugin.yaml");
 
 /// Split out from [`HermesAdapter::hermes_dir`] so the override is testable
 /// without mutating the process environment.
+///
+/// A leading `~` is expanded. Environment variables are not shell-expanded by
+/// the OS, so a `HERMES_HOME` set from a config file or a quoted Windows
+/// variable arrives as the literal string `~/hermes` — using it verbatim would
+/// create a directory actually named `~` under whatever the agent's current
+/// directory happens to be, usually the user's repo.
 fn hermes_dir_from(hermes_home: Option<String>, home: &str) -> PathBuf {
-    match hermes_home.map(|v| v.trim().to_string()).filter(|v| !v.is_empty()) {
-        Some(dir) => PathBuf::from(dir),
-        None => PathBuf::from(format!("{}/.hermes", home)),
+    let Some(dir) = hermes_home.map(|v| v.trim().to_string()).filter(|v| !v.is_empty()) else {
+        return PathBuf::from(format!("{}/.hermes", home));
+    };
+    match dir.strip_prefix('~') {
+        Some("") => PathBuf::from(home),
+        Some(rest) if rest.starts_with('/') || rest.starts_with('\\') => {
+            PathBuf::from(format!("{}{}", home, rest))
+        }
+        _ => PathBuf::from(dir),
     }
 }
 
@@ -61,6 +73,13 @@ impl HermesAdapter {
     /// silently skip a perfectly good Hermes (issue #208).
     fn hermes_dir() -> PathBuf {
         hermes_dir_from(std::env::var("HERMES_HOME").ok(), &home_dir())
+    }
+
+    /// Exposed for tests: proves the variable this adapter actually reads is
+    /// named `HERMES_HOME`, which `hermes_dir_from` alone cannot pin.
+    #[cfg(test)]
+    fn hermes_dir_for_test() -> PathBuf {
+        Self::hermes_dir()
     }
 
     fn plugins_dir() -> PathBuf {
@@ -229,6 +248,34 @@ mod tests {
     fn default_location_is_used_when_hermes_home_is_unset_or_blank() {
         assert_eq!(hermes_dir_from(None, "/home/j"), PathBuf::from("/home/j/.hermes"));
         assert_eq!(hermes_dir_from(Some("  ".into()), "/home/j"), PathBuf::from("/home/j/.hermes"));
+    }
+
+    /// The OS does not shell-expand environment variables, so a HERMES_HOME set
+    /// from a config file or a quoted Windows variable arrives as the literal
+    /// string `~/hermes`. Used verbatim it would create a directory actually
+    /// NAMED `~` under the agent's current directory — usually the user's repo.
+    #[test]
+    fn a_literal_tilde_is_expanded_not_taken_as_a_directory_name() {
+        assert_eq!(hermes_dir_from(Some("~/hermes".into()), "/home/j"), PathBuf::from("/home/j/hermes"));
+        assert_eq!(hermes_dir_from(Some("~".into()), "/home/j"), PathBuf::from("/home/j"));
+        // `~foo` is a username reference, not this user's home — left alone.
+        assert_eq!(hermes_dir_from(Some("~other/h".into()), "/home/j"), PathBuf::from("~other/h"));
+    }
+
+    /// `hermes_dir_from` cannot pin the NAME of the variable the adapter reads;
+    /// renaming it would leave every other test green while re-breaking #208.
+    #[test]
+    fn the_adapter_reads_the_variable_called_hermes_home() {
+        static ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("HERMES_HOME").ok();
+        std::env::set_var("HERMES_HOME", "/tmp/squeez-hermes-probe");
+        let dir = HermesAdapter::hermes_dir_for_test();
+        match prev {
+            Some(v) => std::env::set_var("HERMES_HOME", v),
+            None => std::env::remove_var("HERMES_HOME"),
+        }
+        assert_eq!(dir, PathBuf::from("/tmp/squeez-hermes-probe"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #208

Reported by @Prediction6767 — thanks for the measured table of what each
command actually did under `wrap`, and for checking `src/config.rs` to confirm
no shell override existed. Both suggested fixes landed as suggested, and bash
is the default on Windows rather than opt-in, for the reason you gave: every
one of these hosts executes its own commands through git-bash there.

## Bug 1 — `wrap` re-executed bash commands under cmd.exe

`shell_command()` hardcoded `cmd /C` on Windows. A command the agent wrote for
bash was therefore re-run by a different shell, and the results were **silently
wrong rather than loudly broken**:

| Command | Under `cmd /C` | Expected |
|---|---|---|
| `python -c 'print(1)'` | exit 0, empty output | `1` |
| `echo $HOME` | literal `$HOME` | the path |
| `echo $(echo B)` | literal `$(echo B)` | `B` |
| `grep -n 'foo' /dev/null; echo rc=$?` | `grep: /dev/null;: No such file…` | `rc=1` |

That is a correctness hazard, not a compression bug — the agent reads a
plausible wrong answer and reasons on top of it.

`shell_command` now goes through `shell_choice`:

* `SQUEEZ_SHELL` wins on every platform;
* Unix keeps `sh -c` exactly as before;
* Windows prefers `bash`, then `sh`, when one is on `PATH`;
* `cmd /C` remains the fallback when neither is present.

An override pointing back at `cmd.exe` correctly gets `/C` instead of `-c`, so
`SQUEEZ_SHELL=cmd` restores the old behaviour if anyone wants it. The `PATH`
scan is memoised in a `OnceLock` — `wrap` runs on every Bash tool call, so it
must not pay for a lookup each time.

## Bug 2 — `hermes_dir()` ignored `HERMES_HOME`

It returned `~/.hermes` unconditionally, so a Windows install at
`%LOCALAPPDATA%\hermes` was never detected and `squeez setup --host=hermes`
skipped it without a word. `HERMES_HOME` is now honoured, which fixes
`plugins_dir()`, `soul_md_path()`, `data_dir()` and `is_installed()` in one go,
since they all derive from it.

## Proof

CI runs on macOS, so both decisions are factored into pure functions that take
their platform inputs as arguments. The Windows behaviour is covered by tests
that run everywhere:

```
$ cargo test
1153 passed; 0 failed   (exit 0)
```

Eleven of those are new — shell selection on Unix and Windows, the bash-present
and bash-absent Windows branches, `SQUEEZ_SHELL` override including the
cmd-flag case and a blank value, `is_cmd_shell` basename handling, and
`HERMES_HOME` set / unset / blank.

End to end on this machine, showing the shell actually changes while quoting
and command substitution keep working:

```
$ squeez wrap 'echo "shell=$0"; echo A"B"C; echo $(echo sub)'
shell=sh
ABC
sub

$ SQUEEZ_SHELL=bash squeez wrap 'echo "shell=$0"; echo A"B"C; echo $(echo sub)'
shell=bash
ABC
sub

$ SQUEEZ_SHELL=zsh squeez wrap 'echo "shell=$0"; echo A"B"C'
shell=zsh
ABC
```

## Also

README now documents `SQUEEZ_SHELL` under `squeez wrap`, and Hermes gets a
Platform notes section covering `HERMES_HOME` and the `hermes plugins enable
squeez-fallback` opt-in step.

Your follow-up on #209 — that the `should-wrap` gate does not filter these out
— is handled by this change rather than by narrowing the gate: with bash doing
the re-execution the quoting is no longer corrupted, so degrading to
pass-through is not needed. If you hit a Windows setup with no bash at all, set
`SQUEEZ_SHELL` or `wrap_bash = false` and please reopen.
