### PR TITLE
fix(windows): spawn helper processes without a console window

### DIFF
--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -37,6 +37,7 @@ export default function (pi: any) {
     spawnSync(sq, ["init", "--host=pi"], {
       env: { ...process.env, SQUEEZ_DIR },
       timeout: 5000,
+      windowsHide: true,
     });
   });
 
@@ -65,6 +66,7 @@ export default function (pi: any) {
       encoding: "utf8",
       env: { ...process.env, SQUEEZ_DIR },
       timeout: 3000,
+      windowsHide: true,
     });
     if (result.status === 0 && result.stdout) {
       return { content: [{ type: "text", text: result.stdout as string }] };
@@ -76,6 +78,7 @@ export default function (pi: any) {
     spawnSync(sq, ["track", "PreCompact", "0"], {
       env: { ...process.env, SQUEEZ_DIR },
       timeout: 3000,
+      windowsHide: true,
     });
   });
 }

--- a/opencode-plugin/squeez.js
+++ b/opencode-plugin/squeez.js
@@ -21,6 +21,10 @@
 
 import { execSync, spawn } from "child_process";
 
+// Every child below passes `windowsHide: true`. On Windows, execSync goes
+// through cmd.exe and a detached spawn gets its own console, so without it
+// each tool call flashed a console window (squeez issue #231).
+
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
 const SQUEEZ_BIN = `${HOME}/.claude/squeez/bin/squeez`;
 
@@ -33,7 +37,7 @@ const BUDGET_TOOL_SLUG = {
 
 function squeezExists() {
   try {
-    execSync(`test -x "${SQUEEZ_BIN}"`, { timeout: 500 });
+    execSync(`test -x "${SQUEEZ_BIN}"`, { timeout: 500, windowsHide: true });
     return true;
   } catch {
     return false;
@@ -42,7 +46,10 @@ function squeezExists() {
 
 function runInit() {
   try {
-    execSync(`"${SQUEEZ_BIN}" init --host=opencode`, { timeout: 5000 });
+    execSync(`"${SQUEEZ_BIN}" init --host=opencode`, {
+      timeout: 5000,
+      windowsHide: true,
+    });
   } catch {
     // best-effort — don't break the session if squeez init fails
   }
@@ -55,6 +62,7 @@ function budgetPatch(tool) {
     const out = execSync(`"${SQUEEZ_BIN}" budget-params ${slug}`, {
       timeout: 2000,
       encoding: "utf8",
+      windowsHide: true,
     }).trim();
     if (!out) return null;
     return JSON.parse(out);
@@ -69,6 +77,7 @@ function trackResult(tool) {
     spawn(SQUEEZ_BIN, ["track-result", tool], {
       stdio: "ignore",
       detached: true,
+      windowsHide: true,
     }).unref();
   } catch {
     // best-effort

--- a/src/commands/compress_md/mod.rs
+++ b/src/commands/compress_md/mod.rs
@@ -149,7 +149,7 @@ fn is_git_tracked(path: &Path) -> bool {
         (Some(d), Some(f)) if !d.as_os_str().is_empty() => (d, f),
         _ => return false,
     };
-    std::process::Command::new("git")
+    crate::spawn::helper("git")
         .arg("-C")
         .arg(dir)
         .args(["ls-files", "--error-unmatch", "--"])

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -190,7 +190,7 @@ fn check_hooks_runnable(settings_path: &Path) -> CheckLine {
 /// passes `command -v` but exits non-zero when run (#209).
 fn check_interpreter() -> CheckLine {
     for candidate in ["python3", "python", "py"] {
-        let runs = std::process::Command::new(candidate)
+        let runs = crate::spawn::helper(candidate)
             .args(["-c", ""])
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -525,7 +525,7 @@ fn check_claude_md_size() {
 }
 
 fn git(args: &[&str]) -> String {
-    std::process::Command::new("git")
+    crate::spawn::helper("git")
         .args(args)
         .output()
         .map(|o| String::from_utf8_lossy(&o.stdout).into_owned())

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -2,7 +2,6 @@
 // `sha256sum` / `shasum -a 256` (both already required by install.sh).
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::json_util;
 use crate::session::home_dir;
@@ -226,7 +225,7 @@ fn fetch_latest_tag() -> Result<String, String> {
 }
 
 pub fn curl(url: &str) -> Result<Vec<u8>, String> {
-    let out = Command::new("curl")
+    let out = crate::spawn::helper("curl")
         .args(["-fsSL", "-A", "squeez-update", url])
         .output()
         .map_err(|e| format!("curl spawn: {}", e))?;
@@ -282,7 +281,7 @@ fn compute_sha256(bytes: &[u8]) -> Option<String> {
 
 fn run_hasher(cmd: &str, args: &[&str], input: &[u8]) -> Option<String> {
     use std::io::Write;
-    let mut child = Command::new(cmd)
+    let mut child = crate::spawn::helper(cmd)
         .args(args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -355,16 +354,13 @@ pub fn install_atomic(bytes: &[u8], target: &Path) -> Result<bool, String> {
 
         // Rename dance failed (target locked) — spawn a detached cmd.exe that
         // moves the staged file into place after this process exits.
-        use std::os::windows::process::CommandExt;
-        const CREATE_NO_WINDOW: u32 = 0x08000000;
         let cmd_str = format!(
             "ping -n 2 127.0.0.1 > nul && move /Y \"{}\" \"{}\"",
             staging.display(),
             target.display()
         );
-        let spawned = std::process::Command::new("cmd")
+        let spawned = crate::spawn::helper("cmd")
             .args(["/c", &cmd_str])
-            .creation_flags(CREATE_NO_WINDOW)
             .spawn()
             .is_ok();
         if spawned {

--- a/src/economy/calibrate.rs
+++ b/src/economy/calibrate.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// Returns a squeez lang code: "pt-BR", "en", etc.
 pub fn detect_lang() -> String {
     // macOS: `defaults read -g AppleLanguages` → ("pt-BR", "en-US", ...)
-    if let Ok(out) = std::process::Command::new("defaults")
+    if let Ok(out) = crate::spawn::helper("defaults")
         .args(["read", "-g", "AppleLanguages"])
         .output()
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,5 +8,6 @@ pub mod hosts;
 pub mod json_util;
 pub mod memory;
 pub mod session;
+pub mod spawn;
 pub mod strategies;
 pub mod tokens;

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -1,0 +1,37 @@
+//! Spawning squeez's own helper processes (git, curl, interpreter probes).
+
+use std::ffi::OsStr;
+use std::process::Command;
+
+/// Windows `CREATE_NO_WINDOW` process-creation flag.
+#[cfg(windows)]
+pub const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// `Command::new` for a helper squeez runs for its own bookkeeping, with
+/// captured or discarded stdio — never for a command the user asked for.
+///
+/// On Windows, a console-subsystem child whose parent has no console gets a
+/// console of its own, so every `git status` from a hook flashed a window (a
+/// full Windows Terminal window when that is the default terminal).
+/// `CREATE_NO_WINDOW` runs the child without one (#231). Do not use it for
+/// a child that must write to the user's terminal: it gets no console.
+pub fn helper<S: AsRef<OsStr>>(program: S) -> Command {
+    #[allow(unused_mut)]
+    let mut cmd = Command::new(program);
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn helper_still_captures_output() {
+        let out = super::helper("git").arg("--version").output().expect("spawn git");
+        assert!(out.status.success());
+        assert!(String::from_utf8_lossy(&out.stdout).starts_with("git version"));
+    }
+}


### PR DESCRIPTION
## Summary

squeez shells out to `git` (`init`: `git log` / `git status`; `compress-md`: `git ls-files`), `curl` (the daily update check from `session-start`) and interpreter probes without `CREATE_NO_WINDOW`. A console-subsystem child whose parent has no console gets one of its own, so these flashed a window per call on Windows — a full Windows Terminal window when that is the default terminal.

- New `spawn::helper()`: `Command::new` plus `CREATE_NO_WINDOW` on Windows, plain `Command::new` elsewhere. Every internal helper spawn goes through it (init, compress-md, doctor, calibrate, update's curl/hasher/deferred-move). The existing ad-hoc flag in `update.rs` now uses it too.
- Commands the user asked for keep their console: `wrap`'s child, the `passthrough` fallback and `cargo install` are untouched.
- OpenCode plugin and Pi extension: every `execSync` / `spawn` / `spawnSync` now passes `windowsHide: true` (a `detached` spawn otherwise gets its own console on Windows).

The binary stays CONSOLE-subsystem, as the issue recommends.

## Verification

- `cargo check --target x86_64-pc-windows-msvc --all-targets`: clean, no warnings.
- `spawn::tests::helper_still_captures_output`: output capture is unchanged on Unix.
- `node --check opencode-plugin/squeez.js`: ok.
- Not verified: the window-flash count on a real Windows machine (no Windows host here). A re-run of the reporter's process-creation capture would confirm it.
- `cargo test`: 1242 passed, 0 failed.

Fixes #231
