### PR TITLE
fix(wrap): fail open when the stash is refused instead of compressing lossily

### DIFF
--- a/src/commands/wrap.rs
+++ b/src/commands/wrap.rs
@@ -580,13 +580,23 @@ pub fn run(cmd_str: &str) -> i32 {
     // stashes regardless of line count -- a collapsed `ok git push (...)` on
     // a 6-line output still needs a recovery path, the usual size gates exist
     // to bound the (very different) compression-worth-it decision.
-    let retrieve_marker = if stash_eligible && !net_win_gate {
+    let (retrieve_marker, stash_refused) = if stash_eligible && !net_win_gate {
         context::retrieve::prune(config.retrieve_ttl_days.saturating_mul(86_400));
-        context::retrieve::store(&combined)
-            .map(|id| retrieve_marker_text(orig_line_count, &id))
+        match context::retrieve::store_guarded(&combined) {
+            Ok(id) => (Some(retrieve_marker_text(orig_line_count, &id)), None),
+            Err(reason) => (None, Some(reason)),
+        }
     } else {
-        None
+        (None, None)
     };
+    // No stash means no recovery path, so compressing would silently destroy
+    // the dropped lines — the sensitive-content guard refused to persist a
+    // credential-shaped output, or the write failed. Fail open: ship the
+    // verbatim original, as a gated passthrough does, and say why (#226).
+    let net_win_gate = net_win_gate || stash_refused.is_some();
+    let stash_refused_notice = stash_refused.map(|reason| {
+        format!("[squeez: original not stashed ({reason}) — shown uncompressed so nothing is lost]")
+    });
 
     // Session accounting records what is actually emitted — zero savings on
     // a gated passthrough, and the marker counts against the win when it
@@ -800,6 +810,10 @@ pub fn run(cmd_str: &str) -> i32 {
         overhead_lines.push(marker.clone());
     }
     if let Some(ref w) = sensitive_path_warning {
+        println!("{}", w);
+        overhead_lines.push(w.clone());
+    }
+    if let Some(ref w) = stash_refused_notice {
         println!("{}", w);
         overhead_lines.push(w.clone());
     }

--- a/src/context/retrieve.rs
+++ b/src/context/retrieve.rs
@@ -40,11 +40,9 @@ pub fn store(content: &str) -> Option<String> {
 /// the matched class name (e.g. `"dotenv-bulk-secrets"`). On success `Ok(id)`
 /// carries the retrieval id, same as `store`.
 ///
-/// `store()` collapses this into `Option<String>` because its call site
-/// (wrap.rs) already treats `None` as "no marker" regardless of cause. This
-/// function exists so a future caller — e.g. an orchestrator warning that
-/// wants to tell the model "a secret was found and not stashed" — can get the
-/// reason without changing that call site's contract today.
+/// wrap.rs uses this rather than `store()`: a refused stash leaves no
+/// recovery path, so it must ship the original uncompressed and name the
+/// reason instead of compressing lossily (#226).
 pub fn store_guarded(content: &str) -> Result<String, &'static str> {
     store_guarded_in(&blobs_dir(), content)
 }

--- a/tests/test_wrap_integration.rs
+++ b/tests/test_wrap_integration.rs
@@ -360,3 +360,36 @@ fn test_extract_git_events_non_ascii_safe() {
     let events = squeez::commands::wrap::extract_git_events_pub("git log", text);
     assert!(!events.is_empty(), "should extract git events with non-ASCII, got: {:?}", events);
 }
+
+// ── Sensitive-content guard must fail open (#226) ──────────────────────────
+
+#[test]
+fn refused_stash_ships_original_uncompressed_with_notice() {
+    // The reporter's repro: 400 lines carrying a credential-shaped header.
+    // The guard rightly refuses to persist it, and with no stash there is no
+    // recovery path — so compressing would silently destroy the output.
+    let dir = tmp_squeez_dir("sensitive_fail_open");
+    let cmd = "yes 'Authorization: Bearer TESTTOKEN012345678901234567890123456789' | head -n 400";
+    let out = Command::new(bin())
+        .args(["wrap", cmd])
+        .env("SQUEEZ_DIR", &dir)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let body_lines = stdout
+        .lines()
+        .filter(|l| l.starts_with("Authorization: Bearer TESTTOKEN"))
+        .count();
+    assert_eq!(body_lines, 400, "original must ship whole, got:\n{stdout}");
+    assert!(
+        stdout.contains("original not stashed (bearer-token)"),
+        "refusal must be named, got:\n{stdout}"
+    );
+    assert!(!stdout.contains("squeez_retrieve"), "no marker without a blob:\n{stdout}");
+    let blobs = dir.join("blobs");
+    let stored = std::fs::read_dir(&blobs).map(|d| d.count()).unwrap_or(0);
+    assert_eq!(stored, 0, "credential must never reach disk");
+    assert_eq!(out.status.code(), Some(0));
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
## Summary

When the sensitive-content guard refused to persist a credential-shaped output, `retrieve::store()` collapsed the refusal into `None`, `wrap` emitted no retrieve marker, and still shipped the lossy compressed form. The dropped lines were unrecoverable and nothing said so.

`wrap` now calls `store_guarded()`. On any refusal (a sensitive class, or an I/O error — both leave no recovery path) it treats the call as a gated passthrough, ships the verbatim original, and prints one line naming the reason:

```
[squeez: original not stashed (bearer-token) — shown uncompressed so nothing is lost]
```

The guard's own contract is unchanged: nothing credential-shaped reaches disk.

## Verification

Reporter's exact repro (`yes 'Authorization: Bearer TESTTOKEN…' | head -n 400`):

| | bytes out | body lines | notice | blobs on disk |
|---|---:|---:|---|---:|
| `main` | 1477 | 20 | none | 0 |
| this branch | 24887 | 400 | `original not stashed (bearer-token)` | 0 |

- New `tests/test_wrap_integration.rs::refused_stash_ships_original_uncompressed_with_notice` asserts all 400 lines ship, the notice names the class, no marker is emitted, and the blob dir stays empty. Fails on `main`.
- `cargo test`: 1243 passed, 0 failed.

Fixes #226
