### PR TITLE
fix(context): treat Fable/Mythos as native 1M window

### DIFF
--- a/assets/buddy/lib/hud.js
+++ b/assets/buddy/lib/hud.js
@@ -96,6 +96,9 @@ function contextTokens(transcriptPath) {
 }
 
 const LONG_CONTEXT_RE = /\[1m\]|-1m\b|context-1m|\b1m\s+context\b/i;
+// Fable / Mythos têm 1M nativo — id e display_name vêm crus (`claude-fable-5-1`,
+// "Fable 5.1"), sem marcador nenhum.
+const NATIVE_1M_RE = /fable|mythos/i;
 
 /**
  * Janela de contexto do host. Precedência:
@@ -115,6 +118,7 @@ function contextWindow(model, pinnedTokens) {
     typeof model === 'string'
       ? model
       : `${(model && model.id) || ''} ${(model && model.display_name) || ''}`;
+  if (NATIVE_1M_RE.test(probe)) return 1_000_000;
   return LONG_CONTEXT_RE.test(probe) ? 1_000_000 : 200_000;
 }
 

--- a/assets/buddy/test/hud.test.js
+++ b/assets/buddy/test/hud.test.js
@@ -70,6 +70,9 @@ test('janela de contexto: sufixo [1m] vale 1M, resto 200k', () => {
   assert.strictEqual(contextWindow('claude-opus-4-8[1m]'), 1_000_000);
   assert.strictEqual(contextWindow('claude-sonnet-5'), 200_000);
   assert.strictEqual(contextWindow(undefined), 200_000);
+  // Fable / Mythos: 1M nativo, sem marcador no id nem no display_name.
+  assert.strictEqual(contextWindow('claude-fable-5-1'), 1_000_000);
+  assert.strictEqual(contextWindow({ id: 'claude-fable-5-1', display_name: 'Fable 5.1' }), 1_000_000);
 });
 
 test('janela de contexto: display_name decide quando o id não carrega marcador', () => {

--- a/src/context/transcript.rs
+++ b/src/context/transcript.rs
@@ -188,6 +188,11 @@ pub fn last_cache_ratio_in(text: &str) -> Option<(u64, u64)> {
 /// marker as `(1M context)` rather than a `[1m]` suffix.
 pub fn window_for_model(model: &str) -> u64 {
     let m = model.to_ascii_lowercase();
+    // Fable / Mythos ship 1M natively — no `[1m]` marker in the id or the
+    // marketing name (`claude-fable-5-1` / `Fable 5.1`).
+    if m.contains("fable") || m.contains("mythos") {
+        return 1_000_000;
+    }
     if m.contains("[1m]") || m.contains("-1m") || m.contains(" 1m") || m.contains("(1m") {
         1_000_000
     } else {
@@ -386,6 +391,15 @@ mod tests {
         assert_eq!(window_for_model("claude-opus-4-8[1m]"), 1_000_000);
         assert_eq!(window_for_model("claude-sonnet-5"), 200_000);
         assert_eq!(window_for_model("claude-opus-4-8"), 200_000);
+    }
+
+    #[test]
+    fn window_for_model_treats_fable_family_as_native_1m() {
+        // Fable / Mythos carry no `[1m]` marker anywhere: id and marketing
+        // name are bare, yet the window is 1M.
+        assert_eq!(window_for_model("claude-fable-5-1"), 1_000_000);
+        assert_eq!(window_for_model("claude-fable-5-1 Fable 5.1"), 1_000_000);
+        assert_eq!(window_for_model("Mythos 5.1"), 1_000_000);
     }
 
     #[test]


### PR DESCRIPTION
Closes #228

Fable 5.1 has a native 1M context window but carries no `[1m]` / `(1M context)` marker in its model id or marketing name, so squeez assumed 200K and the statusline showed `175k/200k`.

- `assets/buddy/lib/hud.js`: `contextWindow()` returns 1M for the Fable/Mythos family before the marker sniff.
- `src/context/transcript.rs`: `window_for_model()` does the same, so budget/pressure/burn-rate math and the SessionStart banner key off 1M.
- Regression tests on both sides (`node --test` 15/15, `cargo test window_for_model` 3/3).