### PR TITLE
fix: teach the persona once per session, and stop compressing squeez's own block (#218)

### DIFF
--- a/src/commands/compress_md/mod.rs
+++ b/src/commands/compress_md/mod.rs
@@ -287,7 +287,14 @@ enum State {
     Text,
     FencedCode,
     Table,
+    /// Inside a `<!-- squeez:start -->` … `<!-- squeez:end -->` block.
+    Managed,
 }
+
+/// Opening marker of a squeez-managed region in a host instructions file.
+pub const MANAGED_START: &str = "<!-- squeez:start -->";
+/// Closing marker of a squeez-managed region.
+pub const MANAGED_END: &str = "<!-- squeez:end -->";
 
 pub fn compress_text(input: &str, mode: Mode) -> CompressResult {
     compress_text_with_locale(input, mode, Locale::from_code("en"))
@@ -347,8 +354,28 @@ pub fn compress_text_with_locale(
                     // reprocess this line as Text without advancing i
                 }
             }
+            State::Managed => {
+                out.push_str(line);
+                out.push('\n');
+                if line.contains(MANAGED_END) {
+                    state = State::Text;
+                }
+                i += 1;
+            }
             State::Text => {
-                if line.trim_start().starts_with("```") {
+                // A `<!-- squeez:start -->` block is written by squeez itself
+                // (host adapters' inject_memory). Rewriting it would let the
+                // shipped text and the injected text drift apart, and the
+                // prose pass has mangled punctuation inside squeez's own rules
+                // — including the rule about leaving inline code alone (#218).
+                if line.contains(MANAGED_START) {
+                    out.push_str(line);
+                    out.push('\n');
+                    if !line.contains(MANAGED_END) {
+                        state = State::Managed;
+                    }
+                    i += 1;
+                } else if line.trim_start().starts_with("```") {
                     out.push_str(line);
                     out.push('\n');
                     state = State::FencedCode;
@@ -920,6 +947,32 @@ fn replace_word_boundary(s: String, needle: &str, repl: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn managed_block_survives_compression_verbatim() {
+        // The real regression from #218: the injected rule lost the colon that
+        // separates the term from the rule, and "what actually saves" was
+        // shortened inside squeez's own instructions.
+        let managed = "<!-- squeez:start -->\n\
+             ## squeez — always-on compression\n\n\
+             - Inline `code`: unchanged\n\
+             Full words. Article/filler drop is what actually saves tokens.\n\
+             <!-- squeez:end -->\n";
+        let input = format!("{}\nThe user is going to be able to run the thing.\n", managed);
+        let out = compress_text(&input, Mode::Ultra).output;
+        assert!(out.contains(managed), "managed block was rewritten:\n{}", out);
+        // Prose outside the markers is still compressed.
+        assert!(!out.contains("The user is going to be able to run the thing."));
+    }
+
+    #[test]
+    fn text_after_managed_block_is_compressed_again() {
+        let input = "<!-- squeez:start -->\nkeep this exactly as it is\n<!-- squeez:end -->\n\
+             The user is going to be able to run the thing.\n";
+        let out = compress_text(input, Mode::Ultra).output;
+        assert!(out.contains("keep this exactly as it is"));
+        assert!(!out.contains("The user is going to be able to run the thing."));
+    }
 
     #[test]
     fn count_code_blocks_pairs_fences() {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -14,9 +14,14 @@ pub fn run() -> i32 {
     let mem = session::memory_dir();
     let _ = std::fs::create_dir_all(&sessions);
     let _ = std::fs::create_dir_all(&mem);
-    let code = run_with_dirs(&sessions, &mem, &cfg);
+    let adapter = crate::hosts::find("claude-code");
+    let in_memory_file = adapter
+        .as_ref()
+        .map(|a| a.injects_persona(&cfg))
+        .unwrap_or(false);
+    let code = run_with_dirs_for(&sessions, &mem, &cfg, in_memory_file);
     // Delegate host-specific memory injection (CLAUDE.md) to the adapter.
-    if let Some(adapter) = crate::hosts::find("claude-code") {
+    if let Some(adapter) = adapter {
         let _ = adapter.inject_memory(&cfg, &[]);
     }
     // Auto-compress known memory files + skill bodies (idempotent — backups are
@@ -47,11 +52,16 @@ pub fn run_copilot() -> i32 {
     // Load config from the copilot squeez dir
     let cfg = load_config_from(&base);
 
-    let code = run_with_dirs(&sessions, &mem, &cfg);
+    let adapter = crate::hosts::find("copilot");
+    let in_memory_file = adapter
+        .as_ref()
+        .map(|a| a.injects_persona(&cfg))
+        .unwrap_or(false);
+    let code = run_with_dirs_for(&sessions, &mem, &cfg, in_memory_file);
 
     // Delegate memory injection to the Copilot CLI adapter.
     let summaries = memory::read_last_n(&mem, 3);
-    if let Some(adapter) = crate::hosts::find("copilot") {
+    if let Some(adapter) = adapter {
         let _ = adapter.inject_memory(&cfg, &summaries);
     }
     // Suppress unused-variable warning when copilot adapter is absent at compile time.
@@ -93,7 +103,7 @@ pub fn run_for_host(host_name: &str) -> i32 {
     let _ = std::fs::create_dir_all(&mem);
     let cfg = load_config_from(&data_dir.to_string_lossy());
 
-    let code = run_with_dirs(&sessions, &mem, &cfg);
+    let code = run_with_dirs_for(&sessions, &mem, &cfg, adapter.injects_persona(&cfg));
 
     let summaries = memory::read_last_n(&mem, 3);
     let _ = adapter.inject_memory(&cfg, &summaries);
@@ -152,8 +162,21 @@ pub fn banner_body(
     out
 }
 
-/// Testable version with explicit directories.
+/// Testable version with explicit directories. Prints the persona/focus text
+/// in the banner — the no-host path, where nothing else carries it.
 pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) -> i32 {
+    run_with_dirs_for(sessions_dir, memory_dir, config, false)
+}
+
+/// As [`run_with_dirs`], but told whether the host adapter will write the
+/// persona/focus text into a file it auto-loads. When it will, the banner
+/// leaves that text out instead of teaching it a second time (#218).
+pub fn run_with_dirs_for(
+    sessions_dir: &Path,
+    memory_dir: &Path,
+    config: &Config,
+    persona_in_memory_file: bool,
+) -> i32 {
     // 1. Finalise previous session → memory (best-effort)
     if let Some(prev) = CurrentSession::load(sessions_dir) {
         finalize(&prev, sessions_dir, memory_dir, config);
@@ -238,15 +261,21 @@ pub fn run_with_dirs(sessions_dir: &Path, memory_dir: &Path, config: &Config) ->
     for l in banner_body(config, &summaries, stats_line, degraded) {
         println!("{}", l);
     }
-    let persona_text = persona::text(config.persona);
-    if !persona_text.is_empty() {
-        println!();
-        print!("{}", persona_text);
-    }
-    let focus_text = focus::text_with_lang(config.focus, &config.lang);
-    if !focus_text.is_empty() {
-        println!();
-        print!("{}", focus_text);
+    // The persona/focus text is normally injected into the host's auto-loaded
+    // instructions file (CLAUDE.md and friends). Repeating it here would teach
+    // it twice per session (#218), so the banner carries it only for a host
+    // that has no such file to write to.
+    if !persona_in_memory_file {
+        let persona_text = persona::text_with_lang(config.persona, &config.lang);
+        if !persona_text.is_empty() {
+            println!();
+            print!("{}", persona_text);
+        }
+        let focus_text = focus::text_with_lang(config.focus, &config.lang);
+        if !focus_text.is_empty() {
+            println!();
+            print!("{}", focus_text);
+        }
     }
     // Enterprise-mode hint: when running through Bedrock/Vertex/OTEL,
     // every saved token converts directly to USD on the workspace bill.

--- a/src/hosts/hermes.rs
+++ b/src/hosts/hermes.rs
@@ -168,6 +168,15 @@ impl HostAdapter for HermesAdapter {
         Ok(())
     }
 
+    /// Hermes is the one host whose injection is conditional: without SOUL.md
+    /// there is no auto-loaded file to write to, so the session banner stays
+    /// the only channel that reaches the model.
+    fn injects_persona(&self, cfg: &Config) -> bool {
+        Self::soul_md_path().exists()
+            && (!persona::text_with_lang(cfg.persona, &cfg.lang).is_empty()
+                || !focus::text_with_lang(cfg.focus, &cfg.lang).is_empty())
+    }
+
     fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()> {
         let soul = Self::soul_md_path();
         if !soul.exists() {

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -90,6 +90,23 @@ pub trait HostAdapter {
     /// Write the squeez memory block into the host's auto-loaded instructions
     /// file (CLAUDE.md / copilot-instructions.md / GEMINI.md / AGENTS.md).
     fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()>;
+
+    /// Whether [`Self::inject_memory`] puts the persona/focus text into a file
+    /// this host auto-loads at every session start.
+    ///
+    /// When true, `squeez init` leaves that text out of its session banner:
+    /// otherwise both channels reach the model and the persona is taught twice
+    /// per session — ~145 tokens paid twice, in a tool whose whole point is not
+    /// paying them (#218). The instructions file is the copy worth keeping: it
+    /// is language-aware and the host re-loads it after a compaction, while the
+    /// banner carries the genuinely per-session lines the file cannot.
+    ///
+    /// The default holds for every adapter that unconditionally writes an
+    /// instructions file; a host that may skip injection overrides it.
+    fn injects_persona(&self, cfg: &Config) -> bool {
+        !crate::commands::persona::text_with_lang(cfg.persona, &cfg.lang).is_empty()
+            || !crate::commands::focus::text_with_lang(cfg.focus, &cfg.lang).is_empty()
+    }
 }
 
 // ── Registry ───────────────────────────────────────────────────────────────
@@ -138,5 +155,32 @@ mod tests {
     fn find_returns_hermes() {
         let a = find("hermes").expect("adapter");
         assert_eq!(a.name(), "hermes");
+    }
+
+    #[test]
+    fn hosts_with_an_instructions_file_own_the_persona_channel() {
+        // #218: every adapter but Hermes writes an auto-loaded instructions
+        // file unconditionally, so `squeez init` must not repeat the text.
+        let mut cfg = Config::default();
+        cfg.persona = crate::commands::persona::Persona::Ultra;
+        for h in all_hosts() {
+            if h.name() == "hermes" {
+                continue; // conditional on SOUL.md existing on this machine
+            }
+            assert!(
+                h.injects_persona(&cfg),
+                "{} should own the persona channel",
+                h.name()
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_to_inject_leaves_the_channel_free() {
+        let mut cfg = Config::default();
+        cfg.persona = crate::commands::persona::Persona::Off;
+        cfg.focus = crate::commands::focus::Focus::Off;
+        let a = find("claude-code").expect("adapter");
+        assert!(!a.injects_persona(&cfg));
     }
 }


### PR DESCRIPTION
Closes #218. Both reported problems, one commit each.

## 1. The persona was taught twice

`inject_memory()` writes the persona/focus text into the host's auto-loaded
instructions file, and the `squeez init` banner emits the same text again as
SessionStart context. Both reach the model. ~145 tokens, paid twice, on every
session in every project, before any real work starts.

`HostAdapter::injects_persona()` now declares which channel owns the text; the
banner leaves it out when the adapter writes an auto-loaded file.

Kept the instructions-file copy rather than the banner, contrary to the issue's
suggestion: it is language-aware, and the host re-loads it after a compaction,
while the banner keeps the per-session lines (context budget, prior-session
counts, pipeline health) that a static file cannot carry. Both channels stay
alive — only the duplication goes.

Hermes overrides the default: it is the one adapter that skips injection when
`SOUL.md` is absent, so its banner keeps carrying the text.

This also fixes a latent bug on the same lines — the banner called
`persona::text()` instead of `text_with_lang()`, so a `lang = pt-BR` user got
the English persona in the banner while the injected block was translated.

## 2. `auto_compress_md` was rewriting squeez's own block

The prose pass ran straight through the `<!-- squeez:start -->` …
`<!-- squeez:end -->` region. On a real install it had mangled the punctuation
of squeez's own rules — including the rule that says inline code is left
unchanged:

```diff
- - Inline `code`: unchanged
+ - Inline `code`unchanged
```

The state machine now passes the block through verbatim and resumes
compressing after the closing marker. An unterminated marker leaves the rest of
the file uncompressed — the safe direction.

## Verification

Real `squeez init` against an isolated `HOME`, `persona = ultra`,
`auto_compress_md = true`:

```
─── squeez active ─────────────────────────────────────────
Context budget: ~200K tokens | Compression: ON | Memory: ON | Persona: ultra
────────────────────────────────────────────────────────────
```

One persona copy, in `CLAUDE.md`. After auto-compression the block is intact —
the inline-code rule keeps its colon and "what actually saves tokens" keeps its
word — while prose *outside* the markers still compresses ("The user is going
to be able to run the thing." → " user is going to be able to run thing.").
The original corruption reproduces on the same fixture before the change.

New tests: 2 in `compress_md` (block preserved byte-for-byte; text after the
block still compressed) and 2 in `hosts` (every unconditional adapter owns the
channel; nothing to inject leaves it free). Full suite: 94 binaries, no
failures.
