### PR TITLE
fix(hosts): bash-prefix Codex/Gemini hook commands + self-heal registrations

### DIFF
--- a/src/hosts/codex.rs
+++ b/src/hosts/codex.rs
@@ -45,15 +45,21 @@ const POST_TOOL_USE_SCRIPT: &str = include_str!("../../hooks/codex-posttooluse.s
 /// Events squeez registers under `hooks` in the Codex CLI hooks.json.
 const SQUEEZ_EVENTS: [&str; 3] = ["SessionStart", "PreToolUse", "PostToolUse"];
 
-/// Codex nests its event map under `hooks` and takes a bare script path plus a
-/// per-hook timeout, but no entry name.
+/// Codex nests its event map under `hooks` and takes a per-hook timeout but no
+/// entry name.
+///
+/// Command must be `bash <path>`, not a bare script path: Codex spawns the
+/// command directly rather than handing it to a shell, so on Windows a bare
+/// `.sh` path has no interpreter to run it and the hook dies immediately with
+/// exit code 1 (every squeez Codex hook, starting with SessionStart).
 fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
-    let spec = |event: &'static str, script: &str, timeout_ms: u64| settings_json::HookSpec {
+    let spec = |event: &'static str, script: &'static str, timeout_ms: u64| settings_json::HookSpec {
         event,
         matcher: Some(".*"),
-        command: hooks_dir.join(script).display().to_string(),
+        command: format!("bash {}", settings_json::shell_arg(&hooks_dir.join(script))),
         name: None,
         timeout_ms: Some(timeout_ms),
+        script,
     };
     vec![
         spec("SessionStart", "codex-session-start.sh", 5000),

--- a/src/hosts/copilot.rs
+++ b/src/hosts/copilot.rs
@@ -28,6 +28,7 @@ fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
             command: cmd("copilot-pretooluse.sh"),
             name: None,
             timeout_ms: None,
+            script: "copilot-pretooluse.sh",
         },
         settings_json::HookSpec {
             event: "SessionStart",
@@ -35,6 +36,7 @@ fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
             command: cmd("copilot-session-start.sh"),
             name: None,
             timeout_ms: None,
+            script: "copilot-session-start.sh",
         },
         settings_json::HookSpec {
             event: "PostToolUse",
@@ -42,6 +44,7 @@ fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
             command: cmd("copilot-posttooluse.sh"),
             name: None,
             timeout_ms: None,
+            script: "copilot-posttooluse.sh",
         },
     ]
 }

--- a/src/hosts/gemini.rs
+++ b/src/hosts/gemini.rs
@@ -43,15 +43,20 @@ const AFTER_TOOL_SCRIPT: &str = include_str!("../../hooks/gemini-after-tool.sh")
 /// Events squeez registers under `settings["hooks"]` in the Gemini CLI.
 const SQUEEZ_EVENTS: [&str; 3] = ["SessionStart", "BeforeTool", "AfterTool"];
 
-/// Gemini nests its event map under `hooks`, labels each entry, takes a bare
-/// script path (no `bash` prefix) and a per-hook timeout.
+/// Gemini nests its event map under `hooks`, labels each entry, and takes a
+/// per-hook timeout.
+///
+/// Command must be `bash <path>`, not a bare script path — same Windows
+/// failure mode as Codex (#209-class): Gemini spawns the command directly,
+/// so a bare `.sh` path has no interpreter to run it there.
 fn hook_specs(hooks_dir: &Path) -> Vec<settings_json::HookSpec> {
-    let spec = |event: &'static str, script: &str, timeout_ms: u64| settings_json::HookSpec {
+    let spec = |event: &'static str, script: &'static str, timeout_ms: u64| settings_json::HookSpec {
         event,
         matcher: Some(".*"),
-        command: hooks_dir.join(script).display().to_string(),
+        command: format!("bash {}", settings_json::shell_arg(&hooks_dir.join(script))),
         name: Some(format!("squeez-{}", event.to_lowercase())),
         timeout_ms: Some(timeout_ms),
+        script,
     };
     vec![
         spec("SessionStart", "gemini-session-start.sh", 5000),

--- a/src/hosts/settings_json.rs
+++ b/src/hosts/settings_json.rs
@@ -251,6 +251,35 @@ fn upgrade_hook(
     }
 }
 
+/// [`patch_events`]'s upgrader: same shape as [`upgrade_hook`], but replaces
+/// the whole matching hook object (not just `command`) so a stale `name` or
+/// `timeout` from an older squeez version is corrected too — fields
+/// `upgrade_hook` doesn't know about because Claude Code's specs never carry
+/// them.
+fn upgrade_hook_spec(hooks_root: &mut JsonValue, spec: &HookSpec) {
+    let arr = hooks_root.ensure_arr(spec.event);
+    let matches = |cmd: &str| is_core_script(cmd, spec.script);
+    let Some(entry) = arr.iter_mut().find(|m| entry_cmd_any(m, &matches)) else {
+        arr.push(spec.to_entry());
+        return;
+    };
+    let hooks = entry.get_mut("hooks").and_then(|h| h.as_arr_mut());
+    let Some(hooks) = hooks else { return };
+    let mut only_ours = true;
+    for hook in hooks.iter_mut() {
+        if !matches(hook.get_str("command")) {
+            only_ours = false;
+            continue;
+        }
+        *hook = spec.to_hook();
+    }
+    if let Some(m) = spec.matcher {
+        if only_ours && entry.get_str("matcher") != m {
+            entry.set("matcher", JsonValue::Str(m.to_string()));
+        }
+    }
+}
+
 /// Append `entry` under `event` unless a buddy hook is already there.
 pub fn ensure_buddy_hook(hooks_root: &mut JsonValue, event: &str, entry: JsonValue) {
     let arr = hooks_root.ensure_arr(event);
@@ -293,10 +322,19 @@ pub struct HookSpec {
     pub name: Option<String>,
     /// Gemini and Codex carry a per-hook timeout; copilot does not.
     pub timeout_ms: Option<u64>,
+    /// Bare script filename (e.g. `codex-pretooluse.sh`), used by
+    /// [`patch_events`] to find and upgrade a prior registration of this hook
+    /// in place — see [`upgrade_squeez_hook`] for why presence-only checks
+    /// freeze a broken command string forever.
+    pub script: &'static str,
 }
 
 impl HookSpec {
-    fn to_entry(&self) -> JsonValue {
+    /// The `{"type":"command","command":..}` object, plus `name`/`timeout`
+    /// when the host uses them. This is the part [`upgrade_events`] replaces
+    /// wholesale on upgrade, so a stale `name`/`timeout` from an older
+    /// squeez version can't survive alongside a corrected `command`.
+    fn to_hook(&self) -> JsonValue {
         let mut hook = Vec::new();
         if let Some(n) = &self.name {
             hook.push(("name".to_string(), JsonValue::Str(n.clone())));
@@ -306,13 +344,17 @@ impl HookSpec {
         if let Some(t) = self.timeout_ms {
             hook.push(("timeout".to_string(), JsonValue::Num(t as f64)));
         }
+        JsonValue::Obj(hook)
+    }
+
+    fn to_entry(&self) -> JsonValue {
         let mut entry = Vec::new();
         if let Some(m) = self.matcher {
             entry.push(("matcher".to_string(), JsonValue::Str(m.to_string())));
         }
         entry.push((
             "hooks".to_string(),
-            JsonValue::Arr(vec![JsonValue::Obj(hook)]),
+            JsonValue::Arr(vec![self.to_hook()]),
         ));
         JsonValue::Obj(entry)
     }
@@ -327,7 +369,11 @@ pub enum EventRoot {
 }
 
 /// Register `specs`, appending each only when no squeez hook is present for
-/// that event. Idempotent, and never disturbs foreign entries.
+/// that event, upgrading a matching prior registration in place instead of
+/// freezing it — the same self-heal `upgrade_squeez_hook` gives Claude Code
+/// (issue #209: a broken command string still contains "squeez", so a
+/// presence-only check never corrects it on later `squeez setup` runs).
+/// Idempotent, and never disturbs foreign entries.
 pub fn patch_events(
     path: &Path,
     root_kind: EventRoot,
@@ -342,13 +388,13 @@ pub fn patch_events(
     match root_kind {
         EventRoot::TopLevel => {
             for spec in specs {
-                ensure_squeez_hook(&mut settings, spec.event, spec.to_entry());
+                upgrade_hook_spec(&mut settings, spec);
             }
         }
         EventRoot::Nested => {
             let root = settings.ensure_obj("hooks");
             for spec in specs {
-                ensure_squeez_hook(root, spec.event, spec.to_entry());
+                upgrade_hook_spec(root, spec);
             }
         }
     }

--- a/tests/test_hosts_codex.rs
+++ b/tests/test_hosts_codex.rs
@@ -173,6 +173,57 @@ fn codex_install_idempotent_no_dup_entries() {
     });
 }
 
+// A bare script path with no interpreter has nothing to run it on Windows —
+// Codex spawns `command` directly rather than handing it to a shell, so the
+// hook dies immediately with exit code 1. See codex.rs's `hook_specs` doc.
+#[test]
+fn codex_install_registers_bash_prefixed_command() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        let a = CodexCliAdapter;
+        a.install(&PathBuf::from("/usr/local/bin/squeez")).unwrap();
+        let body = std::fs::read_to_string(home.join(".codex/hooks.json")).unwrap();
+        assert!(
+            body.contains("bash ") && body.contains("codex-session-start.sh"),
+            "SessionStart command must be bash-prefixed, got: {body}"
+        );
+    });
+}
+
+// A pre-fix install froze a bare, unrunnable path in hooks.json forever (the
+// presence-only check only asked "is *a* squeez hook here?"). Re-running
+// install must now upgrade that command in place instead of leaving it dead.
+#[test]
+fn codex_install_heals_prior_bare_path_command() {
+    if python3_missing() {
+        return;
+    }
+    with_home(|home| {
+        std::fs::create_dir_all(home.join(".codex")).unwrap();
+        let hooks_dir = home.join(".codex/squeez/hooks");
+        let broken = hooks_dir.join("codex-session-start.sh");
+        let broken_cmd = broken.display().to_string().replace('\\', "/");
+        std::fs::write(
+            home.join(".codex/hooks.json"),
+            format!(
+                r#"{{"hooks":{{"SessionStart":[{{"matcher":".*","hooks":[{{"type":"command","command":"{broken_cmd}"}}]}}]}}}}"#
+            ),
+        )
+        .unwrap();
+        CodexCliAdapter
+            .install(&PathBuf::from("/usr/local/bin/squeez"))
+            .unwrap();
+        let body = std::fs::read_to_string(home.join(".codex/hooks.json")).unwrap();
+        assert_eq!(body.matches("codex-session-start.sh").count(), 1);
+        assert!(
+            body.contains("bash "),
+            "stale bare-path command must be upgraded to bash-prefixed, got: {body}"
+        );
+    });
+}
+
 /// Create a fake executable `squeez` under <home>/.claude/squeez/bin so the
 /// hook scripts resolve `$SQUEEZ` to a real path. PreToolUse never executes it
 /// (it only string-builds the rewritten command), so a stub is enough.


### PR DESCRIPTION
## Linked issue

Closes #215

## Type of change

- [ ] `feat:` — new functionality (→ minor bump)
- [x] `fix:` / `perf:` — bug fix or perf improvement (→ patch bump)
- [ ] `chore:` / `docs:` / `ci:` / `test:` / `refactor:` — no release
- [ ] Breaking change — `!:` or `BREAKING CHANGE:` in commit body (→ major bump)

## Area

- [x] Handler (`src/commands/*`) — n/a, see host adapters below
- [ ] Compression pipeline
- [ ] Context engine
- [ ] MCP server
- [ ] CI / release / tooling
- [ ] Docs

(Touches `src/hosts/{codex,gemini,copilot,settings_json}.rs` — host adapters, not listed as its own checkbox in the template.)

## Summary

- Codex and Gemini adapters registered hook commands as bare Windows paths with no `bash` prefix. Both hosts spawn the command directly instead of handing it to a shell, so on Windows the `.sh` script has no interpreter to run it and dies immediately with exit code 1 — every squeez hook on those two CLIs, starting with `SessionStart`.
- Extends the #209 self-heal fix (upgrade a matching registration in place instead of a presence-only check that freezes a broken command string forever) from Claude Code to Codex, Gemini, and Copilot, so a rebuilt binary repairs an already-broken install on the next `squeez setup` — no manual uninstall/reinstall needed.
- Adds two regression tests: the registered command is bash-prefixed, and a prior broken bare-path registration is healed in place on reinstall.

## Test plan

- [x] `cargo test` passes (pre-existing, unrelated failures on this Windows dev box — direct `bash <script>` invocation in a handful of PreToolUse/BeforeTool tests and two path-separator/file-permission tests — reproduce identically on `main` before this change, confirmed via `git stash`)
- [ ] `bash bench/run.sh`
- [ ] `bash bench/run_context.sh`

## Checklist

- [x] Issue is linked above
- [ ] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)