### PR TITLE
fix(init): banner reports the detected window; unflake the context-lock test (#222, #223)

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -229,13 +229,24 @@ pub fn run_with_dirs_for(
     // 4. Print banner to stdout (SessionStart hook captures this as context)
     // Window-aware budget (transcript audit CF-2): the audited session showed
     // "~112K tokens" while running on a 1M-window model that reached 286K —
-    // when the user configures the real window, report it instead of the
-    // legacy compact-threshold formula.
-    let budget_k = crate::context::intensity::budget(&config) / 1000;
-    let budget_label = if config.context_window_tokens > 0 {
-        "Context window"
-    } else {
+    // when the real window is known, report it instead of the legacy
+    // compact-threshold formula.
+    //
+    // `budget()` is `budget_for(cfg, 0)`: it sees only a pinned
+    // `context_window_tokens` and throws away the window detected from the
+    // transcript. Every other consumer (burn rate, intensity, the pressure
+    // warnings) passes `real_ctx_window`, so the banner alone announced
+    // "~200K" on a session whose own warnings were already measuring against
+    // 1M. Read the same detected window they do.
+    let real_window = crate::context::cache::SessionContext::load(sessions_dir).real_ctx_window;
+    let budget_k = crate::context::intensity::budget_for(config, real_window) / 1000;
+    // "window" is a claim of fact, so make it only when the window is one:
+    // pinned, or detected above the 200K standard. An unproven fallback stays
+    // "budget" rather than asserting a number squeez is guessing at.
+    let budget_label = if crate::context::intensity::window_is_assumed(config, real_window) {
         "Context budget"
+    } else {
+        "Context window"
     };
     // focus=adhd reorders the banner action-first and shows one prior session
     // instead of three (working memory is small; stats are not an action).

--- a/tests/test_agent_guard.rs
+++ b/tests/test_agent_guard.rs
@@ -113,9 +113,32 @@ fn update_is_not_wedged_by_an_abandoned_lock() {
 }
 
 #[test]
+fn sequential_updates_are_counted_exactly() {
+    // The uncontended path has no fail-open escape, so it is exact. This is
+    // where "every update lands, none double-counts" is pinned down; the
+    // concurrent test below can then assert only what contention allows.
+    let dir = tmp_dir("sequential");
+    for _ in 0..40 {
+        SessionContext::update(&dir, |c| c.note_agent_spawn("Agent", 10));
+    }
+    let got = SessionContext::load(&dir);
+    assert_eq!(got.agent_spawns, 40, "uncontended updates must be exact");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn concurrent_updates_do_not_lose_every_increment() {
     // Threads stand in for the parallel hook processes. Without serialization
     // this collapses toward 1; the point is that it does not.
+    //
+    // Deliberately NOT asserting all 40. `CtxLock::acquire` fails open after
+    // LOCK_WAIT_MS so a hook can never block a tool call, which means a
+    // heavily loaded machine may legitimately drop an increment — observed in
+    // CI as 39/40. Demanding exactness asserts a guarantee the lock does not
+    // make and turns a documented trade-off into a flake. The floor still
+    // separates working serialization from none by a wide margin: measured on
+    // this same workload, the identical read-modify-write with the lock removed
+    // lands 5-8 of 40, while the locked path lands 39-40.
     let dir = tmp_dir("concurrent");
     let handles: Vec<_> = (0..8)
         .map(|_| {
@@ -131,9 +154,14 @@ fn concurrent_updates_do_not_lose_every_increment() {
         h.join().unwrap();
     }
     let got = SessionContext::load(&dir);
-    assert_eq!(
-        got.agent_spawns, 40,
-        "40 serialized increments expected, got {}",
+    assert!(
+        got.agent_spawns >= 32,
+        "serialization lost too many increments: got {} of 40, floor is 32",
+        got.agent_spawns
+    );
+    assert!(
+        got.agent_spawns <= 40,
+        "counted more increments than were issued: got {} of 40",
         got.agent_spawns
     );
     let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
Closes #222. Closes #223. One commit each.

## 1. Banner announced the assumed window (#222)

`intensity::budget(&config)` is defined as `budget_for(cfg, 0)` — it reads a pinned `context_window_tokens` and discards `real_ctx_window`. Every other consumer (`burn_rate`, `agent_tracker`, `derive_with`, the `wrap.rs` pressure warnings) passes the detected window, so a single `squeez init` contradicted itself:

```
⚠️  squeez: session ~376K tokens (37% of budget). Run /compact to free context.
Context budget: ~200K tokens | Compression: ON | Memory: ON | Persona: ultra
```

376K is 37% of 1M; `context.json` held `real_ctx_window = 1000000`.

Same install, before and after this change:

```
BEFORE:  Context budget: ~200K tokens
AFTER:   Context window: ~1000K tokens
```

The label now keys to `window_is_assumed()` instead of the config pin alone, so `Context window` is a claim made only when the window is actually established (pinned, or detected above the 200K standard); an unproven fallback still reads `Context budget`.

This surfaced because #219 made 1M auto-detectable without pinning — previously the pin was the only way to get a correct window, and the pin is the one input `budget()` does read.

## 2. Flaky concurrency assertion (#223)

`concurrent_updates_do_not_lose_every_increment` demanded all 40 increments, but `CtxLock::acquire` fails open after `LOCK_WAIT_MS` precisely so a hook can never block a tool call. Dropping an increment under load is the documented trade, not a bug — CI hit 39/40 and reddened `main` on the release bot's version-bump commit, which touches only `Cargo.toml`/`Cargo.lock`.

The assertion now matches the contract: a floor that still catches a real serialization failure, plus an upper bound so a double-count cannot hide behind the relaxed floor.

**The floor is measured, not guessed.** I ran the identical workload with the lock removed:

```
UNLOCKED trial 0: 8 of 40
UNLOCKED trial 1: 5 of 40
UNLOCKED trial 2: 8 of 40
```

against 39-40 for the locked path. A floor of 32 sits in a wide gap between the two regimes, so the test still fails loudly if serialization ever breaks.

`sequential_updates_are_counted_exactly` is added to keep exactness pinned down on the uncontended path, which has no fail-open escape and so can be asserted precisely — relaxing the concurrent bound costs no coverage.

## Verification

Full suite: 95 binaries, no failures. `test_agent_guard` run 5 consecutive times, clean each time.
