### PR TITLE
fix(update): refresh hooks with the binary just installed

### DIFF
--- a/src/commands/setup.rs
+++ b/src/commands/setup.rs
@@ -177,13 +177,3 @@ fn print_help() {
     println!("Supported hosts: claude-code, copilot, opencode, gemini, codex");
 }
 
-/// Legacy helper preserved for callers (e.g. `squeez update`) that still
-/// expect a Claude Code-specific registration entry point. Now delegates
-/// to the adapter.
-pub fn register_claude_settings() -> Result<(), String> {
-    let adapter = find("claude-code").ok_or("claude-code adapter missing")?;
-    let bin = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("squeez"));
-    adapter
-        .install(&bin)
-        .map_err(|e| format!("claude-code install: {e}"))
-}

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -103,10 +103,11 @@ pub fn run(args: &[String]) -> i32 {
 
     if immediate {
         println!("squeez update: installed {} → {}", current, latest_clean);
-        report_refresh(refresh_hooks(&target_path));
+        refresh_after_install(&target_path);
     } else {
+        // The deferred move re-registers the hooks itself once the new binary
+        // is in place (see `install_atomic`).
         println!("squeez update: {} → {} queued — restart to apply", current, latest_clean);
-        println!("squeez update: then run `squeez setup --host=claude-code` to install its hooks");
     }
 
     0
@@ -173,13 +174,16 @@ fn is_cargo_managed() -> bool {
 
 fn update_via_cargo(version: &str) -> i32 {
     println!("squeez update: cargo install detected — running cargo install squeez@{}...", version);
+    // Resolve the path while this binary still exists: once cargo renames the
+    // new one over it, Linux reports `current_exe` as `… (deleted)`.
+    let installed = install_target_path();
     let status = std::process::Command::new("cargo")
         .args(["install", "squeez", "--version", version])
         .status();
     match status {
         Ok(s) if s.success() => {
             println!("squeez update: installed {} via cargo", version);
-            report_refresh(refresh_hooks(&install_target_path()));
+            refresh_after_install(&installed);
             0
         }
         Ok(s) => {
@@ -213,6 +217,15 @@ pub fn refresh_hooks(installed: &Path) -> Result<String, String> {
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Refresh the Claude Code hooks after an install, when Claude Code is present.
+/// A user of another host only has no Claude hooks to refresh, and `setup`
+/// would fail with "host not detected".
+fn refresh_after_install(installed: &Path) {
+    if crate::hosts::find("claude-code").is_some_and(|a| a.is_installed()) {
+        report_refresh(refresh_hooks(installed));
+    }
 }
 
 /// Relay a hook refresh to the user. On failure nothing is re-registered —
@@ -383,14 +396,20 @@ pub fn install_atomic(bytes: &[u8], target: &Path) -> Result<bool, String> {
         }
 
         // Rename dance failed (target locked) — spawn a detached cmd.exe that
-        // moves the staged file into place after this process exits.
+        // moves the staged file into place after this process exits, then has
+        // the new binary re-register its own hooks (#237; `setup` skips the
+        // host quietly when Claude Code is absent).
         let cmd_str = format!(
-            "ping -n 2 127.0.0.1 > nul && move /Y \"{}\" \"{}\"",
+            "ping -n 2 127.0.0.1 > nul && move /Y \"{0}\" \"{1}\" && \"{1}\" setup --host=claude-code > nul 2>&1",
             staging.display(),
             target.display()
         );
+        // raw_arg, not arg: std quotes arguments by the MSVC convention (`\"`),
+        // which cmd.exe does not understand, so the quoted paths would break.
+        use std::os::windows::process::CommandExt;
         let spawned = crate::spawn::helper("cmd")
-            .args(["/c", &cmd_str])
+            .arg("/c")
+            .raw_arg(&cmd_str)
             .spawn()
             .is_ok();
         if spawned {
@@ -398,6 +417,7 @@ pub fn install_atomic(bytes: &[u8], target: &Path) -> Result<bool, String> {
         } else {
             eprintln!("squeez update: wrote {} — run to complete:", staging.display());
             eprintln!("  move /Y \"{}\" \"{}\"", staging.display(), target.display());
+            eprintln!("  squeez setup --host=claude-code");
         }
         return Ok(false);
     }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -103,12 +103,10 @@ pub fn run(args: &[String]) -> i32 {
 
     if immediate {
         println!("squeez update: installed {} → {}", current, latest_clean);
-        // Re-register hooks in settings.json (path may have changed, or first-time setup)
-        if let Err(e) = crate::commands::setup::register_claude_settings() {
-            eprintln!("squeez update: warning: could not update settings.json: {}", e);
-        }
+        report_refresh(refresh_hooks(&target_path));
     } else {
         println!("squeez update: {} → {} queued — restart to apply", current, latest_clean);
+        println!("squeez update: then run `squeez setup --host=claude-code` to install its hooks");
     }
 
     0
@@ -181,9 +179,7 @@ fn update_via_cargo(version: &str) -> i32 {
     match status {
         Ok(s) if s.success() => {
             println!("squeez update: installed {} via cargo", version);
-            if let Err(e) = crate::commands::setup::register_claude_settings() {
-                eprintln!("squeez update: warning: could not update settings.json: {}", e);
-            }
+            report_refresh(refresh_hooks(&install_target_path()));
             0
         }
         Ok(s) => {
@@ -193,6 +189,40 @@ fn update_via_cargo(version: &str) -> i32 {
         Err(e) => {
             eprintln!("squeez update: could not run cargo: {}", e);
             1
+        }
+    }
+}
+
+/// Re-register the Claude Code hooks by running the binary just installed at
+/// `installed`, and return what its `setup` printed.
+///
+/// This process is the outgoing version: registering in-process wrote the hook
+/// scripts embedded in the *old* binary, so every hook change a release
+/// shipped stayed inert until the user ran `squeez setup` by hand (#237).
+pub fn refresh_hooks(installed: &Path) -> Result<String, String> {
+    let out = crate::spawn::helper(installed)
+        .args(["setup", "--host=claude-code"])
+        .output()
+        .map_err(|e| format!("could not run {}: {e}", installed.display()))?;
+    if !out.status.success() {
+        return Err(format!(
+            "{} setup exited {}: {}",
+            installed.display(),
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Relay a hook refresh to the user. On failure nothing is re-registered —
+/// falling back to this process would reinstall the old scripts.
+fn report_refresh(result: Result<String, String>) {
+    match result {
+        Ok(stdout) => print!("{stdout}"),
+        Err(e) => {
+            eprintln!("squeez update: warning: hooks not refreshed ({e})");
+            eprintln!("squeez update: run `squeez setup --host=claude-code` to finish");
         }
     }
 }

--- a/tests/test_update_refresh.rs
+++ b/tests/test_update_refresh.rs
@@ -1,0 +1,77 @@
+//! `squeez update` must refresh hooks with the binary it just installed, not
+//! with the outgoing process's embedded scripts (#237).
+
+use std::path::{Path, PathBuf};
+
+use squeez::commands::update::refresh_hooks;
+
+fn tmp(label: &str) -> PathBuf {
+    let d = std::env::temp_dir().join(format!(
+        "squeez_update_refresh_{label}_{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    std::fs::create_dir_all(&d).unwrap();
+    d
+}
+
+#[cfg(unix)]
+fn fake_binary(dir: &Path, body: &str) -> PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    let bin = dir.join("squeez");
+    std::fs::write(&bin, format!("#!/bin/sh\n{body}\n")).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+    bin
+}
+
+/// The refresh is delegated to the installed binary — whatever it is — with
+/// exactly the setup invocation, and its report is relayed.
+#[cfg(unix)]
+#[test]
+fn refresh_runs_the_installed_binary() {
+    let dir = tmp("fake");
+    let args = dir.join("args");
+    let bin = fake_binary(
+        &dir,
+        &format!("echo \"$@\" > '{}'; echo 'squeez setup: claude-code  ✓ installed'", args.display()),
+    );
+    let out = refresh_hooks(&bin).expect("refresh must succeed");
+    assert_eq!(std::fs::read_to_string(&args).unwrap().trim(), "setup --host=claude-code");
+    assert!(out.contains("claude-code  ✓ installed"), "{out}");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_failed_refresh_is_reported_not_swallowed() {
+    let dir = tmp("fail");
+    let bin = fake_binary(&dir, "echo boom >&2; exit 3");
+    let err = refresh_hooks(&bin).expect_err("nonzero exit must be an error");
+    assert!(err.contains("exited 3") && err.contains("boom"), "{err}");
+    assert!(refresh_hooks(&dir.join("missing")).is_err());
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+/// End to end with the real binary: a stale installed hook is replaced by the
+/// script this build embeds.
+#[test]
+fn refresh_replaces_stale_hook_scripts() {
+    let home = tmp("home");
+    let hooks = home.join(".claude").join("squeez").join("hooks");
+    std::fs::create_dir_all(&hooks).unwrap();
+    std::fs::write(hooks.join("session-start.sh"), "# stale script from the old binary\n").unwrap();
+    std::env::set_var("HOME", &home);
+    std::env::remove_var("SQUEEZ_DIR");
+
+    refresh_hooks(Path::new(env!("CARGO_BIN_EXE_squeez"))).expect("refresh must succeed");
+
+    assert_eq!(
+        std::fs::read_to_string(hooks.join("session-start.sh")).unwrap(),
+        include_str!("../hooks/session-start.sh")
+    );
+    let settings = std::fs::read_to_string(home.join(".claude").join("settings.json")).unwrap();
+    assert!(settings.contains("session-start.sh"), "{settings}");
+    let _ = std::fs::remove_dir_all(&home);
+}


### PR DESCRIPTION
## Summary

`squeez update` re-registered hooks in-process with `register_claude_settings()`. That process is the outgoing version, so it wrote the hook scripts embedded in the **old** binary. Every hook change a release shipped stayed inert until a manual `squeez setup`, and `doctor` reported the install as stale. Seen updating 1.48.4 → 1.48.8: `session-start.sh` was left without the #225 restore.

Every install path now has the **new** binary re-register its own hooks via `<installed> setup --host=claude-code`, and relays its report:

| Path | How |
|---|---|
| Release download (Unix, Windows immediate rename) | spawn the binary at the target path after the swap |
| cargo install | the path is resolved **before** cargo runs. Afterwards, Linux reports `current_exe` as `… (deleted)` |
| Windows deferred move | the detached `cmd.exe` runs `setup` after the `move`, so no manual step remains |

Other changes:

- If the refresh fails, nothing is re-registered, because falling back to this process would reinstall the old scripts. The user gets the one command that finishes the job.
- The refresh only runs when Claude Code is installed. A Codex- or Gemini-only user no longer gets a false "host not detected" warning on every update, and `~/.claude` is not created for them.
- **Windows deferred move fix.** It now passes its command through `raw_arg`. `std` quotes arguments by the MSVC convention (`\"`), which `cmd.exe` does not parse, so the quoted paths in the existing `move` were mangled.
- `register_claude_settings()` had no other caller and is removed.

Out of scope: hook scripts of the other hosts (Codex, Gemini, Copilot, OpenCode). `update` never refreshed those, and refreshing them would re-register hosts some users deliberately keep off. `squeez setup` still does it on demand.

## Verification

End-to-end with a local release served over `file://` (`SQUEEZ_UPDATE_*_OVERRIDE`). The "old" binary is 1.48.0 with a `session-start.sh` marked `# OLD`; the release asset is this branch's build.

| | installed `session-start.sh` after `update` | `doctor` |
|---|---|---|
| update logic from `main` | `# OLD` | `[FAIL] hooks: stale or missing (session-start.sh)` |
| this branch | the new binary's script | `[ok] hooks: installed scripts match this binary` |
| this branch, Codex-only user (no `~/.claude`) | no warning, `~/.claude` not created | — |

- `tests/test_update_refresh.rs`:
  - the refresh runs the installed binary with exactly `setup --host=claude-code` and relays its output;
  - a nonzero exit or missing binary is an error, not swallowed;
  - end to end with the real binary, a stale hook script is replaced by the embedded one.
- `cargo test`: 1264 passed, 0 failed. `cargo check --target x86_64-pc-windows-msvc --all-targets`: clean.
- A fresh-context review flagged the cargo, Windows-deferred and non-Claude paths; all three are fixed in the second commit.

Fixes #237
