### PR TITLE
fix(wrap): recognize WindowsApps bash.exe alias as WSL launcher

### DIFF
--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -53,10 +53,17 @@ fn shell_choice(
 /// enabled with no distro installed. It also normally precedes git-bash on
 /// PATH, so picking the first `bash.exe` found would reintroduce exactly the
 /// silent-wrong-output class this change exists to remove.
+///
+/// `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe` is the same failure mode
+/// under a different name: an App Execution Alias stub the WSL Windows
+/// feature installs, which also forwards to the default WSL distro's
+/// `/bin/bash`. It commonly precedes git-bash on PATH too (issue #214).
 #[cfg_attr(not(windows), allow(dead_code))] // reached via resolve_shell_program on Windows; tested everywhere
 fn is_wsl_launcher(path: &str) -> bool {
     let p = path.replace('\\', "/").to_ascii_lowercase();
-    p.ends_with("/system32/bash.exe") || p.ends_with("/sysnative/bash.exe")
+    p.ends_with("/system32/bash.exe")
+        || p.ends_with("/sysnative/bash.exe")
+        || p.ends_with("/microsoft/windowsapps/bash.exe")
 }
 
 /// First directory in `dirs` holding an executable `program`, as an absolute
@@ -1223,10 +1230,38 @@ mod tests {
         assert!(!is_wsl_launcher("C:/msys64/usr/bin/bash.exe"));
     }
 
+    /// `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe` is the App Execution
+    /// Alias stub the WSL Windows feature installs — same failure mode as the
+    /// System32 launcher, different path, and it also normally precedes
+    /// git-bash on PATH (issue #214).
+    #[test]
+    fn wsl_app_execution_alias_stub_is_recognised() {
+        assert!(is_wsl_launcher(
+            r"C:\Users\dev\AppData\Local\Microsoft\WindowsApps\bash.exe"
+        ));
+        assert!(is_wsl_launcher(
+            "C:/Users/dev/AppData/Local/Microsoft/WindowsApps/bash.exe"
+        ));
+        assert!(is_wsl_launcher(
+            r"C:\USERS\DEV\APPDATA\LOCAL\MICROSOFT\WINDOWSAPPS\BASH.EXE"
+        ));
+        assert!(!is_wsl_launcher(r"C:\Program Files\Git\bin\bash.exe"));
+    }
+
     #[test]
     fn path_scan_skips_the_wsl_launcher_and_takes_git_bash() {
         let dirs = [
             PathBuf::from("C:/Windows/System32"),
+            PathBuf::from("C:/Program Files/Git/bin"),
+        ];
+        let found = pick_program(dirs.into_iter(), "bash.exe", |_| true);
+        assert_eq!(found, Some("C:/Program Files/Git/bin/bash.exe".to_string()));
+    }
+
+    #[test]
+    fn path_scan_skips_the_windows_apps_alias_and_takes_git_bash() {
+        let dirs = [
+            PathBuf::from(r"C:\Users\dev\AppData\Local\Microsoft\WindowsApps"),
             PathBuf::from("C:/Program Files/Git/bin"),
         ];
         let found = pick_program(dirs.into_iter(), "bash.exe", |_| true);


### PR DESCRIPTION
## Linked issue

Closes #214

## Type

- [x] `fix:` / `perf:` — bug fix or perf improvement (→ patch bump)

## Area

- [x] Handler (`src/commands/*`) — n/a, see below
- [ ] Compression pipeline
- [ ] Context engine
- [ ] MCP server
- [ ] CI / release / tooling
- [ ] Docs

(Touches `src/commands/wrap.rs` — Windows shell resolution, not listed as its own checkbox in the template.)

## Summary

`is_wsl_launcher()` in `src/commands/wrap.rs` only recognized `%SystemRoot%\System32\bash.exe` and `\SysNative\bash.exe` as the WSL launcher to skip during the PATH scan for a POSIX shell. It missed `%LOCALAPPDATA%\Microsoft\WindowsApps\bash.exe` — the App Execution Alias stub the WSL Windows feature installs — which forwards to the default WSL distro's `/bin/bash` the same way System32's does.

On a machine where WSL2 is enabled (e.g. required for Docker Desktop) but no general-purpose distro is installed, or the default distro has no `/bin/bash`, this stub commonly precedes git-bash on PATH and squeez picks it, producing:

```
/bin/bash: --: invalid option
Usage: /usr/bin/bash [GNU long option] [option] ...
```

instead of falling through to git-bash like it already does for the System32 launcher.

Fix: extend `is_wsl_launcher`'s suffix match to also cover `/microsoft/windowsapps/bash.exe`.

## Test plan

- [x] `cargo test` passes (1228 tests, 0 failures)
- [x] Added `wsl_app_execution_alias_stub_is_recognised` (mirrors the existing `wsl_launcher_is_recognised` case for this path shape)
- [x] Added `path_scan_skips_the_windows_apps_alias_and_takes_git_bash` (mirrors `path_scan_skips_the_wsl_launcher_and_takes_git_bash`)

## Checklist

- [x] Issue is linked above
- [ ] CI is green
- [x] No `Co-Authored-By:` trailers in commit messages
- [x] Zero-dependency constraint respected (only `libc` in `Cargo.toml`)
