### PR TITLE
fix(doctor): audit every host's hook registration; don't double a user chain

### DIFF
--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -7,6 +7,7 @@
 
 use crate::config::Config;
 use crate::hosts::claude_code::hooks_manifest;
+use crate::hosts::settings_json::{self, Existing, HookRegistration};
 use crate::json_util::JsonValue;
 use crate::session;
 use std::path::Path;
@@ -184,6 +185,81 @@ fn check_hooks_runnable(settings_path: &Path) -> CheckLine {
     ))
 }
 
+/// Registration check for a hook-file host other than Claude Code: every
+/// squeez event registered exactly once, with a runnable command.
+///
+/// The Claude checks above only read `~/.claude/settings.json`, so a missing,
+/// broken or duplicated Codex/Gemini/Copilot registration was invisible —
+/// including a second chain that ran the pipeline twice per tool call (#230).
+/// `set_up` is whether squeez was ever installed for this host; a host it was
+/// never set up for yields no line at all rather than a false FAIL.
+fn check_host_registration(host: &str, reg: &HookRegistration, set_up: bool) -> Option<CheckLine> {
+    let path = reg.path.display();
+    let settings = match settings_json::load(&reg.path) {
+        Ok(Existing::Object(v)) => v,
+        Ok(Existing::Missing) if !set_up => return None,
+        Ok(Existing::Missing) => {
+            return Some(fail(format!("registration: {host} — {path} missing — run `squeez setup`")))
+        }
+        Err(_) => return Some(warn(format!("registration: {host} — {path} unreadable — skipped"))),
+    };
+    let audits = settings_json::audit_events(&settings, reg.root, &reg.specs);
+    let runs = |a: &settings_json::EventAudit| a.managed.len() + a.user.len();
+    if !set_up && audits.iter().all(|a| runs(a) == 0) {
+        return None;
+    }
+    let missing: Vec<&str> = audits.iter().filter(|a| runs(a) == 0).map(|a| a.event).collect();
+    if !missing.is_empty() {
+        return Some(fail(format!(
+            "registration: {host} — {} not registered in {path} — run `squeez setup`",
+            missing.join(", ")
+        )));
+    }
+    // Only squeez's own commands are judged: `squeez setup` cannot fix a
+    // script the user maintains.
+    let broken: Vec<String> = audits
+        .iter()
+        .flat_map(|a| &a.managed)
+        .filter_map(|c| hook_command_problem(c, |p| p.exists()).map(|why| format!("{c} — {why}")))
+        .collect();
+    if !broken.is_empty() {
+        return Some(fail(format!(
+            "registration: {host} — {} hook command(s) cannot execute — run `squeez setup`\n         {}",
+            broken.len(),
+            broken.join("\n         ")
+        )));
+    }
+    let doubled: Vec<&settings_json::EventAudit> = audits.iter().filter(|a| runs(a) > 1).collect();
+    if !doubled.is_empty() {
+        let events: Vec<String> = doubled.iter().map(|a| format!("{} ×{}", a.event, runs(a))).collect();
+        let cmds: Vec<&String> = doubled.iter().flat_map(|a| a.managed.iter().chain(&a.user)).collect();
+        return Some(warn(format!(
+            "registration: {host} — squeez runs more than once per call ({}) — keep one entry per event in {path}\n         {}",
+            events.join(", "),
+            cmds.iter().map(|c| c.as_str()).collect::<Vec<_>>().join("\n         ")
+        )));
+    }
+    let user: Vec<&str> = audits.iter().filter(|a| !a.user.is_empty()).map(|a| a.event).collect();
+    let total: usize = audits.iter().map(runs).sum();
+    Some(ok(if user.is_empty() {
+        format!("registration: {host} ok ({total} hooks in {path})")
+    } else {
+        format!("registration: {host} ok ({total} hooks in {path}; your own hook on {})", user.join(", "))
+    }))
+}
+
+/// One registration line per installed hook-file host.
+fn host_registration_checks() -> Vec<CheckLine> {
+    crate::hosts::all_hosts()
+        .iter()
+        .filter(|h| h.is_installed())
+        .filter_map(|h| {
+            let reg = h.hook_registration()?;
+            check_host_registration(h.name(), &reg, h.data_dir().exists())
+        })
+        .collect()
+}
+
 /// The hooks drive their JSON handling through Python, so a missing or broken
 /// interpreter makes them no-ops. Probe by EXECUTING each candidate: on Windows
 /// `python3` is usually the Microsoft Store alias stub, which is on PATH and
@@ -330,15 +406,27 @@ fn check_blob_store(squeez_dir: &Path) -> CheckLine {
 
 /// Full doctor report. Returns the printable lines and whether any check FAILed.
 pub fn run_with(squeez_dir: &Path, settings_path: &Path, cfg: &Config) -> (Vec<String>, bool) {
-    let checks = [
+    run_with_hosts(squeez_dir, settings_path, cfg, Vec::new())
+}
+
+fn run_with_hosts(
+    squeez_dir: &Path,
+    settings_path: &Path,
+    cfg: &Config,
+    host_checks: Vec<CheckLine>,
+) -> (Vec<String>, bool) {
+    let mut checks = vec![
         check_hooks_drift(squeez_dir),
         check_hooks_registered(settings_path),
         check_hooks_runnable(settings_path),
+    ];
+    checks.extend(host_checks);
+    checks.extend([
         check_interpreter(),
         check_config(cfg),
         check_freshness(squeez_dir, cfg),
         check_blob_store(squeez_dir),
-    ];
+    ]);
     let has_fail = checks.iter().any(|c| c.fail);
     let mut lines: Vec<String> = vec![format!(
         "squeez doctor — v{} @ {}",
@@ -392,7 +480,12 @@ fn default_settings_path() -> std::path::PathBuf {
 /// CLI entry point: print the report, exit 1 on any FAIL.
 pub fn run() -> i32 {
     let cfg = Config::load();
-    let (lines, has_fail) = run_with(&session::squeez_dir(), &default_settings_path(), &cfg);
+    let (lines, has_fail) = run_with_hosts(
+        &session::squeez_dir(),
+        &default_settings_path(),
+        &cfg,
+        host_registration_checks(),
+    );
     for l in lines {
         println!("{}", l);
     }
@@ -503,5 +596,85 @@ mod tests {
         assert_eq!(cmds.len(), 4, "foreign hook excluded, squeez ones kept: {cmds:?}");
         assert!(cmds.iter().all(|c| c.contains("squeez")));
         assert!(cmds.iter().any(|c| c.contains("statusline.sh")));
+    }
+
+    fn host_fixture(label: &str, hooks_json: Option<&str>) -> (std::path::PathBuf, HookRegistration) {
+        let dir = std::env::temp_dir().join(format!(
+            "squeez_doctor_host_{label}_{}",
+            SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos()
+        ));
+        let hooks = dir.join("squeez").join("hooks");
+        std::fs::create_dir_all(&hooks).unwrap();
+        let mut specs = Vec::new();
+        for (event, script) in [("PreToolUse", "codex-pretooluse.sh"), ("PostToolUse", "codex-posttooluse.sh")] {
+            std::fs::write(hooks.join(script), "#!/bin/sh\n").unwrap();
+            specs.push(settings_json::HookSpec {
+                event,
+                matcher: Some(".*"),
+                command: format!("bash {}", settings_json::shell_arg(&hooks.join(script))),
+                name: None,
+                timeout_ms: None,
+                script,
+            });
+        }
+        let path = dir.join("hooks.json");
+        if let Some(body) = hooks_json {
+            std::fs::write(&path, body.replace("$H", &hooks.display().to_string())).unwrap();
+        }
+        (dir, HookRegistration { path, root: settings_json::EventRoot::Nested, specs })
+    }
+
+    #[test]
+    fn healthy_host_registration_is_ok() {
+        let (dir, reg) = host_fixture(
+            "ok",
+            Some(r#"{"hooks":{
+                 "PreToolUse":[{"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}],
+                 "PostToolUse":[{"hooks":[{"command":"bash \"$H/codex-posttooluse.sh\""}]}]}}"#),
+        );
+        let line = check_host_registration("codex", &reg, true).unwrap();
+        assert!(!line.fail && line.line.starts_with("[ok]") && line.line.contains("codex ok (2 hooks"), "{}", line.line);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #230: a second chain ran the pipeline twice per Codex tool call while
+    /// doctor stayed green, because it only ever read the Claude settings.
+    #[test]
+    fn duplicate_chain_on_another_host_is_reported() {
+        let (dir, reg) = host_fixture(
+            "dup",
+            Some(r#"{"hooks":{
+                 "PreToolUse":[{"hooks":[{"command":"bash /h/.codex/user-hooks/squeez-pretooluse.sh"}]},
+                               {"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}],
+                 "PostToolUse":[{"hooks":[{"command":"bash \"$H/codex-posttooluse.sh\""}]}]}}"#),
+        );
+        let line = check_host_registration("codex", &reg, true).unwrap();
+        assert!(line.line.starts_with("[WARN]"), "{}", line.line);
+        assert!(line.line.contains("PreToolUse ×2"), "{}", line.line);
+        assert!(line.line.contains("user-hooks/squeez-pretooluse.sh"), "{}", line.line);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lost_registration_on_a_set_up_host_fails() {
+        let (dir, reg) = host_fixture(
+            "lost",
+            Some(r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}]}}"#),
+        );
+        let line = check_host_registration("codex", &reg, true).unwrap();
+        assert!(line.fail && line.line.contains("PostToolUse not registered"), "{}", line.line);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A host squeez was never set up for is not a failure — the user may
+    /// simply not want that integration.
+    #[test]
+    fn host_never_set_up_yields_no_line() {
+        let (dir, reg) = host_fixture("none", None);
+        assert!(check_host_registration("codex", &reg, false).is_none());
+        let (dir2, reg2) = host_fixture("foreign", Some(r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"x"}]}]}}"#));
+        assert!(check_host_registration("codex", &reg2, false).is_none());
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&dir2);
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -191,21 +191,22 @@ fn check_hooks_runnable(settings_path: &Path) -> CheckLine {
 /// The Claude checks above only read `~/.claude/settings.json`, so a missing,
 /// broken or duplicated Codex/Gemini/Copilot registration was invisible —
 /// including a second chain that ran the pipeline twice per tool call (#230).
-/// `set_up` is whether squeez was ever installed for this host; a host it was
-/// never set up for yields no line at all rather than a false FAIL.
-fn check_host_registration(host: &str, reg: &HookRegistration, set_up: bool) -> Option<CheckLine> {
+///
+/// A host with no squeez registration at all yields no line: it was never set
+/// up, or `squeez uninstall --host=…` removed it on purpose (uninstall keeps
+/// squeez's data dir, so that is no signal), and telling the user to run
+/// `squeez setup` would re-register a host they just removed. A *partial*
+/// registration is what setup can fix, and that FAILs.
+fn check_host_registration(host: &str, reg: &HookRegistration) -> Option<CheckLine> {
     let path = reg.path.display();
     let settings = match settings_json::load(&reg.path) {
         Ok(Existing::Object(v)) => v,
-        Ok(Existing::Missing) if !set_up => return None,
-        Ok(Existing::Missing) => {
-            return Some(fail(format!("registration: {host} — {path} missing — run `squeez setup`")))
-        }
+        Ok(Existing::Missing) => return None,
         Err(_) => return Some(warn(format!("registration: {host} — {path} unreadable — skipped"))),
     };
     let audits = settings_json::audit_events(&settings, reg.root, &reg.specs);
     let runs = |a: &settings_json::EventAudit| a.managed.len() + a.user.len();
-    if !set_up && audits.iter().all(|a| runs(a) == 0) {
+    if audits.iter().all(|a| runs(a) == 0) {
         return None;
     }
     let missing: Vec<&str> = audits.iter().filter(|a| runs(a) == 0).map(|a| a.event).collect();
@@ -255,7 +256,7 @@ fn host_registration_checks() -> Vec<CheckLine> {
         .filter(|h| h.is_installed())
         .filter_map(|h| {
             let reg = h.hook_registration()?;
-            check_host_registration(h.name(), &reg, h.data_dir().exists())
+            check_host_registration(h.name(), &reg)
         })
         .collect()
 }
@@ -632,7 +633,7 @@ mod tests {
                  "PreToolUse":[{"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}],
                  "PostToolUse":[{"hooks":[{"command":"bash \"$H/codex-posttooluse.sh\""}]}]}}"#),
         );
-        let line = check_host_registration("codex", &reg, true).unwrap();
+        let line = check_host_registration("codex", &reg).unwrap();
         assert!(!line.fail && line.line.starts_with("[ok]") && line.line.contains("codex ok (2 hooks"), "{}", line.line);
         let _ = std::fs::remove_dir_all(&dir);
     }
@@ -648,7 +649,7 @@ mod tests {
                                {"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}],
                  "PostToolUse":[{"hooks":[{"command":"bash \"$H/codex-posttooluse.sh\""}]}]}}"#),
         );
-        let line = check_host_registration("codex", &reg, true).unwrap();
+        let line = check_host_registration("codex", &reg).unwrap();
         assert!(line.line.starts_with("[WARN]"), "{}", line.line);
         assert!(line.line.contains("PreToolUse ×2"), "{}", line.line);
         assert!(line.line.contains("user-hooks/squeez-pretooluse.sh"), "{}", line.line);
@@ -661,19 +662,21 @@ mod tests {
             "lost",
             Some(r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"bash \"$H/codex-pretooluse.sh\""}]}]}}"#),
         );
-        let line = check_host_registration("codex", &reg, true).unwrap();
+        let line = check_host_registration("codex", &reg).unwrap();
         assert!(line.fail && line.line.contains("PostToolUse not registered"), "{}", line.line);
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A host squeez was never set up for is not a failure — the user may
-    /// simply not want that integration.
+    /// A host with no squeez registration is not a failure — never set up, or
+    /// deliberately uninstalled (uninstall keeps the data dir, so "set up"
+    /// cannot be read from it). Unrelated hooks that merely sit under a
+    /// `squeez-*` directory are not squeez registrations either.
     #[test]
     fn host_never_set_up_yields_no_line() {
         let (dir, reg) = host_fixture("none", None);
-        assert!(check_host_registration("codex", &reg, false).is_none());
-        let (dir2, reg2) = host_fixture("foreign", Some(r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"x"}]}]}}"#));
-        assert!(check_host_registration("codex", &reg2, false).is_none());
+        assert!(check_host_registration("codex", &reg).is_none());
+        let (dir2, reg2) = host_fixture("foreign", Some(r#"{"hooks":{"PreToolUse":[{"hooks":[{"command":"bash /h/src/squeez-notes/log.sh"}]}]}}"#));
+        assert!(check_host_registration("codex", &reg2).is_none());
         let _ = std::fs::remove_dir_all(&dir);
         let _ = std::fs::remove_dir_all(&dir2);
     }

--- a/src/hosts/codex.rs
+++ b/src/hosts/codex.rs
@@ -84,6 +84,14 @@ impl CodexCliAdapter {
         Self::codex_dir().join("AGENTS.md")
     }
 
+    fn registration(&self) -> settings_json::HookRegistration {
+        settings_json::HookRegistration {
+            path: Self::hooks_json_path(),
+            root: settings_json::EventRoot::Nested,
+            specs: hook_specs(&Self::hooks_dir()),
+        }
+    }
+
     fn write_hook_scripts(hooks_dir: &Path) -> std::io::Result<()> {
         std::fs::create_dir_all(hooks_dir)?;
         for (name, body) in [
@@ -123,15 +131,12 @@ impl HostAdapter for CodexCliAdapter {
     }
 
     fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        let hooks_dir = Self::hooks_dir();
-        Self::write_hook_scripts(&hooks_dir)?;
-        let hooks_json = Self::hooks_json_path();
-        settings_json::patch_events(
-            &hooks_json,
-            settings_json::EventRoot::Nested,
-            &hook_specs(&hooks_dir),
-        )?;
-        Ok(())
+        Self::write_hook_scripts(&Self::hooks_dir())?;
+        settings_json::install_registration(&self.registration())
+    }
+
+    fn hook_registration(&self) -> Option<settings_json::HookRegistration> {
+        Some(self.registration())
     }
 
     fn uninstall(&self) -> std::io::Result<()> {

--- a/src/hosts/copilot.rs
+++ b/src/hosts/copilot.rs
@@ -58,6 +58,13 @@ impl CopilotCliAdapter {
     fn settings_path() -> PathBuf {
         Self::copilot_dir().join("settings.json")
     }
+    fn registration(&self) -> settings_json::HookRegistration {
+        settings_json::HookRegistration {
+            path: Self::settings_path(),
+            root: settings_json::EventRoot::TopLevel,
+            specs: hook_specs(&self.data_dir().join("hooks")),
+        }
+    }
     fn instructions_path() -> PathBuf {
         Self::copilot_dir().join("copilot-instructions.md")
     }
@@ -105,12 +112,11 @@ impl HostAdapter for CopilotCliAdapter {
         write_hook(&hooks, "copilot-session-start.sh", SESSION_START_SCRIPT)?;
         write_hook(&hooks, "copilot-posttooluse.sh", POSTTOOLUSE_SCRIPT)?;
 
-        settings_json::patch_events(
-            &Self::settings_path(),
-            settings_json::EventRoot::TopLevel,
-            &hook_specs(&hooks),
-        )?;
-        Ok(())
+        settings_json::install_registration(&self.registration())
+    }
+
+    fn hook_registration(&self) -> Option<settings_json::HookRegistration> {
+        Some(self.registration())
     }
 
     fn uninstall(&self) -> std::io::Result<()> {

--- a/src/hosts/gemini.rs
+++ b/src/hosts/gemini.rs
@@ -81,6 +81,14 @@ impl GeminiCliAdapter {
         Self::gemini_dir().join("GEMINI.md")
     }
 
+    fn registration(&self) -> settings_json::HookRegistration {
+        settings_json::HookRegistration {
+            path: Self::settings_path(),
+            root: settings_json::EventRoot::Nested,
+            specs: hook_specs(&Self::hooks_dir()),
+        }
+    }
+
     fn write_hook_scripts(hooks_dir: &Path) -> std::io::Result<()> {
         std::fs::create_dir_all(hooks_dir)?;
         for (name, body) in [
@@ -121,15 +129,12 @@ impl HostAdapter for GeminiCliAdapter {
     }
 
     fn install(&self, _bin_path: &Path) -> std::io::Result<()> {
-        let hooks_dir = Self::hooks_dir();
-        Self::write_hook_scripts(&hooks_dir)?;
-        let settings = Self::settings_path();
-        settings_json::patch_events(
-            &settings,
-            settings_json::EventRoot::Nested,
-            &hook_specs(&hooks_dir),
-        )?;
-        Ok(())
+        Self::write_hook_scripts(&Self::hooks_dir())?;
+        settings_json::install_registration(&self.registration())
+    }
+
+    fn hook_registration(&self) -> Option<settings_json::HookRegistration> {
+        Some(self.registration())
     }
 
     fn uninstall(&self) -> std::io::Result<()> {

--- a/src/hosts/mod.rs
+++ b/src/hosts/mod.rs
@@ -87,6 +87,13 @@ pub trait HostAdapter {
     /// else intact. Idempotent.
     fn uninstall(&self) -> std::io::Result<()>;
 
+    /// Where this host's squeez hooks are registered, so `squeez doctor` can
+    /// audit them (#230). `None` for hosts doctor checks another way (Claude
+    /// Code) or that load squeez as a plugin rather than a hook file.
+    fn hook_registration(&self) -> Option<settings_json::HookRegistration> {
+        None
+    }
+
     /// Write the squeez memory block into the host's auto-loaded instructions
     /// file (CLAUDE.md / copilot-instructions.md / GEMINI.md / AGENTS.md).
     fn inject_memory(&self, cfg: &Config, summaries: &[Summary]) -> std::io::Result<()>;

--- a/src/hosts/settings_json.rs
+++ b/src/hosts/settings_json.rs
@@ -255,9 +255,18 @@ fn upgrade_hook(
 ///
 /// squeez only ever registers scripts under `…/squeez/hooks/` (core) and
 /// `…/squeez/buddy/`. A wrapper the user maintains — e.g.
-/// `~/.codex/user-hooks/squeez-pretooluse.sh` (#230) — is neither.
+/// `~/.codex/user-hooks/squeez-pretooluse.sh` (#230) — is neither. It must
+/// *name* squeez: an argument whose file name contains "squeez" (the script or
+/// the binary). A mere directory match like `~/src/squeez-notes/log.sh` is an
+/// unrelated hook and must not stop squeez from registering its own.
 pub fn is_user_squeez_cmd(cmd: &str) -> bool {
-    cmd.contains("squeez") && !is_buddy_cmd(cmd) && !normalize_sep(cmd).contains("/squeez/hooks/")
+    let norm = normalize_sep(cmd);
+    !is_buddy_cmd(cmd)
+        && !norm.contains("/squeez/hooks/")
+        && norm.split_whitespace().any(|arg| {
+            let arg = arg.trim_matches(|c| c == '"' || c == '\'');
+            arg.rsplit('/').next().is_some_and(|name| name.contains("squeez"))
+        })
 }
 
 /// Every hook `command` string under `event`, in registration order.
@@ -639,6 +648,21 @@ mod tests {
         assert_eq!(upgrade_hook_spec(&mut root, &post), None);
         assert_eq!(event_commands(&root, "PreToolUse").len(), 1, "no second chain");
         assert_eq!(event_commands(&root, "PostToolUse"), vec![post.command.as_str()]);
+    }
+
+    #[test]
+    fn only_a_command_naming_squeez_counts_as_a_user_squeez_hook() {
+        assert!(is_user_squeez_cmd("bash /h/.codex/user-hooks/squeez-pretooluse.sh"));
+        assert!(is_user_squeez_cmd(r#"bash "C:\Users\x\hooks\squeez-pre.sh""#));
+        assert!(is_user_squeez_cmd("/home/u/.claude/squeez/bin/squeez track PostToolUse 0"));
+        assert!(!is_user_squeez_cmd("bash /h/src/squeez-notes/log.sh"), "directory match only");
+        assert!(!is_user_squeez_cmd("bash \"/h/.codex/squeez/hooks/codex-pretooluse.sh\""), "managed");
+        assert!(!is_user_squeez_cmd("bash /h/.claude/squeez/buddy/shims/stop.sh"), "buddy");
+        // …so an unrelated hook never suppresses squeez's own registration.
+        let mut root = obj(r#"{"PreToolUse":[{"hooks":[{"command":"bash /h/src/squeez-notes/log.sh"}]}]}"#);
+        let pre = codex_spec("PreToolUse", "codex-pretooluse.sh");
+        assert_eq!(upgrade_hook_spec(&mut root, &pre), None);
+        assert_eq!(event_commands(&root, "PreToolUse").len(), 2);
     }
 
     /// Our own registration is still upgraded in place when a user hook sits

--- a/src/hosts/settings_json.rs
+++ b/src/hosts/settings_json.rs
@@ -11,7 +11,7 @@
 //! interpreter dependency at all.
 
 use crate::json_util::{self, JsonValue};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Outcome of reading a settings file that squeez is about to rewrite.
 pub enum Existing {
@@ -251,20 +251,58 @@ fn upgrade_hook(
     }
 }
 
+/// True for a hook command that runs squeez but that squeez did not install.
+///
+/// squeez only ever registers scripts under `…/squeez/hooks/` (core) and
+/// `…/squeez/buddy/`. A wrapper the user maintains — e.g.
+/// `~/.codex/user-hooks/squeez-pretooluse.sh` (#230) — is neither.
+pub fn is_user_squeez_cmd(cmd: &str) -> bool {
+    cmd.contains("squeez") && !is_buddy_cmd(cmd) && !normalize_sep(cmd).contains("/squeez/hooks/")
+}
+
+/// Every hook `command` string under `event`, in registration order.
+fn event_commands<'a>(hooks_root: &'a JsonValue, event: &str) -> Vec<&'a str> {
+    hooks_root
+        .get(event)
+        .map(|v| v.as_arr())
+        .unwrap_or(&[])
+        .iter()
+        .flat_map(|entry| entry.get("hooks").map(|h| h.as_arr()).unwrap_or(&[]))
+        .map(|hook| hook.get_str("command"))
+        .collect()
+}
+
 /// [`patch_events`]'s upgrader: same shape as [`upgrade_hook`], but replaces
 /// the whole matching hook object (not just `command`) so a stale `name` or
 /// `timeout` from an older squeez version is corrected too — fields
 /// `upgrade_hook` doesn't know about because Claude Code's specs never carry
 /// them.
-fn upgrade_hook_spec(hooks_root: &mut JsonValue, spec: &HookSpec) {
-    let arr = hooks_root.ensure_arr(spec.event);
+///
+/// Returns a note, and registers nothing, when the event carries no squeez
+/// hook of ours but already runs one the user maintains: appending ours ran
+/// the whole pipeline twice per tool call (#230).
+fn upgrade_hook_spec(hooks_root: &mut JsonValue, spec: &HookSpec) -> Option<String> {
     let matches = |cmd: &str| is_core_script(cmd, spec.script);
+    let has_ours = event_commands(hooks_root, spec.event).into_iter().any(matches);
+    if !has_ours {
+        if let Some(user) = event_commands(hooks_root, spec.event)
+            .into_iter()
+            .find(|c| is_user_squeez_cmd(c))
+        {
+            return Some(format!(
+                "{} already runs squeez via your own hook ({user}) — not adding a second one; \
+                 remove that entry and re-run setup to use squeez's managed hook",
+                spec.event
+            ));
+        }
+    }
+    let arr = hooks_root.ensure_arr(spec.event);
     let Some(entry) = arr.iter_mut().find(|m| entry_cmd_any(m, &matches)) else {
         arr.push(spec.to_entry());
-        return;
+        return None;
     };
     let hooks = entry.get_mut("hooks").and_then(|h| h.as_arr_mut());
-    let Some(hooks) = hooks else { return };
+    let Some(hooks) = hooks else { return None };
     let mut only_ours = true;
     for hook in hooks.iter_mut() {
         if !matches(hook.get_str("command")) {
@@ -278,6 +316,7 @@ fn upgrade_hook_spec(hooks_root: &mut JsonValue, spec: &HookSpec) {
             entry.set("matcher", JsonValue::Str(m.to_string()));
         }
     }
+    None
 }
 
 /// Append `entry` under `event` unless a buddy hook is already there.
@@ -373,32 +412,79 @@ pub enum EventRoot {
 /// freezing it — the same self-heal `upgrade_squeez_hook` gives Claude Code
 /// (issue #209: a broken command string still contains "squeez", so a
 /// presence-only check never corrects it on later `squeez setup` runs).
-/// Idempotent, and never disturbs foreign entries.
+/// Idempotent, and never disturbs foreign entries. Returns one note per event
+/// left to a squeez hook the user maintains (see [`upgrade_hook_spec`]).
 pub fn patch_events(
     path: &Path,
     root_kind: EventRoot,
     specs: &[HookSpec],
-) -> std::io::Result<()> {
+) -> std::io::Result<Vec<String>> {
     let mut settings = match load(path) {
         Ok(Existing::Object(v)) => v,
         Ok(Existing::Missing) => JsonValue::Obj(Vec::new()),
         Err(e) => return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e)),
     };
 
-    match root_kind {
-        EventRoot::TopLevel => {
-            for spec in specs {
-                upgrade_hook_spec(&mut settings, spec);
-            }
-        }
-        EventRoot::Nested => {
-            let root = settings.ensure_obj("hooks");
-            for spec in specs {
-                upgrade_hook_spec(root, spec);
-            }
-        }
+    let root = match root_kind {
+        EventRoot::TopLevel => &mut settings,
+        EventRoot::Nested => settings.ensure_obj("hooks"),
+    };
+    let notes: Vec<String> = specs.iter().filter_map(|spec| upgrade_hook_spec(root, spec)).collect();
+    write_atomic(path, &settings)?;
+    Ok(notes)
+}
+
+/// Where a host registers squeez's hooks. [`install_registration`] writes it
+/// and `squeez doctor` audits it, so the two read the same definition.
+pub struct HookRegistration {
+    pub path: PathBuf,
+    pub root: EventRoot,
+    pub specs: Vec<HookSpec>,
+}
+
+/// `patch_events` for a host's registration, printing any notes for the user.
+pub fn install_registration(reg: &HookRegistration) -> std::io::Result<()> {
+    for note in patch_events(&reg.path, reg.root, &reg.specs)? {
+        eprintln!("squeez setup: {}: {note}", reg.path.display());
     }
-    write_atomic(path, &settings)
+    Ok(())
+}
+
+/// What actually runs for one registered event, for `squeez doctor`.
+pub struct EventAudit {
+    pub event: &'static str,
+    /// Hook commands squeez installed for this event.
+    pub managed: Vec<String>,
+    /// Hook commands that run squeez but that the user maintains.
+    pub user: Vec<String>,
+}
+
+/// Audit each spec's event in `settings` without modifying anything.
+pub fn audit_events(settings: &JsonValue, root_kind: EventRoot, specs: &[HookSpec]) -> Vec<EventAudit> {
+    let empty = JsonValue::Obj(Vec::new());
+    let root = match root_kind {
+        EventRoot::TopLevel => settings,
+        EventRoot::Nested => settings.get("hooks").unwrap_or(&empty),
+    };
+    specs
+        .iter()
+        .map(|spec| {
+            let cmds = event_commands(root, spec.event);
+            EventAudit {
+                event: spec.event,
+                managed: cmds
+                    .iter()
+                    .filter(|c| is_core_script(c, spec.script))
+                    .map(|c| c.to_string())
+                    .collect(),
+                user: cmds
+                    .iter()
+                    .filter(|c| !is_core_script(c, spec.script) && is_user_squeez_cmd(c))
+                    .map(|c| c.to_string())
+                    .collect(),
+            }
+        })
+        .collect()
 }
 
 /// Reverse [`patch_events`]: drop squeez entries for each event, then drop an
@@ -526,5 +612,68 @@ mod tests {
         let bak = std::fs::read_to_string(dir.join("settings.json.bak")).unwrap();
         assert!(bak.contains("old"));
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn codex_spec(event: &'static str, script: &'static str) -> HookSpec {
+        HookSpec {
+            event,
+            matcher: Some(".*"),
+            command: format!("bash \"/h/.codex/squeez/hooks/{script}\""),
+            name: None,
+            timeout_ms: Some(5000),
+            script,
+        }
+    }
+
+    /// #230: a hand-maintained chain already runs squeez on PreToolUse; setup
+    /// must not append its own and run the pipeline twice per tool call.
+    #[test]
+    fn user_maintained_squeez_hook_is_not_doubled() {
+        let mut root = obj(
+            r#"{"PreToolUse":[{"matcher":".*","hooks":[{"type":"command","command":"bash /h/.codex/user-hooks/squeez-pretooluse.sh"}]}]}"#,
+        );
+        let pre = codex_spec("PreToolUse", "codex-pretooluse.sh");
+        let post = codex_spec("PostToolUse", "codex-posttooluse.sh");
+        let note = upgrade_hook_spec(&mut root, &pre).expect("must explain the skip");
+        assert!(note.contains("user-hooks/squeez-pretooluse.sh"), "{note}");
+        assert_eq!(upgrade_hook_spec(&mut root, &post), None);
+        assert_eq!(event_commands(&root, "PreToolUse").len(), 1, "no second chain");
+        assert_eq!(event_commands(&root, "PostToolUse"), vec![post.command.as_str()]);
+    }
+
+    /// Our own registration is still upgraded in place when a user hook sits
+    /// beside it — only the append is suppressed.
+    #[test]
+    fn managed_hook_still_upgrades_beside_a_user_hook() {
+        let mut root = obj(
+            r#"{"PreToolUse":[
+                 {"hooks":[{"command":"bash /h/.codex/user-hooks/squeez-pretooluse.sh"}]},
+                 {"hooks":[{"command":"bash C:\\old\\.codex\\squeez\\hooks\\codex-pretooluse.sh"}]}
+               ]}"#,
+        );
+        let pre = codex_spec("PreToolUse", "codex-pretooluse.sh");
+        assert_eq!(upgrade_hook_spec(&mut root, &pre), None);
+        let cmds = event_commands(&root, "PreToolUse");
+        assert_eq!(cmds.len(), 2);
+        assert_eq!(cmds[1], pre.command);
+    }
+
+    #[test]
+    fn audit_separates_managed_user_and_foreign_hooks() {
+        let settings = obj(
+            r#"{"hooks":{"PreToolUse":[
+                 {"hooks":[{"command":"bash \"/h/.codex/squeez/hooks/codex-pretooluse.sh\""}]},
+                 {"hooks":[{"command":"bash /h/.codex/user-hooks/squeez-pretooluse.sh"}]},
+                 {"hooks":[{"command":"bash /opt/other/hook.sh"}]}
+               ]}}"#,
+        );
+        let specs = [
+            codex_spec("PreToolUse", "codex-pretooluse.sh"),
+            codex_spec("SessionStart", "codex-session-start.sh"),
+        ];
+        let audits = audit_events(&settings, EventRoot::Nested, &specs);
+        assert_eq!(audits[0].managed.len(), 1);
+        assert_eq!(audits[0].user, vec!["bash /h/.codex/user-hooks/squeez-pretooluse.sh"]);
+        assert!(audits[1].managed.is_empty() && audits[1].user.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

`doctor`'s registration and runnable checks only read `~/.claude/settings.json`, so a missing, broken or duplicated Codex / Gemini / Copilot registration was invisible. With a hand-maintained Codex chain in `~/.codex/user-hooks/`, `squeez setup`/`update` appended squeez's own chain next to it and every Codex tool call ran the pipeline twice, while doctor stayed green.

- `HostAdapter::hook_registration()` exposes where a hook-file host registers (path, event root, specs). `install()` and `doctor` read the same definition, so they can't drift apart.
- `doctor` prints one registration line per installed host squeez was set up for:
  - **FAIL** when an event is missing or a managed command cannot execute;
  - **WARN** when squeez runs more than once per event, listing every command;
  - **ok** otherwise, noting events served by the user's own hook.
  A host with no squeez registration at all yields no line — never set up, or removed with `squeez uninstall --host=…` (which keeps the data dir, so that is no signal). A user who only wants Claude Code gets no false FAIL.
- `patch_events` no longer appends squeez's hook to an event that already runs squeez through a hook the user maintains (a command with an argument whose file name contains `squeez` — the wrapper script or the binary — outside `…/squeez/hooks/`; an unrelated hook that merely lives under a `squeez-*` directory does not count). Setup prints why instead. Our own registration is still upgraded in place.

## Verification

End-to-end under an isolated `HOME` with the reporter's layout (`~/.codex/user-hooks/squeez-{session-start,pretooluse,posttooluse}.sh` registered in `~/.codex/hooks.json`):

- `main`: `squeez setup --host=codex` → `PreToolUse` has 2 hooks; `doctor` prints nothing about Codex.
- this branch: setup prints `PreToolUse already runs squeez via your own hook (…) — not adding a second one` and leaves 3 hooks; `doctor` → `[ok] registration: codex ok (3 hooks in ~/.codex/hooks.json; your own hook on SessionStart, PreToolUse, PostToolUse)`.
- With both chains present (the reporter's post-update state): `[WARN] registration: codex — squeez runs more than once per call (SessionStart ×2, PreToolUse ×2, PostToolUse ×2)` followed by all six commands.
- `setup` → `uninstall --host=codex` → `doctor`: no Codex line (no false FAIL telling the user to re-register a removed host).
- Unit tests: setup skip + note, heuristic edge cases (directory-only match, managed, buddy), in-place upgrade beside a user hook, audit classification, and doctor ok / duplicate / lost-registration / never-set-up cases.
- `cargo test`: 1250 passed, 0 failed. Windows cross-check clean.

Fixes #230
