### PR TITLE
fix(json): decode escapes on read so backslashes stop doubling per save

### DIFF
--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -35,7 +35,7 @@ pub fn build_summary() -> Option<String> {
         let listed: Vec<String> = files
             .iter()
             .take(8)
-            .map(|f| format!("{}({})", f.path, f.access.as_char()))
+            .map(|f| format!("{}({})", cap_chars(&f.path, 160), f.access.as_char()))
             .collect();
         parts.push(format!("files: {}", listed.join(", ")));
     }
@@ -92,20 +92,28 @@ pub fn build_summary() -> Option<String> {
     if parts.is_empty() {
         return None;
     }
-    Some(format!(
+    let text = format!(
         "[squeez session state — restored after compaction] {}",
         parts.join("; ")
-    ))
+    );
+    // Hard ceiling: this lands in the context right after compaction reclaimed
+    // it, and a state summary never legitimately needs more. Any future
+    // escaping regression (#229) then costs a few KB, not millions of tokens.
+    Some(cap_chars(&text, MAX_SUMMARY_CHARS))
 }
 
+/// Upper bound on the re-injected summary, in chars.
+const MAX_SUMMARY_CHARS: usize = 4000;
+
 fn trim_snippet(s: &str) -> String {
-    let one_line = s.replace('\n', " ");
-    let t = one_line.trim();
-    const MAX: usize = 80;
-    if t.chars().count() <= MAX {
-        t.to_string()
+    cap_chars(s.replace('\n', " ").trim(), 80)
+}
+
+fn cap_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
     } else {
-        let cut: String = t.chars().take(MAX).collect();
+        let cut: String = s.chars().take(max).collect();
         format!("{cut}…")
     }
 }
@@ -121,6 +129,14 @@ mod tests {
         let out = trim_snippet(&long);
         assert!(out.ends_with('…'));
         assert!(out.chars().count() <= 81);
+    }
+
+    #[test]
+    fn cap_chars_bounds_oversized_text() {
+        let huge = "\\".repeat(1 << 20);
+        let out = cap_chars(&huge, MAX_SUMMARY_CHARS);
+        assert_eq!(out.chars().count(), MAX_SUMMARY_CHARS + 1);
+        assert_eq!(cap_chars("short", MAX_SUMMARY_CHARS), "short");
     }
 }
 

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -1911,6 +1911,31 @@ mod tests {
     }
 
     #[test]
+    fn windows_paths_survive_repeated_round_trips_unchanged() {
+        // Issue #229: each load/save re-escaped every backslash, so a tracked
+        // Windows path doubled its backslashes per cycle.
+        let path = r"C:\Users\You\test\path.txt";
+        let mut c = SessionContext::default();
+        c.session_file = r"C:\sessions\a.jsonl".to_string();
+        c.note_file(path, FileAccess::Read);
+        c.error_snippets.push((1, r#"error: "C:\x" not found"#.to_string()));
+        c.seen_git_refs.push(r"refs\heads\main".to_string());
+        c.last_budget_tag = r"[a\b]".to_string();
+
+        let mut json = c.to_json();
+        for _ in 0..8 {
+            json = SessionContext::from_json(&json).to_json();
+        }
+        let r = SessionContext::from_json(&json);
+        assert_eq!(json.len(), c.to_json().len(), "serialized size must not grow");
+        assert_eq!(r.seen_files[0].path, path);
+        assert_eq!(r.session_file, c.session_file);
+        assert_eq!(r.error_snippets[0].1, c.error_snippets[0].1);
+        assert_eq!(r.seen_git_refs, c.seen_git_refs);
+        assert_eq!(r.last_budget_tag, c.last_budget_tag);
+    }
+
+    #[test]
     fn normalize_url_path_strips_scheme_query_and_www() {
         assert_eq!(normalize_url_path("https://app.co/x?t=1#a"), "app.co/x");
         assert_eq!(normalize_url_path("http://app.co/x"), "app.co/x");

--- a/src/context/cache.rs
+++ b/src/context/cache.rs
@@ -428,6 +428,36 @@ impl Drop for CtxLock {
     }
 }
 
+/// Collapse absurd backslash runs left in `context.json` by the pre-#229
+/// escape-doubling bug, so already-corrupted state self-heals on load instead
+/// of staying multi-MB until the rolling reset. Operates on raw JSON: a run of
+/// 32+ backslashes (16+ decoded — no real path or command carries that) becomes
+/// one escaped backslash, keeping the run's parity so an odd run still escapes
+/// the character that follows it.
+fn heal_backslash_runs(raw: &str) -> std::borrow::Cow<'_, str> {
+    const MIN_RUN: usize = 32;
+    if !raw.contains(&"\\".repeat(MIN_RUN / 2)) {
+        return std::borrow::Cow::Borrowed(raw);
+    }
+    let mut out = String::with_capacity(raw.len());
+    let mut run = 0usize;
+    let flush = |out: &mut String, run: usize| match run {
+        n if n >= MIN_RUN => out.push_str(if n % 2 == 0 { "\\\\" } else { "\\\\\\" }),
+        n => (0..n).for_each(|_| out.push('\\')),
+    };
+    for ch in raw.chars() {
+        if ch == '\\' {
+            run += 1;
+            continue;
+        }
+        flush(&mut out, run);
+        run = 0;
+        out.push(ch);
+    }
+    flush(&mut out, run);
+    std::borrow::Cow::Owned(out)
+}
+
 // ── Public API ─────────────────────────────────────────────────────────────
 
 impl SessionContext {
@@ -441,7 +471,7 @@ impl SessionContext {
             Ok(s) => s,
             Err(_) => return Self::default(),
         };
-        Self::from_json(&content)
+        Self::from_json(&heal_backslash_runs(&content))
     }
 
     /// Copy tunable values from Config into this context so all methods use
@@ -1933,6 +1963,21 @@ mod tests {
         assert_eq!(r.error_snippets[0].1, c.error_snippets[0].1);
         assert_eq!(r.seen_git_refs, c.seen_git_refs);
         assert_eq!(r.last_budget_tag, c.last_budget_tag);
+    }
+
+    #[test]
+    fn corrupted_backslash_runs_heal_on_load() {
+        // State written before the #229 fix: each separator 2^k backslashes.
+        let mut c = SessionContext::default();
+        c.note_file(r"C:\Users\You", FileAccess::Read);
+        c.session_file = r"a\b".to_string();
+        let raw = c.to_json().replace(r"\\", &"\\".repeat(1 << 12));
+        let healed = SessionContext::from_json(&heal_backslash_runs(&raw));
+        assert_eq!(healed.seen_files[0].path, r"C:\Users\You");
+        assert_eq!(healed.session_file, r"a\b");
+        // Ordinary escaping is left alone.
+        let fine = r#"{"session_file":"\\\\server\\share"}"#;
+        assert!(matches!(heal_backslash_runs(fine), std::borrow::Cow::Borrowed(_)));
     }
 
     #[test]

--- a/src/json_util.rs
+++ b/src/json_util.rs
@@ -11,8 +11,14 @@ pub fn extract_str(json: &str, key: &str) -> Option<String> {
         return None;
     }
     pos += 1;
-    let end = json[pos..].find('"')?;
-    Some(json[pos..pos + end].to_string())
+    let start = pos;
+    while pos < bytes.len() && bytes[pos] != b'"' {
+        pos += if bytes[pos] == b'\\' { 2 } else { 1 };
+    }
+    if pos >= bytes.len() {
+        return None;
+    }
+    Some(unescape_str(&json[start..pos]))
 }
 
 /// Extract a u64 value from a flat JSON object: {"key":123,...}
@@ -83,17 +89,46 @@ pub fn extract_str_array(json: &str, key: &str) -> Vec<String> {
     if arr.trim().is_empty() {
         return Vec::new();
     }
-    split_json_array_items(arr)
+    decode_str_items(arr)
+}
+
+/// Decode each quoted item of a JSON string-array interior, dropping empties.
+fn decode_str_items(inner: &str) -> Vec<String> {
+    split_json_array_items(inner)
         .iter()
         .filter_map(|s| {
-            let s = s.trim().trim_matches('"');
+            let s = s.trim();
+            let s = s.strip_prefix('"').unwrap_or(s);
+            let s = s.strip_suffix('"').unwrap_or(s);
             if s.is_empty() {
                 None
             } else {
-                Some(s.to_string())
+                Some(unescape_str(s))
             }
         })
         .collect()
+}
+
+/// Decode the contents of a JSON string literal (quotes already stripped).
+///
+/// Every extractor above must return *decoded* text. They used to hand back
+/// the raw escaped slice, and every writer escapes again on save — so each
+/// load/save cycle doubled every backslash. A tracked Windows path grew 4× per
+/// wrapped command until `context.json` reached tens of MB (issue #229).
+/// Malformed input is returned unchanged rather than dropped.
+pub fn unescape_str(raw: &str) -> String {
+    if !raw.contains('\\') {
+        return raw.to_string();
+    }
+    let mut chars: Vec<char> = Vec::with_capacity(raw.len() + 2);
+    chars.push('"');
+    chars.extend(raw.chars());
+    chars.push('"');
+    let mut pos = 0;
+    match parse_str(&chars, &mut pos) {
+        Some(s) if pos == chars.len() => s,
+        _ => raw.to_string(),
+    }
 }
 
 /// Escape a string for inclusion in a JSON string value (not quoted).
@@ -301,7 +336,7 @@ pub fn extract_all(json: &str) -> HashMap<&str, &str> {
 }
 
 pub fn map_str(map: &HashMap<&str, &str>, key: &str) -> Option<String> {
-    map.get(key).map(|v| v.to_string())
+    map.get(key).map(|v| unescape_str(v))
 }
 
 pub fn map_u64(map: &HashMap<&str, &str>, key: &str) -> Option<u64> {
@@ -325,17 +360,7 @@ pub fn map_str_array(map: &HashMap<&str, &str>, key: &str) -> Vec<String> {
     if inner.trim().is_empty() {
         return Vec::new();
     }
-    split_json_array_items(inner)
-        .iter()
-        .filter_map(|s| {
-            let s = s.trim().trim_matches('"');
-            if s.is_empty() {
-                None
-            } else {
-                Some(s.to_string())
-            }
-        })
-        .collect()
+    decode_str_items(inner)
 }
 
 pub fn map_u64_array(map: &HashMap<&str, &str>, key: &str) -> Vec<u64> {

--- a/tests/test_json_util.rs
+++ b/tests/test_json_util.rs
@@ -118,3 +118,31 @@ fn test_escaped_control_chars_reparse_as_json() {
     let parsed = squeez::json_util::parse_value(&doc).expect("escaped payload must parse");
     assert_eq!(parsed.get_str("text"), raw);
 }
+
+// Issue #229: extractors must return decoded text, or every load/save cycle
+// re-escapes the backslashes it failed to decode.
+#[test]
+fn test_extractors_decode_escapes() {
+    use squeez::json_util::{escape_str, extract_all, extract_str, extract_str_array, map_str, map_str_array, str_array};
+    let path = r#"C:\Users\You\"quoted".txt"#;
+    let obj = format!(
+        "{{\"p\":\"{}\",\"a\":{},\"n\":1}}",
+        escape_str(path),
+        str_array(&[path.to_string(), "plain".to_string()])
+    );
+    assert_eq!(extract_str(&obj, "p").as_deref(), Some(path));
+    assert_eq!(extract_str_array(&obj, "a"), vec![path.to_string(), "plain".to_string()]);
+    let map = extract_all(&obj);
+    assert_eq!(map_str(&map, "p").as_deref(), Some(path));
+    assert_eq!(map_str_array(&map, "a"), vec![path.to_string(), "plain".to_string()]);
+}
+
+#[test]
+fn test_escape_then_extract_is_a_fixed_point() {
+    use squeez::json_util::{escape_str, extract_str};
+    let mut v = r"C:\a\b".to_string();
+    for _ in 0..6 {
+        v = extract_str(&format!("{{\"k\":\"{}\"}}", escape_str(&v)), "k").unwrap();
+    }
+    assert_eq!(v, r"C:\a\b");
+}


### PR DESCRIPTION
## Summary

The flat-JSON extractors in `src/json_util.rs` (`extract_str`, `extract_str_array`, `map_str`, `map_str_array`) returned the raw *escaped* slice, while every writer escapes on save. Each load/save cycle therefore doubled every backslash in `context.json`, memory summaries and stash sidecars. On Windows a tracked path grew 4× per wrapped command (two saves per command).

- New `json_util::unescape_str`, used by all four extractors (reuses the existing recursive parser's string decoder).
- `extract_str` now stops at the first *unescaped* quote instead of any quote.
- Already-corrupted state self-heals: on load, any raw run of 32+ backslashes (16+ decoded — no real path or command carries that) collapses to one escaped backslash, keeping parity.
- `compact-summary` output is hard-capped at 4000 chars (paths at 160), so any future escaping regression costs a few KB after compaction instead of millions of tokens.

## Verification

- New `context::cache` test round-trips a Windows path, error snippet, git ref and tag through 8 save/load cycles and asserts the serialized size does not grow. Without the fix it fails: `left: 7683, right: 1563`.
- New `tests/test_json_util.rs` cases: extractors decode `\\` and `\"`; escape→extract is a fixed point over 6 cycles.
- Same repro against the `main` binary vs this branch (6× `squeez wrap 'ls C:\Users\You\test\path.txt'`): `main` stores the oldest `call_log_cmd` entry with 64 backslashes per separator; this branch stores `C:\\Users\\…` (one escape) on every entry.
- `corrupted_backslash_runs_heal_on_load`: a serialized context whose separators were inflated to 4096 backslashes loads back as `C:\Users\You`.
- `cargo test`: 1246 passed, 0 failed.

Fixes #229
