### PR TITLE
fix(compact): restore session state from SessionStart, not PostCompact

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ No Makefile — tooling is Cargo-native.
 
 Hook-based bash-output compressor for seven CLI agent hosts (Claude Code, Copilot CLI, OpenCode, Gemini CLI, Codex CLI, Pi, Hermes). Intercepts tool invocations and compresses output before the model sees it.
 
-Claude Code hooks: PreToolUse → wrap / budget / prompt-compress / **agent-spawn ceiling**; SessionStart → init; PostToolUse → track-result + `updatedToolOutput` rewrite; SubagentStop → feed sub-agent output into SessionContext + release a spawn slot; PreCompact / PostCompact → log + re-arm.
+Claude Code hooks: PreToolUse → wrap / budget / prompt-compress / **agent-spawn ceiling**; SessionStart → init (+ post-compact state restore on `source: compact`); PostToolUse → track-result + `updatedToolOutput` rewrite; SubagentStop → feed sub-agent output into SessionContext + release a spawn slot; PreCompact / PostCompact → log + re-arm.
 
 **Pipeline** (per invocation): `smart_filter` (ANSI/progress/spinners/timestamps) → `dedup` (repeats → `[×N]`) → `grouping` (≥5 siblings → `dir/  N modified`) → `truncation` (head/tail by handler).
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ squeez update --insecure  # skip checksum (not recommended)
 | **`git status` porcelain** | `git status` is re-run as `git status --porcelain=v1 -b` and rendered as a working-tree summary (branch, ahead/behind, staged/unstaged/untracked/conflicted). Exact paths are preserved, never collapsed to counts, and raw porcelain codes never reach the model. In-progress rebase/merge/bisect/cherry-pick — which porcelain omits — is read from `.git/` markers rather than a second `git status` run. Yields to any output flag you passed yourself; degrades to raw output on an unrecognized shape. |
 | **Preservation guard** | On calls that reduce by ≥90%, the surviving fraction of navigation anchors (file paths, `file:line` refs, error markers, test verdicts) is scored at wrap time. Below `preservation_floor` (0.70) the verbatim original is stashed even outside the usual size gates and the header carries `[anchors: N%]` — so over-compression costs a marker, not a re-investigation. |
 | **Config CLI + `/squeez`** | `squeez config get/set/list/reset/path` reads and writes `config.ini` safely (schema validation, comment-preserving writes). `squeez setup` installs a `/squeez` slash command that drives it in natural language from inside the session. |
-| **Post-compact re-injection** | After `/compact`, the `PostCompact` hook re-injects squeez's tracked session state (recent files, error snippets, git refs, retrievable blob ids) as `additionalContext` — so concrete state survives compaction instead of being re-discovered. |
+| **Post-compact re-injection** | After `/compact`, the `SessionStart` hook (`source: compact`) re-injects squeez's tracked session state (recent files, error snippets, git refs, retrievable blob ids), capped at 4000 chars — so concrete state survives compaction instead of being re-discovered. |
 | **Bash-wrap safety** | Risky commands (`rm -rf`, `git push --force`, `npm publish`, … — configurable `bash_risk_patterns`) and bypassed commands run **unwrapped**, so the host's native permission rules evaluate the original command. `wrap_bash = false` disables wrapping entirely. See [SECURITY.md](SECURITY.md). |
 | **Token estimate** | Compression-timing decisions use a content-class calibrated estimate: output is classified Dense/Prose/Mixed and counted at chars/2.0, chars/3.7, or the code- and CJK-aware char-class estimator — dense tool output really runs ~1.9 chars/token in production, not chars/4. Flat legacy path stays available via `class_density = false`. |
 | **Auto-teach payload** | `squeez protocol` (or the `squeez_protocol` MCP tool) prints a 2.4 KB self-describing payload — the LLM learns squeez's markers and protocol on first call. |
@@ -174,7 +174,7 @@ squeez optimizes what it can reach — the surfaces exposed by each host's hook 
 | **Read / Grep / Glob / Monitor output rewrite** | `PostToolUse` runs `squeez compress-output` and returns `updatedToolOutput` when content is redundant or oversized | Claude Code v2.1.119+ | Claude Code |
 | **Agent / Task prompt** | `PreToolUse` compresses `tool_input.prompt` (markdown-aware, via `compress-prompt`) | When prompt > `agent_prompt_max_tokens` | Claude Code (post–v1.8.0) |
 | **Sub-agent output** | `SubagentStop` hook feeds `last_assistant_message` into SessionContext for cross-call dedup | On every sub-agent completion | Claude Code |
-| **Compaction lifecycle** | `PreCompact` logs the event; `PostCompact` re-injects tracked session state (files, errors, git refs, retrievable blob ids) as `additionalContext` so it survives compaction | On context compaction | Claude Code |
+| **Compaction lifecycle** | `PreCompact` / `PostCompact` log the event; `SessionStart` (`source: compact`) re-injects tracked session state (files, errors, git refs, retrievable blob ids) so it survives compaction | On context compaction | Claude Code |
 | **Session memory** | `SessionStart` injects prior session summary + file-access cache | Once per session start | all 5 |
 | **Markdown viewing** | Bash handler routes `.md` reads through `compress-md` when `auto_compress_md=true` | Viewer commands on .md paths | all 5 |
 
@@ -324,7 +324,7 @@ squeez update [--check] [--insecure]     # self-update
 squeez init [--copilot]                  # session-start hook (called by hook, not manually)
 squeez calibrate                         # auto-tune config from benchmarks
 squeez budget-params <tool>              # output JSON budget patch for tool
-squeez compact-summary                   # PostCompact hook: re-inject session state (called by hook)
+squeez compact-summary [--session-start] # re-inject session state after /compact (called by SessionStart hook)
 squeez --version
 ```
 
@@ -590,7 +590,7 @@ Six hooks work together automatically after install on Claude Code (three on Cop
 - **`PostToolUse`** — tracks every tool result; rewrites Read/Grep/Glob/Monitor output via `updatedToolOutput` when content is redundant or oversized (Claude Code v2.1.119+)
 - **`SubagentStop`** *(Claude Code only)* — feeds `last_assistant_message` into SessionContext so the parent agent can dedup against what the sub-agent saw
 - **`PreCompact`** *(Claude Code only)* — logs compaction events for session efficiency metrics; allows compaction to proceed
-- **`PostCompact`** *(Claude Code only)* — re-injects tracked session state (files, errors, git refs, retrievable blob ids) as `additionalContext` so it survives compaction (`squeez compact-summary`)
+- **`PostCompact`** *(Claude Code only)* — logs the compaction. Session state (files, errors, git refs, retrievable blob ids) is re-injected by `SessionStart` with `source: compact` (`squeez compact-summary --session-start`), since Claude Code does not deliver PostCompact output to the model
 
 ### Cross-call redundancy
 

--- a/hooks/postcompact.sh
+++ b/hooks/postcompact.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env bash
-# squeez PostCompact hook — re-injects session state after context compaction.
+# squeez PostCompact hook — logs the compaction.
 #
-# PostCompact fires after Claude Code compacts the context window. Compaction
-# can drop concrete state (files touched, errors hit, git refs). squeez already
-# tracks that, so we re-inject it as `additionalContext` — the documented,
-# reliable way to add context that survives into the compacted session — plus
-# pointers to any squeez_retrieve blobs holding dropped output.
+# Session state is restored from session-start.sh (source=compact), not here:
+# Claude Code rejects hookSpecificOutput for PostCompact and only shows its
+# stdout as a UI notice, so nothing emitted here can reach the model (#225).
+# Keep stdout empty.
 set -euo pipefail
 
 SQUEEZ="$HOME/.claude/squeez/bin/squeez"
@@ -15,9 +14,4 @@ if [ ! -x "$SQUEEZ" ]; then
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
 
-"$SQUEEZ" track PostCompact 0 2>/dev/null || true
-
-# Emit the PostCompact hookSpecificOutput JSON (or nothing if there's no state
-# worth restoring). This is the reliable injection path; a plain echo is not
-# guaranteed to reach the model's context.
-"$SQUEEZ" compact-summary 2>/dev/null || true
+"$SQUEEZ" track PostCompact 0 >/dev/null 2>&1 || true

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -25,6 +25,11 @@ if [ ! -x "$SQUEEZ" ]; then
     [ -n "$_sq" ] && SQUEEZ="$_sq"
 fi
 [ ! -x "$SQUEEZ" ] && exit 0
+# After /compact (source=compact on the stdin payload), restore squeez's
+# session state first: it must read the pre-compaction session before init
+# rolls it over, and SessionStart stdout is what reaches the model — PostCompact
+# output does not (#225). Consumes stdin; prints nothing on any other start.
+"$SQUEEZ" compact-summary --session-start 2>/dev/null || true
 "$SQUEEZ" init
 
 # Hook health check — warn if squeez hooks were removed from settings.json

--- a/src/commands/compact.rs
+++ b/src/commands/compact.rs
@@ -6,21 +6,22 @@
 //! recent git refs — and re-discovers it with fresh tool calls.
 //!
 //! A PreCompact hook can't steer the built-in summarizer (researched: no
-//! custom-instructions / transcript-rewrite API; it can only block). But a
-//! **PostCompact** hook can return `additionalContext` that survives into the
-//! freshly-compacted context. So squeez re-injects its own accumulated session
-//! state — which it already tracks in `SessionContext` — as a dense block,
-//! plus pointers to any `squeez_retrieve` blobs holding outputs that
-//! compaction dropped.
+//! custom-instructions / transcript-rewrite API; it can only block). So squeez
+//! re-injects its own accumulated session state — which it already tracks in
+//! `SessionContext` — as a dense block, plus pointers to any `squeez_retrieve`
+//! blobs holding outputs that compaction dropped.
 //!
-//! Output is the Claude Code PostCompact hook JSON shape; the hook script
-//! prints it on stdout.
+//! Delivery goes through **SessionStart** (`source: "compact"`), which fires
+//! right after the compaction summary is written and whose stdout becomes
+//! context. PostCompact cannot inject anything: Claude Code rejects
+//! `hookSpecificOutput` for it and shows its stdout only as a UI notice
+//! (#225). Output is therefore plain text, never hook JSON.
 
 use crate::context::cache::SessionContext;
 use crate::context::retrieve;
 use crate::session;
 
-/// Build the post-compact `additionalContext` text from current session state.
+/// Build the post-compact context text from current session state.
 /// Returns `None` when there's nothing worth re-injecting.
 pub fn build_summary() -> Option<String> {
     let ctx = SessionContext::load(&session::sessions_dir());
@@ -138,16 +139,46 @@ mod tests {
         assert_eq!(out.chars().count(), MAX_SUMMARY_CHARS + 1);
         assert_eq!(cap_chars("short", MAX_SUMMARY_CHARS), "short");
     }
+
+    #[test]
+    fn only_the_compact_source_counts_as_a_compact_start() {
+        assert!(is_compact_start(r#"{"session_id":"s","source":"compact"}"#));
+        assert!(is_compact_start(r#"{"source": "compact"}"#));
+        for other in ["startup", "resume", "clear"] {
+            assert!(!is_compact_start(&format!(r#"{{"source":"{other}"}}"#)));
+        }
+        assert!(!is_compact_start(""));
+    }
 }
 
-/// Emit the PostCompact hook JSON on stdout. Always exits 0 — re-injection is
-/// best-effort and must never disrupt the host.
+/// Whether a SessionStart hook payload is the restart that follows `/compact`.
+pub fn is_compact_start(payload: &str) -> bool {
+    crate::json_util::extract_str(payload, "source").as_deref() == Some("compact")
+}
+
+/// `squeez compact-summary --session-start`: the SessionStart hook entry.
+/// Reads the hook payload from stdin and restores state only when this start
+/// follows a compaction; every other start prints nothing.
+pub fn run_session_start() -> i32 {
+    use std::io::{IsTerminal, Read};
+    let mut stdin = std::io::stdin();
+    if stdin.is_terminal() {
+        return 0;
+    }
+    let mut payload = String::new();
+    let _ = stdin.read_to_string(&mut payload);
+    if is_compact_start(&payload) {
+        run()
+    } else {
+        0
+    }
+}
+
+/// Print the session-state summary as plain text on stdout. Always exits 0 —
+/// re-injection is best-effort and must never disrupt the host.
 pub fn run() -> i32 {
     if let Some(text) = build_summary() {
-        println!(
-            "{{\"hookSpecificOutput\":{{\"hookEventName\":\"PostCompact\",\"additionalContext\":\"{}\"}}}}",
-            crate::json_util::escape_str(&text)
-        );
+        println!("{text}");
     }
     // The header tag-dedup memo (E1) tracks what the model has already seen;
     // compaction rebuilds the model's context from scratch, so the memo must

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,9 +44,14 @@ fn main() {
             std::process::exit(exit_code);
         }
         Some("compact-summary") => {
-            // PostCompact hook: emit dense session state as additionalContext
-            // so it survives /compact. See commands/compact.rs.
-            std::process::exit(squeez::commands::compact::run());
+            // Dense session state that survives /compact, delivered from the
+            // SessionStart hook (source=compact). See commands/compact.rs.
+            let code = if args.get(2).map(String::as_str) == Some("--session-start") {
+                squeez::commands::compact::run_session_start()
+            } else {
+                squeez::commands::compact::run()
+            };
+            std::process::exit(code);
         }
         Some("should-wrap") => {
             // PreToolUse hook gate (#150): exit 0 → safe to rewrite to
@@ -143,7 +148,7 @@ fn main() {
             eprintln!("       squeez protocol                  — print the auto-teach payload");
             eprintln!("       squeez discover                  — rank commands worth a custom filter-DSL rule");
             eprintln!("       squeez filter-test                — run inline tests from .squeez/filters.ini");
-            eprintln!("       squeez compact-summary           — PostCompact hook: re-inject session state");
+            eprintln!("       squeez compact-summary [--session-start] — re-inject session state after /compact");
             eprintln!("       squeez calibrate                 — auto-tune config from benchmarks");
             eprintln!("       squeez doctor                    — self-health check (hooks, config, tracking)");
             eprintln!("       squeez prune                     — clear expired stashed blobs + old session summaries");

--- a/tests/test_compact_summary.rs
+++ b/tests/test_compact_summary.rs
@@ -1,0 +1,75 @@
+//! `squeez compact-summary --session-start` — post-compaction state restore
+//! delivered through SessionStart (#225).
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use squeez::context::cache::{FileAccess, SessionContext};
+
+fn tmp() -> std::path::PathBuf {
+    let d = std::env::temp_dir().join(format!(
+        "squeez_compact_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(d.join("sessions")).unwrap();
+    d
+}
+
+fn run_session_start(dir: &std::path::Path, payload: &str) -> String {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_squeez"))
+        .args(["compact-summary", "--session-start"])
+        .env("SQUEEZ_DIR", dir)
+        .env("HOME", dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("spawn squeez");
+    child.stdin.take().unwrap().write_all(payload.as_bytes()).unwrap();
+    let out = child.wait_with_output().unwrap();
+    assert!(out.status.success(), "exited nonzero: {out:?}");
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn seeded() -> std::path::PathBuf {
+    let dir = tmp();
+    let mut ctx = SessionContext::default();
+    ctx.note_file(r"C:\Users\You\src\main.rs", FileAccess::Read);
+    ctx.save(&dir.join("sessions"));
+    dir
+}
+
+#[test]
+fn compact_start_restores_state_as_plain_text() {
+    let dir = seeded();
+    let out = run_session_start(&dir, r#"{"session_id":"s1","source":"compact"}"#);
+    assert!(out.starts_with("[squeez session state"), "got: {out:?}");
+    // Plain text, never hook JSON: PostCompact's hookSpecificOutput shape is
+    // rejected by Claude Code, and SessionStart stdout is already context.
+    assert!(!out.contains("hookSpecificOutput"), "got: {out:?}");
+    // Decoded once — no doubled backslashes (#229).
+    assert!(out.contains(r"C:\Users\You\src\main.rs(R)"), "got: {out:?}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn other_session_starts_print_nothing() {
+    let dir = seeded();
+    for src in ["startup", "resume", "clear"] {
+        let out = run_session_start(&dir, &format!(r#"{{"source":"{src}"}}"#));
+        assert!(out.is_empty(), "source={src} printed: {out:?}");
+    }
+    assert!(run_session_start(&dir, "").is_empty());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn postcompact_hook_no_longer_emits_the_summary() {
+    let script = include_str!("../hooks/postcompact.sh");
+    let code: Vec<&str> = script.lines().filter(|l| !l.trim_start().starts_with('#')).collect();
+    assert!(!code.iter().any(|l| l.contains("compact-summary")), "{script}");
+    let start = include_str!("../hooks/session-start.sh");
+    assert!(start.contains("compact-summary --session-start"));
+}


### PR DESCRIPTION
## Summary

Claude Code rejects `hookSpecificOutput` for `PostCompact` (the event is not in its whitelist) and only shows `PostCompact` stdout as a UI notice, so squeez's post-compaction state restore never reached the model, and every `/compact` printed a red validation block.

`SessionStart` fires with `source: "compact"` right after the compaction summary is written, and its stdout is context. So:

- `hooks/session-start.sh` runs `squeez compact-summary --session-start` first. It reads the hook payload from stdin and prints the summary as **plain text** only when `source == "compact"`, before `init` rolls the session over (so the pre-compaction stats are still readable). Every other start prints nothing.
- `hooks/postcompact.sh` keeps `squeez track PostCompact 0` and emits nothing.
- `compact-summary` itself now prints plain text instead of PostCompact hook JSON, so stale `postcompact.sh` installs stop tripping validation even before `squeez setup` refreshes the scripts.
- README / CLAUDE.md updated.

Stacked on #229's branch on purpose: this makes the summary deliverable, and the reporter rightly asked that it not ship without the backslash fix and the output cap.

## Verification

- `tests/test_compact_summary.rs` drives the real binary with real payloads: `source=compact` → plain-text state line with the Windows path decoded once; `startup`/`resume`/`clear`/empty stdin → no output; `postcompact.sh` no longer calls `compact-summary`.
- End-to-end with the real hook scripts under an isolated `HOME`: `session-start.sh` with `{"source":"compact"}` prints `[squeez session state — restored after compaction] errors: …` above the banner; with `{"source":"resume"}` only the banner; `postcompact.sh` stdout is 0 bytes.
- Not verified: an actual `/compact` inside a live Claude Code session (can't trigger one from inside this session without losing it).
- `cargo test`: 1251 passed, 0 failed.

Fixes #225
